### PR TITLE
COLLECTIONS-521 Typo in MultiMapKey's isEqualKey(entry, key1, key2)

### DIFF
--- a/src/main/java/org/apache/commons/collections4/map/MultiKeyMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/MultiKeyMap.java
@@ -249,7 +249,7 @@ public class MultiKeyMap<K, V> extends AbstractMapDecorator<MultiKey<? extends K
         return
             multi.size() == 2 &&
             (key1 == multi.getKey(0) || key1 != null && key1.equals(multi.getKey(0))) &&
-            (key2 == multi.getKey(1) || key1 != null && key2.equals(multi.getKey(1)));
+            (key2 == multi.getKey(1) || key2 != null && key2.equals(multi.getKey(1)));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
https://issues.apache.org/jira/browse/COLLECTIONS-521
