### PR TITLE
Removing unnecessary method from PassiveExpiringMap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Maven build files
+target
+*.log
+maven-eclipse.xml
+build.properties
+site-content
+
+# IntelliJ IDEA files
+.idea
+.iws
+*.iml
+*.ipr
+
+# Eclipse files
+.settings
+.classpath
+.project
+bin

--- a/src/main/java/org/apache/commons/collections4/map/PassiveExpiringMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/PassiveExpiringMap.java
@@ -425,17 +425,13 @@ public class PassiveExpiringMap<K, V>
         return System.currentTimeMillis();
     }
 
-    @Override
-    public V put(final K key, final V value) {
-        return put(key, value, now());
-    }
-
     /**
      * Add the given key-value pair to this map as well as recording the entry's expiration time based on
-     * the current time in milliseconds, <code>now</code> and this map's {@link #expiringPolicy}.
+     * the current time in milliseconds and this map's {@link #expiringPolicy}.
      */
-    private V put(final K key, final V value, final long now) {
-        // record expiration time of new entry
+    @Override
+    public V put(final K key, final V value) {
+    	 // record expiration time of new entry
         final long expirationTime = expiringPolicy.expirationTime(key, value);
         expirationMap.put(key, Long.valueOf(expirationTime));
 


### PR DESCRIPTION
I suggest remmove unnecessary method `private V put(final K key, final V value, final long now)` from the class `PassiveExpiringMap` once the `final long now` parameter was never used. I've addapted the code to work properly.

The param was confusing the logic of this method.

I've created the ticket https://issues.apache.org/jira/browse/COLLECTIONS-523 to track this PullRequest.