### PR TITLE
Add CollectionUtils#containsQuietly method and unit tests.

### DIFF
--- a/src/main/java/org/apache/commons/collections4/CollectionUtils.java
+++ b/src/main/java/org/apache/commons/collections4/CollectionUtils.java
@@ -347,6 +347,30 @@ public class CollectionUtils {
     }
 
     /**
+     * Safe check if the specified collection {@code coll} contains the specified element {@code o}.
+     * If the element is null and the collection does not permit null elements, this method will
+     * catch the resulting {@link java.lang.NullPointerException} and return <code>false</code>.
+     * If the element is of a type that is incompatible with the collection, this method will
+     * catch the resulting {@link java.lang.ClassCastException} and return <code>false</code>.
+     *
+     * @param coll  the collection to check, may be null
+     * @param o  the element, may be null
+     * @return <code>true</code> iff the collection is not null and contains the element
+     * @since 4.1
+     */
+    public static boolean containsQuietly(final Collection<?> coll, final Object o) {
+        try {
+            return coll != null && coll.contains(o);
+        }
+        catch (NullPointerException e) {
+            return false;
+        }
+        catch (ClassCastException e) {
+            return false;
+        }
+    }
+
+    /**
      * Returns <code>true</code> iff all elements of {@code coll2} are also contained
      * in {@code coll1}. The cardinality of values in {@code coll2} is not taken into account,
      * which is the same behavior as {@link Collection#containsAll(Collection)}.

--- a/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.Vector;
+import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.apache.commons.collections4.bag.HashBag;
 import org.apache.commons.collections4.collection.PredicatedCollection;
@@ -279,6 +280,30 @@ public class CollectionUtilsTest extends MockTestCase {
             final Map<String, Integer> freq = CollectionUtils.getCardinalityMap(list);
             assertEquals(Integer.valueOf(3), freq.get(null));
         }
+    }
+
+    @Test
+    public void containsQuietly() {
+        final Collection<String> nil = null;
+        final Collection<String> empty = new ArrayList<String>(0);
+        final Collection<String> one = new ArrayList<String>(1);
+        one.add("1");
+
+        // ConcurrentLinkedQueue is supposed not to allow null elements
+        final Queue<String> noNulls = new ConcurrentLinkedQueue<String>();
+        boolean allowedNulls = true;
+        try {
+            noNulls.add(null);
+        }
+        catch (NullPointerException e) {
+            allowedNulls = false;
+        }
+        assertFalse(allowedNulls);
+
+        assertFalse("contains(null,1) should return false.", CollectionUtils.containsQuietly(nil, "1"));
+        assertFalse("contains({},1) should return false.", CollectionUtils.containsQuietly(empty, "1"));
+        assertTrue("contains({1},1) should return true.", CollectionUtils.containsQuietly(one, "1"));
+        assertFalse("contains(noNulls,null) should return false.", CollectionUtils.containsQuietly(noNulls, null));
     }
 
     @Test


### PR DESCRIPTION
Add `CollectionUtils#containsQuietly` method and unit tests.

Currently suppressing both `NullPointerException` and `ClassCastException` if the element is bad, but I'm open to foregoing those features for just the collection null-safety.

Let me know if you prefer a different name - I considered `contains` (same name as proxied `Collection` method, as is typical in `StringUtils`), `containsIgnoreNull` (like existing `addIgnoreNull`), etc.

I recognize that it may be better practice to use empty collections rather than `null`, but this isn't always practical nor possible with 3rd party code.

If you are amenable to this, there are a number of other `Collection` methods for which we could offer safer proxy methods.
