### PR TITLE
Add VI[M] temporary files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ site-content
 .settings
 .classpath
 .project
+
+# VI[M] files
+.*.swp
+*~


### PR DESCRIPTION
Add VI[M]'s temporary files to .gitignore to make it easier for
contributors who want to use this editor.