### PR TITLE
[COLLECTIONS-600] Null-safe implementation of CollectionUtils#isEqualCollection

### DIFF
--- a/src/main/java/org/apache/commons/collections4/CollectionUtils.java
+++ b/src/main/java/org/apache/commons/collections4/CollectionUtils.java
@@ -560,20 +560,8 @@ public class CollectionUtils {
     public static <E> boolean isEqualCollection(final Collection<? extends E> a,
                                                 final Collection<? extends E> b,
                                                 final Equator<? super E> equator) {
-        if(a == null && b == null) {
-            return true;
-        }
-
-        if(a == null || b == null) {
-            return false;
-        }
-
         if (equator == null) {
             throw new NullPointerException("Equator must not be null.");
-        }
-
-        if(a.size() != b.size()) {
-            return false;
         }
 
         @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/src/main/java/org/apache/commons/collections4/CollectionUtils.java
+++ b/src/main/java/org/apache/commons/collections4/CollectionUtils.java
@@ -503,12 +503,21 @@ public class CollectionUtils {
      * That is, iff the cardinality of <i>e</i> in <i>a</i> is
      * equal to the cardinality of <i>e</i> in <i>b</i>,
      * for each element <i>e</i> in <i>a</i> or <i>b</i>.
+     * <p>
+     * {@code null}s are handled without exceptions. Two {@code null}
+     * references are considered to be equal.
      *
      * @param a  the first collection, must not be null
      * @param b  the second collection, must not be null
      * @return <code>true</code> iff the collections contain the same elements with the same cardinalities.
      */
     public static boolean isEqualCollection(final Collection<?> a, final Collection<?> b) {
+        if(a == null && b == null) {
+            return true;
+        }
+        if(a == null || b == null) {
+            return false;
+        }
         if(a.size() != b.size()) {
             return false;
         }
@@ -532,6 +541,9 @@ public class CollectionUtils {
      * equal to the cardinality of <i>e</i> in <i>b</i>,
      * for each element <i>e</i> in <i>a</i> or <i>b</i>.
      * <p>
+     * {@code null}s are handled without exceptions. Two {@code null}
+     * references are considered to be equal.
+     * <p>
      * <b>Note:</b> from version 4.1 onwards this method requires the input
      * collections and equator to be of compatible type (using bounded wildcards).
      * Providing incompatible arguments (e.g. by casting to their rawtypes)
@@ -548,6 +560,14 @@ public class CollectionUtils {
     public static <E> boolean isEqualCollection(final Collection<? extends E> a,
                                                 final Collection<? extends E> b,
                                                 final Equator<? super E> equator) {
+        if(a == null && b == null) {
+            return true;
+        }
+
+        if(a == null || b == null) {
+            return false;
+        }
+
         if (equator == null) {
             throw new NullPointerException("Equator must not be null.");
         }

--- a/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
@@ -560,6 +560,13 @@ public class CollectionUtilsTest extends MockTestCase {
     }
 
     @Test
+    public void testIsEqualCollectionWithNulls() {
+        assertTrue(CollectionUtils.isEqualCollection(null, null));
+        assertFalse(CollectionUtils.isEqualCollection(collectionA, null));
+        assertFalse(CollectionUtils.isEqualCollection(null, collectionA));
+    }
+
+    @Test
     public void testIsEqualCollectionEquator() {
         final Collection<Integer> collB = CollectionUtils.collect(collectionB, TRANSFORM_TO_INTEGER);
 
@@ -592,6 +599,25 @@ public class CollectionUtilsTest extends MockTestCase {
     @Test(expected=NullPointerException.class)
     public void testIsEqualCollectionNullEquator() {
         CollectionUtils.isEqualCollection(collectionA, collectionA, null);
+    }
+
+    @Test
+    public void testIsEqualCollectionEquatorWithNulls() {
+        Equator<Object> equator = new Equator<Object>() {
+            @Override
+            public boolean equate(Object o1, Object o2) {
+                return false;
+            }
+
+            @Override
+            public int hash(Object o) {
+                return 0;
+            }
+        };
+
+        assertTrue(CollectionUtils.isEqualCollection(null, null, equator));
+        assertFalse(CollectionUtils.isEqualCollection(collectionA, null, equator));
+        assertFalse(CollectionUtils.isEqualCollection(null, collectionA, equator));
     }
 
     @Test


### PR DESCRIPTION
Other Commons `*Utils` classes as `StringUtils` etc. feature null-safe methods. With this Pull Request now `CollectionUtils#isEqualCollection` does, too.

Fixes issue [COLLECTIONS-600](https://issues.apache.org/jira/browse/COLLECTIONS-600).