### PR TITLE
COLLECTIONS-656 Update commons-parent version, and use inherited FindBugs plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-parent</artifactId>
-    <version>40</version>
+    <version>42</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.commons</groupId>
@@ -631,7 +631,8 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.5.5</version>
+        <!-- Use version from parent pom as that is adjusted according to the Java version used to run Maven -->
+        <version>${commons.findbugs.version}</version>
         <configuration>
           <threshold>Normal</threshold>
           <effort>Default</effort>


### PR DESCRIPTION
Copied settings from [text] component after Javadocs issues were fixed but then the `mvn site` command failed in the FindBugs reporting.

With this change, `mvn clean site` works with Java 8, and produces the correct site reports.

Created the ticket and this pull request to wait for feedback & reviews in case there's any issue associated with upgrading the commons-parent version (there's none in this case as far as I can tell).

Feel free to comment here or merge the pull request (and add changes.xml entry...) in case you know there is nothing wrong in updating the commons-parent version.

Thanks
Bruno