### PR TITLE
COLLECTIONS-661: fix for concurrency issue in HashSetValuedHashMapTest

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -21,6 +21,9 @@
   </properties>
   <body>
   <release version="4.2" date="YYYY-MM-DD" description="New features">
+    <action issue="COLLECTIONS-661" dev="kinow" type="fix">
+      Intermittent test failures in Windows for HashSetValuedHashMap
+    </action>
     <action issue="COLLECTIONS-660" dev="kinow" type="fix">
       Uncomment test in AbstractMapTest regarding LRUMap equals
     </action>

--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -1086,7 +1086,10 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         @Override
         @SuppressWarnings("unchecked")
         public Collection<V>[] getSampleValues() {
-            boolean isSetValuedMap = AbstractMultiValuedMapTest.this.getMap() instanceof SetValuedMap;
+            // Calling getMap() instead of makeObject() would make more sense, but due to concurrency
+            // issues, this may lead to intermittent issues. See COLLECTIONS-661. A better solution
+            // would be to re-design the tests, or add a boolean method to the parent.
+            boolean isSetValuedMap = AbstractMultiValuedMapTest.this.makeObject() instanceof SetValuedMap;
             V[] sampleValues = AbstractMultiValuedMapTest.this.getSampleValues();
             Collection<V>[] colArr = new Collection[3];
             for(int i = 0; i < 3; i++) {
@@ -1099,7 +1102,9 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         @Override
         @SuppressWarnings("unchecked")
         public Collection<V>[] getNewSampleValues() {
-            boolean isSetValuedMap = AbstractMultiValuedMapTest.this.getMap() instanceof SetValuedMap;
+            // See comment in getSampleValues() to understand why we are calling makeObject() and not
+            // getMap(). See COLLECTIONS-661 for more.
+            boolean isSetValuedMap = AbstractMultiValuedMapTest.this.makeObject() instanceof SetValuedMap;
             Object[] sampleValues = { "ein", "ek", "zwei", "duey", "drei", "teen" };
             Collection<V>[] colArr = new Collection[3];
             for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
The `getMap()` method, when testing a `HashSetValuedHashMap`, would return an object of this type. Which is an instance of `SetValuedMap`.

Running it in debug mode would - most of the times - run the tests and succeed. Running normally - especially on Windows - would result in intermittent, but very frequent, failures.

The `getMap()` method sometimes, depending on the order and execution of tests, will return `null`. So the collection added to the map will be either a `Hashset` (when it is not `null`), or a `Arrays$ArrayList` (otherwise). When the types are different, `hashCode()` and `equals()` calls return incorrect values, resulting in the errors we have seen in [COLLECTIONS-661](https://issues.apache.org/jira/browse/COLLECTIONS-661).

A good solution would be to re-design the tests. The `TestMultiValuedMapAsMap` is testing `MultiValuedMap`'s, which include `HashSetValuedHashMap`. However, some of its methods contain extra logic for when the type under test has some characteristics like being an instance of `SetValuedMap`.

It might be possible to come up with a better design, where there are multiple test classes, for `MultiValuedMap`'s that use `SetValuedMap`'s; `MultieValuedMap`'s that use `List`'s, and so it goes.

Or we could add a class to the parent class, with a flag defining the type under test. For now, I have used the `makeObject()` method, which returns the collection under test. Then I validate its instance type. There is also a comment above the code to indicate why we are using `makeObject()` and not `getMap()`.

It was a fun ticket. Happy to get feedback on better solutions, or feel free to edit this pull request if you have right to it, or merge if you are happy and it has gathered some consensus.

Cheers,
Bruno