### PR TITLE
 COLLECTIONS-662 : Override Jacoco version for Java9 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -509,6 +509,9 @@
 
     <!-- Override clirr version to enable clirr on Java 8 -->
     <commons.clirr.version>2.8</commons.clirr.version>
+    
+    <!-- Override jacoco for java 9 compatibility -->
+	<commons.jacoco.version>0.7.9</commons.jacoco.version>
   </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -511,7 +511,7 @@
     <commons.clirr.version>2.8</commons.clirr.version>
     
     <!-- Override jacoco for java 9 compatibility -->
-	<commons.jacoco.version>0.7.9</commons.jacoco.version>
+    <commons.jacoco.version>0.7.9</commons.jacoco.version>
   </properties>
 
 


### PR DESCRIPTION
Overriding Jacoco version fixed the failures in Java 9.