### PR TITLE
COLLECTION-599: Fix for out-of-memory errors during session replication

### DIFF
--- a/src/java/org/apache/commons/collections/map/AbstractReferenceMap.java
+++ b/src/java/org/apache/commons/collections/map/AbstractReferenceMap.java
@@ -966,6 +966,15 @@ public abstract class AbstractReferenceMap extends AbstractHashedMap {
         int capacity = in.readInt();
         init();
         data = new HashEntry[capacity];
+
+        // COLLECTIONS-599: Calculate threshold before populating, otherwise it will be 0 
+        // when it hits AbstractHashedMap.checkCapacity() and so will unnecessarily 
+        // double up the size of the "data" array during population.
+        //
+        // NB: AbstractHashedMap.doReadObject() DOES calculate the threshold before populating.
+        //
+        threshold = calculateThreshold(data.length, loadFactor);
+
         while (true) {
             Object key = in.readObject();
             if (key == null) {
@@ -974,7 +983,6 @@ public abstract class AbstractReferenceMap extends AbstractHashedMap {
             Object value = in.readObject();
             put(key, value);
         }
-        threshold = calculateThreshold(data.length, loadFactor);
         // do not call super.doReadObject() as code there doesn't work for reference map
     }
 

--- a/src/test/org/apache/commons/collections/map/TestReferenceMap.java
+++ b/src/test/org/apache/commons/collections/map/TestReferenceMap.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections.map;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.lang.ref.WeakReference;
 import java.util.Map;
 
@@ -241,6 +246,30 @@ public class TestReferenceMap extends AbstractTestIterableMap {
                 bytz = bytz * 2;
             }
         }
+    }
+    
+    /**
+     * Test whether after serialization the "data" HashEntry array is the same size as the original.<p>
+     * 
+     * See <a href="https://issues.apache.org/jira/browse/COLLECTIONS-599">COLLECTIONS-599: HashEntry array object naming data initialized with double the size during deserialization</a>
+     */
+    public void testDataSizeAfterSerialization() throws IOException, ClassNotFoundException {
+        
+        ReferenceMap serialiseMap = new ReferenceMap(ReferenceMap.HARD, ReferenceMap.HARD, true);
+        serialiseMap.put("KEY", "VALUE");
+        
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(baos);
+        out.writeObject(serialiseMap);
+        out.close();
+        
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream in = new ObjectInputStream(bais);
+        ReferenceMap deserialisedMap = (ReferenceMap) in.readObject();
+        in.close();
+        
+        assertEquals(1, deserialisedMap.size());
+        assertEquals(serialiseMap.data.length, deserialisedMap.data.length);
     }
 
     private static void gc() {


### PR DESCRIPTION
While using "non-sticky" session replication in a clustered environment,
the frequent de-serialisation meant the ReferenceMap's we were using
eventually consumed most of the server memory due to this bug.