### PR TITLE
COLLECTION-599: Fix for out-of-memory errors during session replication

### DIFF
--- a/src/main/java/org/apache/commons/collections4/map/AbstractReferenceMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/AbstractReferenceMap.java
@@ -1045,6 +1045,15 @@ public abstract class AbstractReferenceMap<K, V> extends AbstractHashedMap<K, V>
         final int capacity = in.readInt();
         init();
         data = new HashEntry[capacity];
+
+        // COLLECTIONS-599: Calculate threshold before populating, otherwise it will be 0 
+        // when it hits AbstractHashedMap.checkCapacity() and so will unnecessarily 
+        // double up the size of the "data" array during population.
+        //
+        // NB: AbstractHashedMap.doReadObject() DOES calculate the threshold before populating.
+        //
+        threshold = calculateThreshold(data.length, loadFactor);
+        
         while (true) {
             final K key = (K) in.readObject();
             if (key == null) {
@@ -1053,7 +1062,6 @@ public abstract class AbstractReferenceMap<K, V> extends AbstractHashedMap<K, V>
             final V value = (V) in.readObject();
             put(key, value);
         }
-        threshold = calculateThreshold(data.length, loadFactor);
         // do not call super.doReadObject() as code there doesn't work for reference map
     }
 

--- a/src/test/java/org/apache/commons/collections4/map/ReferenceMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ReferenceMapTest.java
@@ -16,6 +16,12 @@
  */
 package org.apache.commons.collections4.map;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 import java.lang.ref.WeakReference;
 import java.util.Map;
 
@@ -249,6 +255,30 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         }
     }
 
+    /**
+     * Test whether after serialization the "data" HashEntry array is the same size as the original.<p>
+     * 
+     * See <a href="https://issues.apache.org/jira/browse/COLLECTIONS-599">COLLECTIONS-599: HashEntry array object naming data initialized with double the size during deserialization</a>
+     */
+    public void testDataSizeAfterSerialization() throws IOException, ClassNotFoundException {
+        
+        ReferenceMap serialiseMap = new ReferenceMap(ReferenceStrength.WEAK, ReferenceStrength.WEAK, true);
+        serialiseMap.put("KEY", "VALUE");
+        
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(baos);
+        out.writeObject(serialiseMap);
+        out.close();
+        
+        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+        ObjectInputStream in = new ObjectInputStream(bais);
+        ReferenceMap deserialisedMap = (ReferenceMap) in.readObject();
+        in.close();
+        
+        assertEquals(1, deserialisedMap.size());
+        assertEquals(serialiseMap.data.length, deserialisedMap.data.length);
+    }
+    
     @SuppressWarnings("unused")
     private static void gc() {
         try {


### PR DESCRIPTION
While using "non-sticky" session replication in a clustered environment,
the frequent de-serialisation meant the ReferenceMap's we were using
eventually consumed most of the server memory due to this bug.