### PR TITLE
The verification of unsupported iterator methods was not complete.

### DIFF
--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractListIteratorTest.java
@@ -166,6 +166,7 @@ public abstract class AbstractListIteratorTest<E> extends AbstractIteratorTest<E
             // check for UnsupportedOperationException if not supported
             try {
                 it.add(addValue);
+                fail("UnsupportedOperationException must be thrown from add of " + it.getClass().getSimpleName());
             } catch (final UnsupportedOperationException ex) {}
             return;
         }
@@ -201,6 +202,7 @@ public abstract class AbstractListIteratorTest<E> extends AbstractIteratorTest<E
             // check for UnsupportedOperationException if not supported
             try {
                 it.set(addSetValue());
+                fail("UnsupportedOperationException must be thrown from set in " + it.getClass().getSimpleName());
             } catch (final UnsupportedOperationException ex) {}
             return;
         }


### PR DESCRIPTION
In particular there is a verification for unsupported `add` and `set` methods in iterators. The verification misses an assertion. If the unsupported method does not throw the exception the test doesn't fail.