### PR TITLE
COLLECTIONS-673: Fix inspired by the Guava partition() implementation

### DIFF
--- a/src/main/java/org/apache/commons/collections4/ListUtils.java
+++ b/src/main/java/org/apache/commons/collections4/ListUtils.java
@@ -688,7 +688,7 @@ public class ListUtils {
 
         @Override
         public int size() {
-            return (list.size() + size - 1) / size;
+            return (int)Math.ceil((double)list.size() / (double)size);
         }
 
         @Override

--- a/src/test/java/org/apache/commons/collections4/ListUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/ListUtilsTest.java
@@ -425,6 +425,10 @@ public class ListUtilsTest {
             fail("failed to check for size argument");
         } catch (final IllegalArgumentException e) {}
 
+        List<List<Integer>> partitionMax = ListUtils.partition(strings, Integer.MAX_VALUE);
+        assertEquals(1, partitionMax.size());
+        assertEquals(strings.size(), partitionMax.get(0).size());
+        assertEquals(strings, partitionMax.get(0));
     }
 
     private static Predicate<Number> EQUALS_TWO = new Predicate<Number>() {


### PR DESCRIPTION
A fix for the COLLECTIONS-673 bug and a unit test proving the fix for the shown defect.

See the bug here: https://issues.apache.org/jira/browse/COLLECTIONS-673
See the Guava implementation here: https://github.com/google/guava/blob/master/guava/src/com/google/common/collect/Lists.java