### PR TITLE
COLLECTIONS-685: IterableUtils has public constructor

### DIFF
--- a/src/main/java/org/apache/commons/collections4/IterableUtils.java
+++ b/src/main/java/org/apache/commons/collections4/IterableUtils.java
@@ -49,6 +49,11 @@ import org.apache.commons.collections4.iterators.UniqueFilterIterator;
 public class IterableUtils {
 
     /**
+     * IterableUtils is not normally instantiated.
+     */
+    private IterableUtils() {}
+
+    /**
      * An empty iterable.
      */
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
Constructor for Utils class was not private. 
This was obviously not intended as all other Utils classes have private constructors.