### PR TITLE
Fix checkstyle config.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -573,6 +573,7 @@
         <configuration>
           <configLocation>${basedir}/src/conf/checkstyle.xml</configLocation>
           <enableRulesSummary>false</enableRulesSummary>
+          <suppressionsLocation>${basedir}/src/conf/checkstyle-suppressions.xml</suppressionsLocation>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
mvn clean checkstyle:checkstyle was failing. 

Error was: [ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.0.0:checkstyle (default-cli) on project commons-collections4: An error has occurred in Checkstyle report generation.: Failed during checkstyle execution: Failed during checkstyle configuration: unable to parse configuration stream: Property ${checkstyle.suppressions.file} has not been set -> [Help 1]