### PR TITLE
Fix for 5 CheckStyle 3.0.0 plugin warnings.

### DIFF
--- a/src/main/java/org/apache/commons/collections4/CollectionUtils.java
+++ b/src/main/java/org/apache/commons/collections4/CollectionUtils.java
@@ -401,6 +401,8 @@ public class CollectionUtils {
      *
      * @param coll1  the first collection, must not be null
      * @param coll2  the second collection, must not be null
+     * @param <T> the generic type that is able to represent the types contained
+     *        in the second input collection.
      * @return <code>true</code> iff the intersection of the collections is non-empty
      * @since 4.2
      * @see #intersection

--- a/src/main/java/org/apache/commons/collections4/set/AbstractNavigableSetDecorator.java
+++ b/src/main/java/org/apache/commons/collections4/set/AbstractNavigableSetDecorator.java
@@ -104,7 +104,8 @@ public abstract class AbstractNavigableSetDecorator<E>
     }
 
     @Override
-    public NavigableSet<E> subSet(final E fromElement, final boolean fromInclusive, final E toElement, final boolean toInclusive) {
+    public NavigableSet<E> subSet(final E fromElement, final boolean fromInclusive,
+            final E toElement, final boolean toInclusive) {
         return decorated().subSet(fromElement, fromInclusive, toElement, toInclusive);
     }
 

--- a/src/main/java/org/apache/commons/collections4/set/PredicatedNavigableSet.java
+++ b/src/main/java/org/apache/commons/collections4/set/PredicatedNavigableSet.java
@@ -132,7 +132,8 @@ public class PredicatedNavigableSet<E> extends PredicatedSortedSet<E> implements
     }
 
     @Override
-    public NavigableSet<E> subSet(final E fromElement, final boolean fromInclusive, final E toElement, final boolean toInclusive) {
+    public NavigableSet<E> subSet(final E fromElement, final boolean fromInclusive,
+            final E toElement, final boolean toInclusive) {
         final NavigableSet<E> sub = decorated().subSet(fromElement, fromInclusive, toElement, toInclusive);
         return predicatedNavigableSet(sub, predicate);
     }

--- a/src/main/java/org/apache/commons/collections4/set/TransformedNavigableSet.java
+++ b/src/main/java/org/apache/commons/collections4/set/TransformedNavigableSet.java
@@ -153,7 +153,8 @@ public class TransformedNavigableSet<E> extends TransformedSortedSet<E> implemen
     }
 
     @Override
-    public NavigableSet<E> subSet(final E fromElement, final boolean fromInclusive, final E toElement, final boolean toInclusive) {
+    public NavigableSet<E> subSet(final E fromElement, final boolean fromInclusive,
+            final E toElement, final boolean toInclusive) {
         final NavigableSet<E> sub = decorated().subSet(fromElement, fromInclusive, toElement, toInclusive);
         return transformingNavigableSet(sub, transformer);
     }

--- a/src/main/java/org/apache/commons/collections4/set/UnmodifiableNavigableSet.java
+++ b/src/main/java/org/apache/commons/collections4/set/UnmodifiableNavigableSet.java
@@ -137,7 +137,8 @@ public final class UnmodifiableNavigableSet<E>
     }
 
     @Override
-    public NavigableSet<E> subSet(final E fromElement, final boolean fromInclusive, final E toElement, final boolean toInclusive) {
+    public NavigableSet<E> subSet(final E fromElement, final boolean fromInclusive,
+            final E toElement, final boolean toInclusive) {
         final NavigableSet<E> sub = decorated().subSet(fromElement, fromInclusive, toElement, toInclusive);
         return unmodifiableNavigableSet(sub);
     }


### PR DESCRIPTION
Fixed 5 CheckStyle warnings.

There are still 11 warnings left which are false positive (JavadocMethod	Unable to get class information for @throws tag 'FunctorException'.). 
See also: https://github.com/checkstyle/checkstyle/issues/5088

Maven Checkstyle Plugin 3.0.0 uses CheckStyle 6.18.