### PR TITLE
COLLECTIONS-687: Moved some JUnit 3 tests to JUnit 4

### DIFF
--- a/src/test/java/org/apache/commons/collections4/iterators/FilterListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/FilterListIteratorTest.java
@@ -22,18 +22,22 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Random;
 
-import junit.framework.TestCase;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.PredicateUtils;
 import org.apache.commons.collections4.list.GrowthList;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Tests the FilterListIterator class.
  *
  */
 @SuppressWarnings("boxing")
-public class FilterListIteratorTest extends TestCase {
+public class FilterListIteratorTest {
 
     private ArrayList<Integer> list = null;
     private ArrayList<Integer> odds = null;
@@ -49,7 +53,7 @@ public class FilterListIteratorTest extends TestCase {
     private Predicate<Integer> fourPred = null;
     private final Random random = new Random();
 
-    @Override
+    @Before
     public void setUp() {
         list = new ArrayList<>();
         odds = new ArrayList<>();
@@ -110,7 +114,7 @@ public class FilterListIteratorTest extends TestCase {
 
     }
 
-    @Override
+    @After
     public void tearDown() throws Exception {
         list = null;
         odds = null;
@@ -126,11 +130,13 @@ public class FilterListIteratorTest extends TestCase {
         fourPred = null;
     }
 
+    @Test
     public void testWalkLists() {
         // this just confirms that our walkLists method works OK
         walkLists(list,list.listIterator());
     }
 
+    @Test
     public void testManual() {
         // do this one "by hand" as a sanity check
         final FilterListIterator<Integer> filtered = new FilterListIterator<>(list.listIterator(), threePred);
@@ -190,36 +196,43 @@ public class FilterListIteratorTest extends TestCase {
         assertEquals(Integer.valueOf(9), filtered.previous());
     }
 
+    @Test
     public void testTruePredicate() {
         final FilterListIterator<Integer> filtered = new FilterListIterator<>(list.listIterator(), truePred);
         walkLists(list, filtered);
     }
 
+    @Test
     public void testFalsePredicate() {
         final FilterListIterator<Integer> filtered = new FilterListIterator<>(list.listIterator(), falsePred);
         walkLists(new ArrayList<Integer>(), filtered);
     }
 
+    @Test
     public void testEvens() {
         final FilterListIterator<Integer> filtered = new FilterListIterator<>(list.listIterator(), evenPred);
         walkLists(evens, filtered);
     }
 
+    @Test
     public void testOdds() {
         final FilterListIterator<Integer> filtered = new FilterListIterator<>(list.listIterator(), oddPred);
         walkLists(odds, filtered);
     }
 
+    @Test
     public void testThrees() {
         final FilterListIterator<Integer> filtered = new FilterListIterator<>(list.listIterator(), threePred);
         walkLists(threes, filtered);
     }
 
+    @Test
     public void testFours() {
         final FilterListIterator<Integer> filtered = new FilterListIterator<>(list.listIterator(), fourPred);
         walkLists(fours, filtered);
     }
 
+    @Test
     public void testNestedSixes() {
         final FilterListIterator<Integer> filtered = new FilterListIterator<>(
                                         new FilterListIterator<>(list.listIterator(), threePred),
@@ -228,6 +241,7 @@ public class FilterListIteratorTest extends TestCase {
         walkLists(sixes, filtered);
     }
 
+    @Test
     public void testNestedSixes2() {
         final FilterListIterator<Integer> filtered = new FilterListIterator<>(
                                         new FilterListIterator<>(list.listIterator(), evenPred),
@@ -236,6 +250,7 @@ public class FilterListIteratorTest extends TestCase {
         walkLists(sixes, filtered);
     }
 
+    @Test
     public void testNestedSixes3() {
         final FilterListIterator<Integer> filtered = new FilterListIterator<>(
                                         new FilterListIterator<>(list.listIterator(), threePred),
@@ -244,6 +259,7 @@ public class FilterListIteratorTest extends TestCase {
         walkLists(sixes, new FilterListIterator<>(filtered, truePred));
     }
 
+    @Test
     public void testNextChangesPrevious() {
         {
             final FilterListIterator<Integer> filtered = new FilterListIterator<>(list.listIterator(), threePred);
@@ -256,6 +272,7 @@ public class FilterListIteratorTest extends TestCase {
         }
     }
 
+    @Test
     public void testPreviousChangesNext() {
         {
             final FilterListIterator<Integer> filtered = new FilterListIterator<>(list.listIterator(), threePred);
@@ -271,6 +288,7 @@ public class FilterListIteratorTest extends TestCase {
         }
     }
 
+    @Test
     public void testFailingHasNextBug() {
         final FilterListIterator<Integer> filtered = new FilterListIterator<>(list.listIterator(), fourPred);
         final ListIterator<Integer> expected = fours.listIterator();
@@ -286,6 +304,7 @@ public class FilterListIteratorTest extends TestCase {
     /**
      * Test for {@link "https://issues.apache.org/jira/browse/COLLECTIONS-360 COLLECTIONS-360"}
      */
+    @Test
     public void testCollections360() throws Throwable {
         final Collection<Predicate<Object>> var7 = new GrowthList<>();
         final Predicate<Object> var9 = PredicateUtils.anyPredicate(var7);

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorEnumerationTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorEnumerationTest.java
@@ -21,14 +21,16 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
  * Tests the IteratorEnumeration.
  *
  */
-public class IteratorEnumerationTest extends TestCase {
+public class IteratorEnumerationTest {
 
+    @Test
     public void testEnumeration() {
         final Iterator<String> iterator = Arrays.asList("a", "b", "c").iterator();
         final IteratorEnumeration<String> enumeration = new IteratorEnumeration<>(iterator);

--- a/src/test/java/org/apache/commons/collections4/iterators/LoopingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/LoopingIteratorTest.java
@@ -21,17 +21,20 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Tests the LoopingIterator class.
  *
  */
-public class LoopingIteratorTest extends TestCase {
+public class LoopingIteratorTest {
 
     /**
      * Tests constructor exception.
      */
+    @Test
     public void testConstructorEx() throws Exception {
         try {
             new LoopingIterator<>(null);
@@ -44,6 +47,7 @@ public class LoopingIteratorTest extends TestCase {
      * Tests whether an empty looping iterator works as designed.
      * @throws Exception  If something unexpected occurs.
      */
+    @Test
     public void testLooping0() throws Exception {
         final List<Object> list = new ArrayList<>();
         final LoopingIterator<Object> loop = new LoopingIterator<>(list);
@@ -60,6 +64,7 @@ public class LoopingIteratorTest extends TestCase {
      * Tests whether a populated looping iterator works as designed.
      * @throws Exception  If something unexpected occurs.
      */
+    @Test
     public void testLooping1() throws Exception {
         final List<String> list = Arrays.asList("a");
         final LoopingIterator<String> loop = new LoopingIterator<>(list);
@@ -79,6 +84,7 @@ public class LoopingIteratorTest extends TestCase {
      * Tests whether a populated looping iterator works as designed.
      * @throws Exception  If something unexpected occurs.
      */
+    @Test
     public void testLooping2() throws Exception {
         final List<String> list = Arrays.asList("a", "b");
         final LoopingIterator<String> loop = new LoopingIterator<>(list);
@@ -98,6 +104,7 @@ public class LoopingIteratorTest extends TestCase {
      * Tests whether a populated looping iterator works as designed.
      * @throws Exception  If something unexpected occurs.
      */
+    @Test
     public void testLooping3() throws Exception {
         final List<String> list = Arrays.asList("a", "b", "c");
         final LoopingIterator<String> loop = new LoopingIterator<>(list);
@@ -120,6 +127,7 @@ public class LoopingIteratorTest extends TestCase {
      * Tests the remove() method on a LoopingIterator wrapped ArrayList.
      * @throws Exception  If something unexpected occurs.
      */
+    @Test
     public void testRemoving1() throws Exception {
         final List<String> list = new ArrayList<>(Arrays.asList("a", "b", "c"));
         final LoopingIterator<String> loop = new LoopingIterator<>(list);
@@ -152,6 +160,7 @@ public class LoopingIteratorTest extends TestCase {
      * Tests the reset() method on a LoopingIterator wrapped ArrayList.
      * @throws Exception  If something unexpected occurs.
      */
+    @Test
     public void testReset() throws Exception {
         final List<String> list = Arrays.asList("a", "b", "c");
         final LoopingIterator<String> loop = new LoopingIterator<>(list);
@@ -174,6 +183,7 @@ public class LoopingIteratorTest extends TestCase {
      * Tests the size() method on a LoopingIterator wrapped ArrayList.
      * @throws Exception  If something unexpected occurs.
      */
+    @Test
     public void testSize() throws Exception {
         final List<String> list = new ArrayList<>(Arrays.asList("a", "b", "c"));
         final LoopingIterator<String> loop = new LoopingIterator<>(list);

--- a/src/test/java/org/apache/commons/collections4/iterators/LoopingListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/LoopingListIteratorTest.java
@@ -21,17 +21,19 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
  * Tests the LoopingListIterator class.
  *
  */
-public class LoopingListIteratorTest extends TestCase {
+public class LoopingListIteratorTest {
 
     /**
      * Tests constructor exception.
      */
+    @Test
     public void testConstructorEx() throws Exception {
         try {
             new LoopingListIterator<>(null);
@@ -43,6 +45,7 @@ public class LoopingListIteratorTest extends TestCase {
     /**
      * Tests whether an empty looping list iterator works.
      */
+    @Test
     public void testLooping0() throws Exception {
         final List<Object> list = new ArrayList<>();
         final LoopingListIterator<Object> loop = new LoopingListIterator<>(list);
@@ -66,6 +69,7 @@ public class LoopingListIteratorTest extends TestCase {
      * Tests whether a looping list iterator works on a list with only
      * one element.
      */
+    @Test
     public void testLooping1() throws Exception {
         final List<String> list = Arrays.asList("a");
         final LoopingListIterator<String> loop = new LoopingListIterator<>(list); // <a>
@@ -93,6 +97,7 @@ public class LoopingListIteratorTest extends TestCase {
      * Tests whether a looping list iterator works on a list with two
      * elements.
      */
+    @Test
     public void testLooping2() throws Exception {
         final List<String> list = Arrays.asList("a", "b");
         final LoopingListIterator<String> loop = new LoopingListIterator<>(list); // <a> b
@@ -123,6 +128,7 @@ public class LoopingListIteratorTest extends TestCase {
      * Tests jogging back and forth between two elements, but not over
      * the begin/end boundary of the list.
      */
+    @Test
     public void testJoggingNotOverBoundary() {
         final List<String> list = Arrays.asList("a", "b");
         final LoopingListIterator<String> loop = new LoopingListIterator<>(list); // <a> b
@@ -143,6 +149,7 @@ public class LoopingListIteratorTest extends TestCase {
      * Tests jogging back and forth between two elements over the
      * begin/end boundary of the list.
      */
+    @Test
     public void testJoggingOverBoundary() {
         final List<String> list = Arrays.asList("a", "b");
         final LoopingListIterator<String> loop = new LoopingListIterator<>(list); // <a> b
@@ -161,6 +168,7 @@ public class LoopingListIteratorTest extends TestCase {
     /**
      * Tests removing an element from a wrapped ArrayList.
      */
+    @Test
     public void testRemovingElementsAndIteratingForward() {
         final List<String> list = new ArrayList<>(Arrays.asList("a", "b", "c"));
         final LoopingListIterator<String> loop = new LoopingListIterator<>(list); // <a> b c
@@ -191,6 +199,7 @@ public class LoopingListIteratorTest extends TestCase {
     /**
      * Tests removing an element from a wrapped ArrayList.
      */
+    @Test
     public void testRemovingElementsAndIteratingBackwards() {
         final List<String> list = new ArrayList<>(Arrays.asList("a", "b", "c"));
         final LoopingListIterator<String> loop = new LoopingListIterator<>(list); // <a> b c
@@ -221,6 +230,7 @@ public class LoopingListIteratorTest extends TestCase {
     /**
      * Tests the reset method.
      */
+    @Test
     public void testReset() {
         final List<String> list = Arrays.asList("a", "b", "c");
         final LoopingListIterator<String> loop = new LoopingListIterator<>(list); // <a> b c
@@ -248,6 +258,7 @@ public class LoopingListIteratorTest extends TestCase {
     /**
      * Tests the add method.
      */
+    @Test
     public void testAdd() {
         List<String> list = new ArrayList<>(Arrays.asList("b", "e", "f"));
         LoopingListIterator<String> loop = new LoopingListIterator<>(list); // <b> e f
@@ -302,6 +313,7 @@ public class LoopingListIteratorTest extends TestCase {
     /**
      * Tests nextIndex and previousIndex.
      */
+    @Test
     public void testNextAndPreviousIndex() {
         final List<String> list = Arrays.asList("a", "b", "c");
         final LoopingListIterator<String> loop = new LoopingListIterator<>(list); // <a> b c
@@ -333,6 +345,7 @@ public class LoopingListIteratorTest extends TestCase {
     /**
      * Tests using the set method to change elements.
      */
+    @Test
     public void testSet() {
         final List<String> list = Arrays.asList("q", "r", "z");
         final LoopingListIterator<String> loop = new LoopingListIterator<>(list); // <q> r z

--- a/src/test/java/org/apache/commons/collections4/keyvalue/AbstractMapEntryTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/AbstractMapEntryTest.java
@@ -19,7 +19,8 @@ package org.apache.commons.collections4.keyvalue;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
  * Abstract tests that can be extended to test any Map.Entry implementation.
@@ -30,7 +31,7 @@ import junit.framework.TestCase;
  *
  * @since 3.0
  */
-public abstract class AbstractMapEntryTest<K, V> extends TestCase {
+public abstract class AbstractMapEntryTest<K, V> {
 
     protected final String key = "name";
     protected final String value = "duke";
@@ -71,6 +72,7 @@ public abstract class AbstractMapEntryTest<K, V> extends TestCase {
 
     //-----------------------------------------------------------------------
     @SuppressWarnings("unchecked")
+    @Test
     public void testAccessorsAndMutators() {
         Map.Entry<K, V> entry = makeMapEntry((K) key, (V) value);
 
@@ -95,6 +97,7 @@ public abstract class AbstractMapEntryTest<K, V> extends TestCase {
      */
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testSelfReferenceHandling() {
         // test that #setValue does not permit
         //  the MapEntry to contain itself (and thus cause infinite recursion
@@ -120,6 +123,7 @@ public abstract class AbstractMapEntryTest<K, V> extends TestCase {
     public abstract void testConstructors();
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testEqualsAndHashCode() {
         // 1. test with object data
         Map.Entry<K, V> e1 = makeMapEntry((K) key, (V) value);
@@ -141,6 +145,7 @@ public abstract class AbstractMapEntryTest<K, V> extends TestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testToString() {
         Map.Entry<K, V> entry = makeMapEntry((K) key, (V) value);
         assertTrue(entry.toString().equals(entry.getKey() + "=" + entry.getValue()));

--- a/src/test/java/org/apache/commons/collections4/keyvalue/DefaultKeyValueTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/DefaultKeyValueTest.java
@@ -16,17 +16,19 @@
  */
 package org.apache.commons.collections4.keyvalue;
 
+import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
 
 /**
  * Test the DefaultKeyValue class.
  *
  * @since 3.0
  */
-public class DefaultKeyValueTest<K, V> extends TestCase {
+public class DefaultKeyValueTest<K, V> {
 
     private final String key = "name";
     private final String value = "duke";
@@ -52,6 +54,7 @@ public class DefaultKeyValueTest<K, V> extends TestCase {
 
     //-----------------------------------------------------------------------
     @SuppressWarnings("unchecked")
+    @Test
     public void testAccessorsAndMutators() {
         final DefaultKeyValue<K, V> kv = makeDefaultKeyValue();
 
@@ -71,6 +74,7 @@ public class DefaultKeyValueTest<K, V> extends TestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testSelfReferenceHandling() {
         // test that #setKey and #setValue do not permit
         //  the KVP to contain itself (and thus cause infinite recursion
@@ -103,6 +107,7 @@ public class DefaultKeyValueTest<K, V> extends TestCase {
      * Subclasses should override this method to test their own constructors.
      */
     @SuppressWarnings("unchecked")
+    @Test
     public void testConstructors() {
         // 1. test default constructor
         DefaultKeyValue<K, V> kv = new DefaultKeyValue<>();
@@ -137,6 +142,7 @@ public class DefaultKeyValueTest<K, V> extends TestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testEqualsAndHashCode() {
         // 1. test with object data
         DefaultKeyValue<K, V> kv = makeDefaultKeyValue((K) key, (V) value);
@@ -156,6 +162,7 @@ public class DefaultKeyValueTest<K, V> extends TestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testToString() {
         DefaultKeyValue<K, V> kv = makeDefaultKeyValue((K) key, (V) value);
         assertTrue(kv.toString().equals(kv.getKey() + "=" + kv.getValue()));
@@ -166,6 +173,7 @@ public class DefaultKeyValueTest<K, V> extends TestCase {
     }
 
     @SuppressWarnings("unchecked")
+    @Test
     public void testToMapEntry() {
         final DefaultKeyValue<K, V> kv = makeDefaultKeyValue((K) key, (V) value);
 

--- a/src/test/java/org/apache/commons/collections4/keyvalue/DefaultMapEntryTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/DefaultMapEntryTest.java
@@ -19,6 +19,9 @@ package org.apache.commons.collections4.keyvalue;
 import java.util.Map;
 
 import org.apache.commons.collections4.KeyValue;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Test the DefaultMapEntry class.
@@ -55,6 +58,7 @@ public class DefaultMapEntryTest<K, V> extends AbstractMapEntryTest<K, V> {
      */
     @Override
     @SuppressWarnings("unchecked")
+    @Test
     public void testConstructors() {
         // 1. test key-value constructor
         final Map.Entry<K, V> entry = new DefaultMapEntry<>((K) key, (V) value);

--- a/src/test/java/org/apache/commons/collections4/keyvalue/MultiKeyTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/MultiKeyTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.keyvalue;
 
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -26,13 +29,13 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.TestCase;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for {@link org.apache.commons.collections4.keyvalue.MultiKey}.
  *
  */
-public class MultiKeyTest extends TestCase {
+public class MultiKeyTest {
 
     Integer ONE = Integer.valueOf(1);
     Integer TWO = Integer.valueOf(2);
@@ -40,17 +43,8 @@ public class MultiKeyTest extends TestCase {
     Integer FOUR = Integer.valueOf(4);
     Integer FIVE = Integer.valueOf(5);
 
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-        super.tearDown();
-    }
-
     //-----------------------------------------------------------------------
+    @Test
     public void testConstructors() throws Exception {
         MultiKey<Integer> mk;
         mk = new MultiKey<>(ONE, TWO);
@@ -69,6 +63,7 @@ public class MultiKeyTest extends TestCase {
         assertTrue(Arrays.equals(new Object[] { THREE, FOUR, ONE, TWO }, mk.getKeys()));
     }
 
+    @Test
     public void testConstructorsByArray() throws Exception {
         MultiKey<Integer> mk;
         Integer[] keys = new Integer[] { THREE, FOUR, ONE, TWO };
@@ -96,6 +91,7 @@ public class MultiKeyTest extends TestCase {
         assertTrue(Arrays.equals(new Object[] { THREE, FOUR, ONE, FIVE }, mk.getKeys()));
     }
 
+    @Test
     public void testConstructorsByArrayNull() throws Exception {
         final Integer[] keys = null;
         try {
@@ -112,6 +108,7 @@ public class MultiKeyTest extends TestCase {
         } catch (final IllegalArgumentException ex) {}
     }
 
+    @Test
     public void testSize() {
         assertEquals(2, new MultiKey<>(ONE, TWO).size());
         assertEquals(2, new MultiKey<>(null, null).size());
@@ -128,6 +125,7 @@ public class MultiKeyTest extends TestCase {
         assertEquals(7, new MultiKey<>(new Integer[] { ONE, TWO, ONE, TWO, ONE, TWO, ONE }).size());
     }
 
+    @Test
     public void testGetIndexed() {
         final MultiKey<Integer> mk = new MultiKey<>(ONE, TWO);
         assertSame(ONE, mk.getKey(0));
@@ -142,6 +140,7 @@ public class MultiKeyTest extends TestCase {
         } catch (final IndexOutOfBoundsException ex) {}
     }
 
+    @Test
     public void testGetKeysSimpleConstructor() {
         final MultiKey<Integer> mk = new MultiKey<>(ONE, TWO);
         final Object[] array = mk.getKeys();
@@ -150,6 +149,7 @@ public class MultiKeyTest extends TestCase {
         assertEquals(2, array.length);
     }
 
+    @Test
     public void testGetKeysArrayConstructorCloned() {
         final Integer[] keys = new Integer[] { ONE, TWO };
         final MultiKey<Integer> mk = new MultiKey<>(keys, true);
@@ -161,6 +161,7 @@ public class MultiKeyTest extends TestCase {
         assertEquals(2, array.length);
     }
 
+    @Test
     public void testGetKeysArrayConstructorNonCloned() {
         final Integer[] keys = new Integer[] { ONE, TWO };
         final MultiKey<Integer> mk = new MultiKey<>(keys, false);
@@ -172,6 +173,7 @@ public class MultiKeyTest extends TestCase {
         assertEquals(2, array.length);
     }
 
+    @Test
     public void testHashCode() {
         final MultiKey<Integer> mk1 = new MultiKey<>(ONE, TWO);
         final MultiKey<Integer> mk2 = new MultiKey<>(ONE, TWO);
@@ -185,6 +187,7 @@ public class MultiKeyTest extends TestCase {
         assertEquals(total, mk1.hashCode());
     }
 
+    @Test
     public void testEquals() {
         final MultiKey<Integer> mk1 = new MultiKey<>(ONE, TWO);
         final MultiKey<Integer> mk2 = new MultiKey<>(ONE, TWO);
@@ -227,6 +230,7 @@ public class MultiKeyTest extends TestCase {
         }
     }
 
+    @Test
     public void testEqualsAfterSerialization() throws IOException, ClassNotFoundException
     {
         SystemHashCodeSimulatingKey sysKey = new SystemHashCodeSimulatingKey("test");
@@ -272,6 +276,7 @@ public class MultiKeyTest extends TestCase {
 
     }
 
+    @Test
     public void testEqualsAfterSerializationOfDerivedClass() throws IOException, ClassNotFoundException
     {
         final DerivedMultiKey<?> mk = new DerivedMultiKey<>("A", "B");

--- a/src/test/java/org/apache/commons/collections4/keyvalue/TiedMapEntryTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/TiedMapEntryTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.commons.collections4.keyvalue;
 
+import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.Map;
+import static org.junit.Assert.*;
 
 /**
  * Test the TiedMapEntry class.
@@ -42,6 +45,7 @@ public class TiedMapEntryTest<K, V> extends AbstractMapEntryTest<K, V> {
      * Tests the constructors.
      */
     @Override
+    @Test
     public void testConstructors() {
         // ignore
     }
@@ -50,6 +54,7 @@ public class TiedMapEntryTest<K, V> extends AbstractMapEntryTest<K, V> {
      * Tests the constructors.
      */
     @SuppressWarnings("unchecked")
+    @Test
     public void testSetValue() {
         final Map<K, V> map = new HashMap<>();
         map.put((K) "A", (V) "a");

--- a/src/test/java/org/apache/commons/collections4/keyvalue/UnmodifiableMapEntryTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/UnmodifiableMapEntryTest.java
@@ -20,6 +20,9 @@ import java.util.Map;
 
 import org.apache.commons.collections4.KeyValue;
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 /**
  * Test the UnmodifiableMapEntry class.
@@ -56,6 +59,7 @@ public class UnmodifiableMapEntryTest<K, V> extends AbstractMapEntryTest<K, V> {
      */
     @Override
     @SuppressWarnings("unchecked")
+    @Test
     public void testConstructors() {
         // 1. test key-value constructor
         Map.Entry<K, V> entry = new UnmodifiableMapEntry<>((K) key, (V) value);
@@ -91,10 +95,12 @@ public class UnmodifiableMapEntryTest<K, V> extends AbstractMapEntryTest<K, V> {
     }
 
     @Override
+    @Test
     public void testSelfReferenceHandling() {
         // block
     }
 
+    @Test
     public void testUnmodifiable() {
         final Map.Entry<K, V> entry = makeMapEntry();
         try {


### PR DESCRIPTION
This pull request moves many JUnit 3 tests to JUnit 4 nomenclature.
Actually this was the easy part without base class usage of `src/test/java/org/apache/commons/collections4/BulkTest.java`.

**Verified?**
I verified that the tests in master branch and this PR are the same:

`[INFO] Tests run: 24589, Failures: 0, Errors: 0, Skipped: 0
`

**Numbers**
Here are some numbers to show the reduction.

master branch:

```
$ grep "extends TestCase" * -R|grep java:|wc -l
8
```

JUnit4 branch:
```
$ grep "extends TestCase" * -R|grep java:|wc -l
1
```