### PR TITLE
global: make use of FunctionalInterface

### DIFF
--- a/src/main/java/org/apache/commons/collections4/Closure.java
+++ b/src/main/java/org/apache/commons/collections4/Closure.java
@@ -28,6 +28,7 @@ package org.apache.commons.collections4;
  * @param <T> the type that the closure acts on
  * @since 1.0
  */
+@FunctionalInterface
 public interface Closure<T> {
 
     /**

--- a/src/main/java/org/apache/commons/collections4/Factory.java
+++ b/src/main/java/org/apache/commons/collections4/Factory.java
@@ -30,6 +30,7 @@ package org.apache.commons.collections4;
  *
  * @since 2.1
  */
+@FunctionalInterface
 public interface Factory<T> {
 
     /**

--- a/src/main/java/org/apache/commons/collections4/Predicate.java
+++ b/src/main/java/org/apache/commons/collections4/Predicate.java
@@ -32,6 +32,7 @@ package org.apache.commons.collections4;
  *
  * @since 1.0
  */
+@FunctionalInterface
 public interface Predicate<T> {
 
     /**

--- a/src/main/java/org/apache/commons/collections4/Transformer.java
+++ b/src/main/java/org/apache/commons/collections4/Transformer.java
@@ -34,6 +34,7 @@ package org.apache.commons.collections4;
  *
  * @since 1.0
  */
+@FunctionalInterface
 public interface Transformer<I, O> {
 
     /**

--- a/src/main/java/org/apache/commons/collections4/map/PassiveExpiringMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/PassiveExpiringMap.java
@@ -159,6 +159,7 @@ public class PassiveExpiringMap<K, V>
      * @param <V> the value object type
      * @since 4.0
      */
+    @FunctionalInterface
     public interface ExpirationPolicy<K, V>
         extends Serializable {
 

--- a/src/main/java/org/apache/commons/collections4/sequence/ReplacementsHandler.java
+++ b/src/main/java/org/apache/commons/collections4/sequence/ReplacementsHandler.java
@@ -24,6 +24,7 @@ import java.util.List;
  * @see ReplacementsFinder
  * @since 4.0
  */
+@FunctionalInterface
 public interface ReplacementsHandler<T> {
 
     /**


### PR DESCRIPTION
Now that we're using Java 8, it seems reasonable to annotate.