### PR TITLE
[COLLECTIONS-694] Support Transformer for LazyList

### DIFF
--- a/src/main/java/org/apache/commons/collections4/ListUtils.java
+++ b/src/main/java/org/apache/commons/collections4/ListUtils.java
@@ -457,7 +457,7 @@ public class ListUtils {
      * </pre>
      *
      * After the above code is executed, <code>date</code> will refer to
-     * a new <code>Date</code> instance.  Furthermore, that <code>Date</code>
+     * a new <code>Date</code> instance. Furthermore, that <code>Date</code>
      * instance is the fourth element in the list.  The first, second,
      * and third element are all set to <code>null</code>.
      *
@@ -469,6 +469,37 @@ public class ListUtils {
      */
     public static <E> List<E> lazyList(final List<E> list, final Factory<? extends E> factory) {
         return LazyList.lazyList(list, factory);
+    }
+
+    /**
+     * Returns a "lazy" list whose elements will be created on demand.
+     * <p>
+     * When the index passed to the returned list's {@link List#get(int) get}
+     * method is greater than the list's size, then the transformer will be used
+     * to create a new object and that object will be inserted at that index.
+     * <p>
+     * For instance:
+     *
+     * <pre>
+     * List&lt;Integer&gt; hours = Arrays.asList(7, 5, 8, 2);
+     * Transformer&lt;Integer,Date&gt; transformer = input -&gt; LocalDateTime.now().withHour(hours.get(input));
+     * List&lt;LocalDateTime&gt; lazy = ListUtils.lazyList(new ArrayList&lt;LocalDateTime&gt;(), transformer);
+     * Date date = lazy.get(3);
+     * </pre>
+     *
+     * After the above code is executed, <code>date</code> will refer to
+     * a new <code>Date</code> instance. Furthermore, that <code>Date</code>
+     * instance is the fourth element in the list.  The first, second,
+     * and third element are all set to <code>null</code>.
+     *
+     * @param <E> the element type
+     * @param list  the list to make lazy, must not be null
+     * @param transformer  the transformer for creating new objects, must not be null
+     * @return a lazy list backed by the given list
+     * @throws NullPointerException if the List or Transformer is null
+     */
+    public static <E> List<E> lazyList(final List<E> list, final Transformer<Integer, ? extends E> transformer) {
+        return LazyList.lazyList(list, transformer);
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/ListUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/ListUtilsTest.java
@@ -145,7 +145,7 @@ public class ListUtilsTest {
     }
 
     @Test
-    public void testLazyList() {
+    public void testLazyFactoryList() {
         final List<Integer> list = ListUtils.lazyList(new ArrayList<Integer>(), new Factory<Integer>() {
 
             private int index;
@@ -155,6 +155,27 @@ public class ListUtilsTest {
                 index++;
                 return Integer.valueOf(index);
             }
+        });
+
+        assertNotNull(list.get(5));
+        assertEquals(6, list.size());
+
+        assertNotNull(list.get(5));
+        assertEquals(6, list.size());
+    }
+
+    @Test
+    public void testLazyTransformerList() {
+        final List<Integer> offsets = Arrays.asList(3, 5, 1, 5, 3, 6);
+        final List<Integer> list = ListUtils.lazyList(new ArrayList<>(), new Transformer<Integer, Integer>() {
+
+            private int index;
+
+            @Override
+            public Integer transform(Integer input) {
+                return offsets.get(input) + index++;
+            }
+
         });
 
         assertNotNull(list.get(5));

--- a/src/test/java/org/apache/commons/collections4/list/LazyListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/LazyListTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4.list;
+
+import org.apache.commons.collections4.AbstractObjectTest;
+import org.apache.commons.collections4.Factory;
+import org.apache.commons.collections4.Transformer;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class LazyListTest extends AbstractObjectTest {
+
+    public LazyListTest(String testName) {
+        super(testName);
+    }
+
+    @Override
+    public Object makeObject() {
+        final Factory<LocalDateTime> dateFactory = LocalDateTime::now;
+        return new LazyList<>(new ArrayList<>(), dateFactory);
+    }
+
+    @Override
+    public void testSimpleSerialization() {
+        // Factory and Transformer are not serializable
+    }
+
+    @Override
+    public void testSerializeDeserializeThenCompare() {
+        // Factory and Transformer are not serializable
+    }
+
+    @Override
+    public void testCanonicalEmptyCollectionExists() {
+        // Factory and Transformer are not serializable
+    }
+
+    @Override
+    public void testCanonicalFullCollectionExists() {
+        // Factory and Transformer are not serializable
+    }
+
+    public void testElementCreationWithFactory() {
+        final Factory<LocalDateTime> dateFactory = LocalDateTime::now;
+        final List<LocalDateTime> list = new LazyList<>(new ArrayList<>(), dateFactory);
+
+        assertTrue(list.isEmpty());
+
+        final LocalDateTime firstElement = list.get(0);
+        assertNotNull(firstElement);
+        assertFalse(list.isEmpty());
+    }
+
+    public void testElementCreationWithTransformer() {
+        final Factory<LocalDateTime> dateFactory = LocalDateTime::now;
+        final List<LocalDateTime> list = new LazyList<>(new ArrayList<>(), dateFactory);
+
+        assertTrue(list.isEmpty());
+
+        final LocalDateTime firstElement = list.get(0);
+        assertNotNull(firstElement);
+        assertFalse(list.isEmpty());
+    }
+
+    public void testCreateNullGapsWithFactory() {
+        final Factory<LocalDateTime> dateFactory = LocalDateTime::now;
+        final List<LocalDateTime> list = new LazyList<>(new ArrayList<>(), dateFactory);
+
+        final LocalDateTime fourthElement = list.get(3);
+        assertFalse(list.isEmpty());
+        assertNotNull(fourthElement);
+    }
+
+    public void testCreateNullGapsWithTransformer() {
+        final List<Integer> hours = Arrays.asList(7, 5, 8, 2);
+        final Transformer<Integer, LocalDateTime> dateFactory = input -> LocalDateTime.now().withHour(hours.get(input));
+        final List<LocalDateTime> list = new LazyList<>(new ArrayList<>(), dateFactory);
+
+        final LocalDateTime fourthElement = list.get(3);
+        assertFalse(list.isEmpty());
+        assertNotNull(fourthElement);
+    }
+
+
+
+}


### PR DESCRIPTION
This change adds support for `Transformer` in the `LazyList` class.

Some test cases have been added since I could not find any tests for `LazyList`. However, the class does not seem to be serializable as stated in the Javadoc.