### PR TITLE
COLLECTIONS-697 JavaDoc FixedSizeList should warn that modifying underlying list is not prevented

### DIFF
--- a/src/main/java/org/apache/commons/collections4/list/FixedSizeList.java
+++ b/src/main/java/org/apache/commons/collections4/list/FixedSizeList.java
@@ -31,7 +31,6 @@ import org.apache.commons.collections4.iterators.UnmodifiableIterator;
  * The add, remove, clear and retain operations are unsupported.
  * The set method is allowed (as it doesn't change the list size).
  * <p>
- * <p>
  * NOTE:
  * Modifying the decorated list directly would results in influencing the outcome
  * of method calls on this object. For example, the bounds of this list would reflect

--- a/src/main/java/org/apache/commons/collections4/list/FixedSizeList.java
+++ b/src/main/java/org/apache/commons/collections4/list/FixedSizeList.java
@@ -31,6 +31,12 @@ import org.apache.commons.collections4.iterators.UnmodifiableIterator;
  * The add, remove, clear and retain operations are unsupported.
  * The set method is allowed (as it doesn't change the list size).
  * <p>
+ * <p>
+ * NOTE:
+ * Modifying the decorated list directly would results in influencing the outcome
+ * of method calls on this object. For example, the bounds of this list would reflect
+ * a newly added object to the underlying list.
+ * <p>
  * This class is Serializable from Commons Collections 3.1.
  *
  * @param <E> the type of elements in this collection

--- a/src/test/java/org/apache/commons/collections4/list/FixedSizeListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/FixedSizeListTest.java
@@ -68,7 +68,6 @@ public class FixedSizeListTest<E> extends AbstractListTest<E> {
 //        writeExternalFormToDisk((java.io.Serializable) getCollection(), "src/test/resources/data/test/FixedSizeList.fullCollection.version4.obj");
 //    }
 
-
     public void testListAllowsMutationOfUnderlyingCollection() {
 
         List<String> decoratedList = new ArrayList<>();

--- a/src/test/java/org/apache/commons/collections4/list/FixedSizeListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/FixedSizeListTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.list;
 
+import org.junit.Assert;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -66,4 +68,20 @@ public class FixedSizeListTest<E> extends AbstractListTest<E> {
 //        writeExternalFormToDisk((java.io.Serializable) getCollection(), "src/test/resources/data/test/FixedSizeList.fullCollection.version4.obj");
 //    }
 
+
+    public void testListAllowsMutationOfUnderlyingCollection() {
+
+        List<String> decoratedList = new ArrayList<>();
+        decoratedList.add("item 1");
+        decoratedList.add("item 2");
+        //
+        FixedSizeList<String> fixedSizeList = FixedSizeList.fixedSizeList(decoratedList);
+        int sizeBefore = fixedSizeList.size();
+        //
+        boolean changed = decoratedList.add("New Value");
+        Assert.assertTrue(changed);
+        //
+        Assert.assertEquals("Modifying an the underlying list is allowed",
+                sizeBefore + 1, fixedSizeList.size());
+    }
 }


### PR DESCRIPTION
I just noticed that it is not explicitly mentioned in the JavaDoc that modifying the underlying list of a FixedSizeList would actually land up modifying the list of the constructed FixedSizeList. Not sure if this was by design, but at the very list I think the JavaDoc should caution against this.

This Pull Request has the necessary updates to the JavaDoc and a test that proves the findings.

NOTE: this is my first PR and I have tried to follow the guidelines.  Pleas let me know if I need to do anything more.  Thanks!