### PR TITLE
The put method should return the previous record only if not expired

### DIFF
--- a/src/main/java/org/apache/commons/collections4/map/PassiveExpiringMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/PassiveExpiringMap.java
@@ -430,6 +430,9 @@ public class PassiveExpiringMap<K, V>
     */
     @Override
     public V put(final K key, final V value) {
+        // remove the previous record
+        removeIfExpired(key, now());
+
         // record expiration time of new entry
         final long expirationTime = expiringPolicy.expirationTime(key, value);
         expirationMap.put(key, Long.valueOf(expirationTime));

--- a/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
@@ -191,6 +191,16 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
         assertEquals("six", m.get(Integer.valueOf(6)));
     }
 
+    public void testPut() {
+        final Map<Integer, String> m = makeTestMap();
+        assertNull(m.put(Integer.valueOf(1), "ONE"));
+        assertEquals("two", m.put(Integer.valueOf(2), "TWO"));
+        assertNull(m.put(Integer.valueOf(3), "THREE"));
+        assertEquals("four", m.put(Integer.valueOf(4), "FOUR"));
+        assertNull(m.put(Integer.valueOf(5), "FIVE"));
+        assertEquals("six", m.put(Integer.valueOf(6), "SIX"));
+    }
+
     public void testIsEmpty() {
         Map<Integer, String> m = makeTestMap();
         assertFalse(m.isEmpty());


### PR DESCRIPTION
Useful for the following scenario:
```
if (myCache.put(key, value) == null) {
  // the key is new 
} else {
  // the key is being altered
}
```