### PR TITLE
[COLLECTIONS 706] Add set utils.as set method

### DIFF
--- a/src/main/java/org/apache/commons/collections4/SetUtils.java
+++ b/src/main/java/org/apache/commons/collections4/SetUtils.java
@@ -48,7 +48,8 @@ import org.apache.commons.collections4.set.UnmodifiableSortedSet;
 public class SetUtils {
 
     /**
-     * Create an unmodifiable set from the given items.
+     * Create an unmodifiable set from the given items. If the passed var-args argument is {@code
+     * null}, then the method returns {@code null}.
      * @param <E> the element type
      * @return a set
      */

--- a/src/main/java/org/apache/commons/collections4/SetUtils.java
+++ b/src/main/java/org/apache/commons/collections4/SetUtils.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4;
 
 import java.util.AbstractSet;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -46,6 +47,20 @@ import org.apache.commons.collections4.set.UnmodifiableSortedSet;
  */
 public class SetUtils {
 
+    /**
+     * Create an unmodifiable set from the given items.
+     * @param <E> the element type
+     * @return a set
+     */
+    public static <E> Set<E> asSet(final E... items) {
+        if (items == null) {
+            return null;
+        }
+        else {
+            return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(items)));
+        }
+    }
+    
     /**
      * Get a typed empty unmodifiable Set.
      * @param <E> the element type

--- a/src/test/java/org/apache/commons/collections4/SetUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/SetUtilsTest.java
@@ -61,6 +61,32 @@ public class SetUtilsTest {
     //-----------------------------------------------------------------------
 
     @Test
+    public void testAsSet()
+    {
+        Set<?> set1 = SetUtils.asSet();
+        assertTrue("set is empty", set1.isEmpty());
+        
+        Set<Integer> set2 = SetUtils.asSet(1, 2, 2, 3);
+        assertEquals("set has 3 elements", 3, set2.size());
+        assertTrue("set contains 1", set2.contains(1));
+        assertTrue("set contains 2", set2.contains(2));
+        assertTrue("set contains 3", set2.contains(3));
+        
+        Set<String> set3 = SetUtils.asSet("1", "2", "2", "3");
+        assertEquals("set has 3 elements", 3, set3.size());
+        assertTrue("set contains 1", set3.contains("1"));
+        assertTrue("set contains 2", set3.contains("2"));
+        assertTrue("set contains 3", set3.contains("3"));
+        
+        Set<?> set4 = SetUtils.asSet(null, null);
+        assertEquals("set has 1 element", 1, set4.size());
+        assertTrue("set contains null", set4.contains(null));
+        
+        Set<?> set5 = SetUtils.asSet(null);
+        assertEquals("set is null", null, set5);
+    }
+    
+    @Test
     public void testpredicatedSet() {
         final Predicate<Object> predicate = new Predicate<Object>() {
             @Override


### PR DESCRIPTION
PR adds the method described in https://issues.apache.org/jira/projects/COLLECTIONS/issues/COLLECTIONS-706 .

Could be discussed how to handle this case:

```
SetUtils.asSet(null)
```

The compile will warn (at least in Eclipse) that this actually means passing a null array as the var-args argument. 

* Right now, I implemented it such that in this case, the method will return `null`. 
* It might be arguable to better return an empty set in this case.
* It could even be argued to return a set with the value `null` in this case. 

Opinions?