### PR TITLE
COLLECTIONS-709 Set Entry count to 0 after remove

### DIFF
--- a/src/main/java/org/apache/commons/collections4/multiset/AbstractMapMultiSet.java
+++ b/src/main/java/org/apache/commons/collections4/multiset/AbstractMapMultiSet.java
@@ -265,6 +265,7 @@ public abstract class AbstractMapMultiSet<E> extends AbstractMultiSet<E> {
             } else {
                 map.remove(object);
                 size -= mut.value;
+                mut.value = 0;
             }
         }
         return oldCount;

--- a/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
@@ -463,6 +463,22 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
     }
 
     @SuppressWarnings("unchecked")
+    public void testMultiSetEntrySetUpdatedToZero() {
+        if (!isAddSupported()) {
+            return;
+        }
+        final MultiSet<T> multiset = makeObject();
+        multiset.add((T) "A");
+        multiset.add((T) "A");
+        final MultiSet.Entry<T> entry = multiset.entrySet().iterator().next();
+        assertEquals(2, entry.getCount());
+        multiset.remove((T) "A");
+        assertEquals(1, entry.getCount());
+        multiset.remove((T) "A");
+        assertEquals(0, entry.getCount());
+    }
+
+    @SuppressWarnings("unchecked")
     public void testMultiSetToArray() {
         if (!isAddSupported()) {
             return;


### PR DESCRIPTION
Currently, after removing the last element of a MultiSet, the Entry doesn't have a count of 0. This commit fixes the count after removing the last of the current Entry of a MultiSet.