### PR TITLE
[BulkTest] remove workarounds for buggy JDK 1.6 implementations

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap.java
+++ b/src/main/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap.java
@@ -378,7 +378,6 @@ public class DualTreeBidiMap<K, V> extends AbstractDualBidiMap<K, V>
             final V oldValue = parent.put(last.getKey(), value);
             // Map.Entry specifies that the behavior is undefined when the backing map
             // has been modified (as we did with the put), so we also set the value
-            // (especially needed for IBM JDK)
             last.setValue(value);
             return oldValue;
         }

--- a/src/test/java/org/apache/commons/collections4/BulkTest.java
+++ b/src/test/java/org/apache/commons/collections4/BulkTest.java
@@ -136,17 +136,6 @@ import junit.framework.TestSuite;
  */
 public class BulkTest extends TestCase implements Cloneable {
 
-    /**
-     * IBM JDK 1.6.0 has several bugs in their java.util.TreeMap implementation.
-     */
-    protected static final boolean IBMJDK16;
-    static {
-        final String vmName = System.getProperty("java.vm.name");
-        final String version = System.getProperty("java.version");
-
-        IBMJDK16 = vmName != null  && vmName.equals("IBM J9 VM") &&
-                   version != null && version.equals("1.6.0");
-    }
 
     // Note:  BulkTest is Cloneable to make it easier to construct
     // BulkTest instances for simple test methods that are defined in

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap2Test.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap2Test.java
@@ -154,24 +154,6 @@ public class DualTreeBidiMap2Test<K extends Comparable<K>, V extends Comparable<
     @Override
     public String[] ignoredTests() {
         final String recursiveTest = "DualTreeBidiMap2Test.bulkTestInverseMap.bulkTestInverseMap";
-
-        if (IBMJDK16) {
-            final String preSub = "DualTreeBidiMap2Test.bulkTestSubMap.";
-            final String preTail = "DualTreeBidiMap2Test.bulkTestTailMap.";
-            return new String[] {
-                    recursiveTest,
-                    preSub + "bulkTestMapEntrySet.testCollectionIteratorRemove",
-                    preSub + "bulkTestMapValues.testCollectionIteratorRemove",
-                    preTail + "testMapRemove",
-                    preTail + "bulkTestMapEntrySet.testCollectionIteratorRemove",
-                    preTail + "bulkTestMapEntrySet.testCollectionRemoveAll",
-                    preTail + "bulkTestMapKeySet.testCollectionIteratorRemove",
-                    preTail + "bulkTestMapKeySet.testCollectionRemoveAll",
-                    preTail + "bulkTestMapValues.testCollectionClear",
-                    preTail + "bulkTestMapValues.testCollectionRemoveAll",
-                    preTail + "bulkTestMapValues.testCollectionRetainAll"
-            };
-        }
         return new String[] { recursiveTest };
     }
 

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMapTest.java
@@ -48,24 +48,6 @@ public class DualTreeBidiMapTest<K extends Comparable<K>, V extends Comparable<V
     @Override
     public String[] ignoredTests() {
         final String recursiveTest = "DualTreeBidiMapTest.bulkTestInverseMap.bulkTestInverseMap";
-
-        if (IBMJDK16) {
-            final String preSub = "DualTreeBidiMapTest.bulkTestSubMap.";
-            final String preTail = "DualTreeBidiMapTest.bulkTestTailMap.";
-            return new String[] {
-                    recursiveTest,
-                    preSub + "bulkTestMapEntrySet.testCollectionIteratorRemove",
-                    preSub + "bulkTestMapValues.testCollectionIteratorRemove",
-                    preTail + "testMapRemove",
-                    preTail + "bulkTestMapEntrySet.testCollectionIteratorRemove",
-                    preTail + "bulkTestMapEntrySet.testCollectionRemoveAll",
-                    preTail + "bulkTestMapKeySet.testCollectionIteratorRemove",
-                    preTail + "bulkTestMapKeySet.testCollectionRemoveAll",
-                    preTail + "bulkTestMapValues.testCollectionClear",
-                    preTail + "bulkTestMapValues.testCollectionRemoveAll",
-                    preTail + "bulkTestMapValues.testCollectionRetainAll"
-            };
-        }
         return new String[] { recursiveTest };
     }
 

--- a/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
@@ -2006,10 +2006,6 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     public void verifyValues() {
         final List<V> known = new ArrayList<>(getConfirmed().values());
 
-        // bug in IBM JDK: IBM J9 VM build 2.4, JRE 1.6.0 IBM J9 2.4 Linux x86-32 jvmxi3260sr12-20121024_126067
-        // a call to values() on an empty map retrieved via TreeMap#headMap or tailMap
-        // will render the values view unusable: resulting in NullPointerExceptions or missing values
-        // it will also not recover, as the value view is cached internally
         values = getMap().values();
 
         final List<V> test = new ArrayList<>(values);

--- a/src/test/java/org/apache/commons/collections4/map/TransformedSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/TransformedSortedMapTest.java
@@ -46,23 +46,6 @@ public class TransformedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> 
 
     @Override
     public String[] ignoredTests() {
-        if (IBMJDK16) {
-            final String preSubMap = "TransformedSortedMapTest.bulkTestSubMap.";
-            final String preTailMap = "TransformedSortedMapTest.bulkTestTailMap.";
-            return new String[] {
-                    preSubMap + "bulkTestMapEntrySet.testCollectionIteratorRemove",
-                    preSubMap + "bulkTestMapKeySet.testCollectionRemove",
-                    preSubMap + "bulkTestMapValues.testCollectionIteratorRemove",
-                    preTailMap + "testMapRemove",
-                    preTailMap + "bulkTestMapEntrySet.testCollectionIteratorRemove",
-                    preTailMap + "bulkTestMapEntrySet.testCollectionRemoveAll",
-                    preTailMap + "bulkTestMapKeySet.testCollectionIteratorRemove",
-                    preTailMap + "bulkTestMapKeySet.testCollectionRemoveAll",
-                    preTailMap + "bulkTestMapValues.testCollectionClear",
-                    preTailMap + "bulkTestMapValues.testCollectionRemoveAll",
-                    preTailMap + "bulkTestMapValues.testCollectionRetainAll"
-            };
-        }
         return null;
     }
 

--- a/src/test/java/org/apache/commons/collections4/trie/UnmodifiableTrieTest.java
+++ b/src/test/java/org/apache/commons/collections4/trie/UnmodifiableTrieTest.java
@@ -92,14 +92,6 @@ public class UnmodifiableTrieTest<V> extends AbstractSortedMapTest<String, V> {
      */
     @Override
     public String[] ignoredTests() {
-        if (IBMJDK16) {
-            final String prefix = "UnmodifiableTrieTest.";
-            return new String[] {
-                    prefix + "bulkTestHeadMap.bulkTestMapEntrySet.testCollectionToArray2",
-                    prefix + "bulkTestTailMap.bulkTestMapEntrySet.testCollectionToArray2",
-                    prefix + "bulkTestSubMap.bulkTestMapEntrySet.testCollectionToArray2"
-            };
-        }
         return null;
     }
 


### PR DESCRIPTION
Considering that we now require Java 8, having a workaround for IBM's
version of JDK 1.6 isn't required.