### PR TITLE
Fix Travis build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -606,6 +606,13 @@
           </archive>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+            <source>8</source>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Use source=8 for maven-javadoc-plugin. Build passing on JDK 11 for me, on Ubuntu LTS, Maven 3.5.4.

Hoping Travis will pass too.