### PR TITLE
Collections 699 - PairingIterator

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -457,7 +457,7 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.9</version>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/apache/commons/collections4/iterators/PairingIterator.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/PairingIterator.java
@@ -47,60 +47,60 @@ import org.apache.commons.lang3.tuple.Pair;
  */
 public class PairingIterator<L, R> implements Iterator<Pair<L, R>> {
 
-	private final Iterator<L> firstIterator;
-	private final Iterator<R> secondIterator;
+    private final Iterator<L> firstIterator;
+    private final Iterator<R> secondIterator;
 
-	/**
-	 * Constructs a new <code>PairingIterator</code> that will provide a
-	 * {@link} Pair of the child iterator elements.
-	 * 
-	 * @param firstIterator
-	 *            the first iterator
-	 * @param secondIterator
-	 *            the second iterator
-	 */
-	public PairingIterator(Iterator<L> firstIterator, Iterator<R> secondIterator) {
-		this.firstIterator = firstIterator;
-		this.secondIterator = secondIterator;
-	}
+    /**
+     * Constructs a new <code>PairingIterator</code> that will provide a
+     * {@link} Pair of the child iterator elements.
+     * 
+     * @param firstIterator
+     *            the first iterator
+     * @param secondIterator
+     *            the second iterator
+     */
+    public PairingIterator(Iterator<L> firstIterator, Iterator<R> secondIterator) {
+        this.firstIterator = firstIterator;
+        this.secondIterator = secondIterator;
+    }
 
-	/**
-	 * Returns {@code true} if one of the child iterators has remaining elements.
-	 */
-	@Override
-	public boolean hasNext() {
-		return (null != firstIterator && firstIterator.hasNext())
-				|| (null != secondIterator && secondIterator.hasNext());
-	}
+    /**
+     * Returns {@code true} if one of the child iterators has remaining elements.
+     */
+    @Override
+    public boolean hasNext() {
+        return (null != firstIterator && firstIterator.hasNext())
+                || (null != secondIterator && secondIterator.hasNext());
+    }
 
-	/**
-	 * Returns the next {@link Pair} with the next values of the child iterators.
-	 * 
-	 * @return a {@link Pair} with the next values of child iterators
-	 * @throws NoSuchElementException
-	 *             if no child iterator has any more elements
-	 */
-	@Override
-	public Pair<L, R> next() throws NoSuchElementException {
-		if (!hasNext()) {
-			throw new NoSuchElementException();
-		}
-		final L leftValue = null != firstIterator && firstIterator.hasNext() ? firstIterator.next() : null;
-		final R rightValue = null != secondIterator && secondIterator.hasNext() ? secondIterator.next() : null;
-		return Pair.of(leftValue, rightValue);
-	}
+    /**
+     * Returns the next {@link Pair} with the next values of the child iterators.
+     * 
+     * @return a {@link Pair} with the next values of child iterators
+     * @throws NoSuchElementException
+     *             if no child iterator has any more elements
+     */
+    @Override
+    public Pair<L, R> next() throws NoSuchElementException {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        final L leftValue = null != firstIterator && firstIterator.hasNext() ? firstIterator.next() : null;
+        final R rightValue = null != secondIterator && secondIterator.hasNext() ? secondIterator.next() : null;
+        return Pair.of(leftValue, rightValue);
+    }
 
-	/**
-	 * Removes the last returned values of the child iterators.
-	 */
-	@Override
-	public void remove() {
-		if (firstIterator != null) {
-			firstIterator.remove();
-		}
-		if (secondIterator != null) {
-			secondIterator.remove();
-		}
-	}
+    /**
+     * Removes the last returned values of the child iterators.
+     */
+    @Override
+    public void remove() {
+        if (firstIterator != null) {
+            firstIterator.remove();
+        }
+        if (secondIterator != null) {
+            secondIterator.remove();
+        }
+    }
 
 }

--- a/src/main/java/org/apache/commons/collections4/iterators/PairingIterator.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/PairingIterator.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4.iterators;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * Provides an iteration over the elements of two iterators. It will be return a
+ * {@link Pair} with the elements of the iterators.
+ * <p>
+ * Given two {@link Iterator} instances {@code A} and {@code B}. The
+ * {@link #next()} method will return a {@link Pair} with the elements of the
+ * {@code A} and {@code B} until both iterators are exhausted.
+ * </p>
+ * <p>
+ * If one of the iterators is null, the result {@link Pair} has also a null
+ * value and the value of the other iterator.
+ * </p>
+ * <p>
+ * If one iterator has more elements then the other, the result {@link Pair}
+ * will contain null values if one of the iterator exhausted.
+ *
+ * @param <L>
+ *            type of left value of {@link Pair}
+ * 
+ * @param <R>
+ *            type of the right value of {@link Pair}
+ * 
+ * @since 4.4
+ */
+public class PairingIterator<L, R> implements Iterator<Pair<L, R>> {
+
+	private final Iterator<L> firstIterator;
+	private final Iterator<R> secondIterator;
+
+	/**
+	 * Constructs a new <code>PairingIterator</code> that will provide a
+	 * {@link} Pair of the child iterator elements.
+	 * 
+	 * @param firstIterator
+	 *            the first iterator
+	 * @param secondIterator
+	 *            the second iterator
+	 */
+	public PairingIterator(Iterator<L> firstIterator, Iterator<R> secondIterator) {
+		this.firstIterator = firstIterator;
+		this.secondIterator = secondIterator;
+	}
+
+	/**
+	 * Returns {@code true} if one of the child iterators has remaining elements.
+	 */
+	@Override
+	public boolean hasNext() {
+		return (null != firstIterator && firstIterator.hasNext())
+				|| (null != secondIterator && secondIterator.hasNext());
+	}
+
+	/**
+	 * Returns the next {@link Pair} with the next values of the child iterators.
+	 * 
+	 * @return a {@link Pair} with the next values of child iterators
+	 * @throws NoSuchElementException
+	 *             if no child iterator has any more elements
+	 */
+	@Override
+	public Pair<L, R> next() throws NoSuchElementException {
+		if (!hasNext()) {
+			throw new NoSuchElementException();
+		}
+		final L leftValue = null != firstIterator && firstIterator.hasNext() ? firstIterator.next() : null;
+		final R rightValue = null != secondIterator && secondIterator.hasNext() ? secondIterator.next() : null;
+		return Pair.of(leftValue, rightValue);
+	}
+
+	/**
+	 * Removes the last returned values of the child iterators.
+	 */
+	@Override
+	public void remove() {
+		if (firstIterator != null) {
+			firstIterator.remove();
+		}
+		if (secondIterator != null) {
+			secondIterator.remove();
+		}
+	}
+
+}

--- a/src/test/java/org/apache/commons/collections4/iterators/PairingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/PairingIteratorTest.java
@@ -34,179 +34,179 @@ import org.junit.Test;
  */
 public class PairingIteratorTest extends AbstractIteratorTest<Pair<String, String>> {
 
-	public PairingIteratorTest(String testName) {
-		super(testName);
-	}
+    public PairingIteratorTest(String testName) {
+        super(testName);
+    }
 
-	@Test
-	public void testNullValuesBoth() {
-		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(null, null);
+    @Test
+    public void testNullValuesBoth() {
+        final PairingIterator<String, String> pairingIterator = new PairingIterator<>(null, null);
 
-		Assert.assertFalse(pairingIterator.hasNext());
-		try {
-			pairingIterator.next();
-			fail();
+        Assert.assertFalse(pairingIterator.hasNext());
+        try {
+            pairingIterator.next();
+            fail();
 
-		} catch (NoSuchElementException e) {
-			Assert.assertNotNull(e);
-		}
-	}
+        } catch (NoSuchElementException e) {
+            Assert.assertNotNull(e);
+        }
+    }
 
-	@Test
-	public void testNullValueFirst() {
-		final List<String> rightList = Arrays.asList(new String[] { "A" });
-		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(null, rightList.iterator());
+    @Test
+    public void testNullValueFirst() {
+        final List<String> rightList = Arrays.asList(new String[] { "A" });
+        final PairingIterator<String, String> pairingIterator = new PairingIterator<>(null, rightList.iterator());
 
-		Assert.assertTrue(pairingIterator.hasNext());
+        Assert.assertTrue(pairingIterator.hasNext());
 
-		Pair<String, String> next = pairingIterator.next();
-		Assert.assertEquals(null, next.getLeft());
-		Assert.assertEquals("A", next.getRight());
-	}
+        Pair<String, String> next = pairingIterator.next();
+        Assert.assertEquals(null, next.getLeft());
+        Assert.assertEquals("A", next.getRight());
+    }
 
-	@Test
-	public void testNullValueSecond() {
-		final List<String> leftList = Arrays.asList(new String[] { "A" });
-		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(), null);
+    @Test
+    public void testNullValueSecond() {
+        final List<String> leftList = Arrays.asList(new String[] { "A" });
+        final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(), null);
 
-		Assert.assertTrue(pairingIterator.hasNext());
+        Assert.assertTrue(pairingIterator.hasNext());
 
-		Pair<String, String> next = pairingIterator.next();
-		Assert.assertEquals("A", next.getLeft());
-		Assert.assertEquals(null, next.getRight());
-	}
+        Pair<String, String> next = pairingIterator.next();
+        Assert.assertEquals("A", next.getLeft());
+        Assert.assertEquals(null, next.getRight());
+    }
 
-	@Test
-	public void testTwoIteratorsWithBothTwoElements() {
-		final List<String> leftList = Arrays.asList(new String[] { "A1", "A2" });
-		final List<String> rightList = Arrays.asList(new String[] { "B1", "B2" });
-		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(),
-				rightList.iterator());
+    @Test
+    public void testTwoIteratorsWithBothTwoElements() {
+        final List<String> leftList = Arrays.asList(new String[] { "A1", "A2" });
+        final List<String> rightList = Arrays.asList(new String[] { "B1", "B2" });
+        final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(),
+                rightList.iterator());
 
-		Assert.assertTrue(pairingIterator.hasNext());
+        Assert.assertTrue(pairingIterator.hasNext());
 
-		Pair<String, String> next = pairingIterator.next();
-		Assert.assertEquals("A1", next.getLeft());
-		Assert.assertEquals("B1", next.getRight());
+        Pair<String, String> next = pairingIterator.next();
+        Assert.assertEquals("A1", next.getLeft());
+        Assert.assertEquals("B1", next.getRight());
 
-		Assert.assertTrue(pairingIterator.hasNext());
-		next = pairingIterator.next();
-		Assert.assertEquals("A2", next.getLeft());
-		Assert.assertEquals("B2", next.getRight());
+        Assert.assertTrue(pairingIterator.hasNext());
+        next = pairingIterator.next();
+        Assert.assertEquals("A2", next.getLeft());
+        Assert.assertEquals("B2", next.getRight());
 
-		Assert.assertFalse(pairingIterator.hasNext());
-	}
+        Assert.assertFalse(pairingIterator.hasNext());
+    }
 
-	@Test
-	public void testTwoIteratorsWithDifferentSize() {
-		final List<String> leftList = Arrays.asList(new String[] { "A1", "A2", "A3" });
-		final List<String> rightList = Arrays.asList(new String[] { "B1", "B2" });
-		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(),
-				rightList.iterator());
+    @Test
+    public void testTwoIteratorsWithDifferentSize() {
+        final List<String> leftList = Arrays.asList(new String[] { "A1", "A2", "A3" });
+        final List<String> rightList = Arrays.asList(new String[] { "B1", "B2" });
+        final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(),
+                rightList.iterator());
 
-		Assert.assertTrue(pairingIterator.hasNext());
+        Assert.assertTrue(pairingIterator.hasNext());
 
-		Pair<String, String> next = pairingIterator.next();
-		Assert.assertEquals("A1", next.getLeft());
-		Assert.assertEquals("B1", next.getRight());
+        Pair<String, String> next = pairingIterator.next();
+        Assert.assertEquals("A1", next.getLeft());
+        Assert.assertEquals("B1", next.getRight());
 
-		Assert.assertTrue(pairingIterator.hasNext());
+        Assert.assertTrue(pairingIterator.hasNext());
 
-		next = pairingIterator.next();
-		Assert.assertEquals("A2", next.getLeft());
-		Assert.assertEquals("B2", next.getRight());
+        next = pairingIterator.next();
+        Assert.assertEquals("A2", next.getLeft());
+        Assert.assertEquals("B2", next.getRight());
 
-		Assert.assertTrue(pairingIterator.hasNext());
-		next = pairingIterator.next();
-		Assert.assertEquals("A3", next.getLeft());
-		Assert.assertEquals(null, next.getRight());
+        Assert.assertTrue(pairingIterator.hasNext());
+        next = pairingIterator.next();
+        Assert.assertEquals("A3", next.getLeft());
+        Assert.assertEquals(null, next.getRight());
 
-		Assert.assertFalse(pairingIterator.hasNext());
-	}
+        Assert.assertFalse(pairingIterator.hasNext());
+    }
 
-	@Test
-	public void testTwoIteratorsWithDifferentSize2() {
-		final List<String> leftList = Arrays.asList(new String[] { "A1", });
-		final List<String> rightList = Arrays.asList(new String[] { "B1", "B2" });
-		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(),
-				rightList.iterator());
+    @Test
+    public void testTwoIteratorsWithDifferentSize2() {
+        final List<String> leftList = Arrays.asList(new String[] { "A1", });
+        final List<String> rightList = Arrays.asList(new String[] { "B1", "B2" });
+        final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(),
+                rightList.iterator());
 
-		Assert.assertTrue(pairingIterator.hasNext());
+        Assert.assertTrue(pairingIterator.hasNext());
 
-		Pair<String, String> next = pairingIterator.next();
-		Assert.assertEquals("A1", next.getLeft());
-		Assert.assertEquals("B1", next.getRight());
+        Pair<String, String> next = pairingIterator.next();
+        Assert.assertEquals("A1", next.getLeft());
+        Assert.assertEquals("B1", next.getRight());
 
-		Assert.assertTrue(pairingIterator.hasNext());
+        Assert.assertTrue(pairingIterator.hasNext());
 
-		next = pairingIterator.next();
-		Assert.assertEquals(null, next.getLeft());
-		Assert.assertEquals("B2", next.getRight());
+        next = pairingIterator.next();
+        Assert.assertEquals(null, next.getLeft());
+        Assert.assertEquals("B2", next.getRight());
 
-		Assert.assertFalse(pairingIterator.hasNext());
-	}
+        Assert.assertFalse(pairingIterator.hasNext());
+    }
 
-	@Test
-	public void testTwoIteratorsWithNullValues() {
-		final List<String> leftList = Arrays.asList(new String[] { null, "A2" });
-		final List<String> rightList = Arrays.asList(new String[] { "B1", null });
-		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(),
-				rightList.iterator());
+    @Test
+    public void testTwoIteratorsWithNullValues() {
+        final List<String> leftList = Arrays.asList(new String[] { null, "A2" });
+        final List<String> rightList = Arrays.asList(new String[] { "B1", null });
+        final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(),
+                rightList.iterator());
 
-		Assert.assertTrue(pairingIterator.hasNext());
+        Assert.assertTrue(pairingIterator.hasNext());
 
-		Pair<String, String> next = pairingIterator.next();
-		Assert.assertEquals(null, next.getLeft());
-		Assert.assertEquals("B1", next.getRight());
+        Pair<String, String> next = pairingIterator.next();
+        Assert.assertEquals(null, next.getLeft());
+        Assert.assertEquals("B1", next.getRight());
 
-		Assert.assertTrue(pairingIterator.hasNext());
-		next = pairingIterator.next();
-		Assert.assertEquals("A2", next.getLeft());
-		Assert.assertEquals(null, next.getRight());
+        Assert.assertTrue(pairingIterator.hasNext());
+        next = pairingIterator.next();
+        Assert.assertEquals("A2", next.getLeft());
+        Assert.assertEquals(null, next.getRight());
 
-		Assert.assertFalse(pairingIterator.hasNext());
-	}
+        Assert.assertFalse(pairingIterator.hasNext());
+    }
 
-	@Test
-	public void testRemoveWithOneNullIterator() {
-		final List<String> leftList = new ArrayList<>();
-		leftList.add("A1");
-		final Iterator<String> leftIterator = leftList.iterator();
-		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftIterator, null);
+    @Test
+    public void testRemoveWithOneNullIterator() {
+        final List<String> leftList = new ArrayList<>();
+        leftList.add("A1");
+        final Iterator<String> leftIterator = leftList.iterator();
+        final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftIterator, null);
 
-		pairingIterator.next();
-		pairingIterator.remove();
-		Assert.assertTrue(leftList.isEmpty());
-	}
-	
-	@Test
-	public void testRemoveWithOneNullIterator2() {
-		final List<String> rightList = new ArrayList<>();
-		rightList.add("A1");
-		final Iterator<String> rightIterator = rightList.iterator();
-		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(null, rightIterator);
+        pairingIterator.next();
+        pairingIterator.remove();
+        Assert.assertTrue(leftList.isEmpty());
+    }
 
-		pairingIterator.next();
-		pairingIterator.remove();
-		Assert.assertTrue(rightList.isEmpty());
-	}
+    @Test
+    public void testRemoveWithOneNullIterator2() {
+        final List<String> rightList = new ArrayList<>();
+        rightList.add("A1");
+        final Iterator<String> rightIterator = rightList.iterator();
+        final PairingIterator<String, String> pairingIterator = new PairingIterator<>(null, rightIterator);
 
-	@Override
-	public Iterator<Pair<String, String>> makeEmptyIterator() {
-		return new PairingIterator<String, String>(IteratorUtils.<String>emptyIterator(),
-				IteratorUtils.<String>emptyIterator());
-	}
+        pairingIterator.next();
+        pairingIterator.remove();
+        Assert.assertTrue(rightList.isEmpty());
+    }
 
-	@Override
-	public Iterator<Pair<String, String>> makeObject() {
-		final List<String> leftList = new ArrayList<>();
-		leftList.add("A1");
-		leftList.add("A2");
-		leftList.add("A3");
-		final List<String> rightList = new ArrayList<>();
-		rightList.add("B1");
-		rightList.add("B2");
-		return new PairingIterator<>(leftList.iterator(), rightList.iterator());
-	}
+    @Override
+    public Iterator<Pair<String, String>> makeEmptyIterator() {
+        return new PairingIterator<String, String>(IteratorUtils.<String>emptyIterator(),
+                IteratorUtils.<String>emptyIterator());
+    }
+
+    @Override
+    public Iterator<Pair<String, String>> makeObject() {
+        final List<String> leftList = new ArrayList<>();
+        leftList.add("A1");
+        leftList.add("A2");
+        leftList.add("A3");
+        final List<String> rightList = new ArrayList<>();
+        rightList.add("B1");
+        rightList.add("B2");
+        return new PairingIterator<>(leftList.iterator(), rightList.iterator());
+    }
 
 }

--- a/src/test/java/org/apache/commons/collections4/iterators/PairingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/PairingIteratorTest.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.collections4.iterators;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test suite for {@link PairingIterator}.
+ *
+ */
+public class PairingIteratorTest extends AbstractIteratorTest<Pair<String, String>> {
+
+	public PairingIteratorTest(String testName) {
+		super(testName);
+	}
+
+	@Test
+	public void testNullValuesBoth() {
+		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(null, null);
+
+		Assert.assertFalse(pairingIterator.hasNext());
+		try {
+			pairingIterator.next();
+			fail();
+
+		} catch (NoSuchElementException e) {
+			Assert.assertNotNull(e);
+		}
+	}
+
+	@Test
+	public void testNullValueFirst() {
+		final List<String> rightList = Arrays.asList(new String[] { "A" });
+		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(null, rightList.iterator());
+
+		Assert.assertTrue(pairingIterator.hasNext());
+
+		Pair<String, String> next = pairingIterator.next();
+		Assert.assertEquals(null, next.getLeft());
+		Assert.assertEquals("A", next.getRight());
+	}
+
+	@Test
+	public void testNullValueSecond() {
+		final List<String> leftList = Arrays.asList(new String[] { "A" });
+		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(), null);
+
+		Assert.assertTrue(pairingIterator.hasNext());
+
+		Pair<String, String> next = pairingIterator.next();
+		Assert.assertEquals("A", next.getLeft());
+		Assert.assertEquals(null, next.getRight());
+	}
+
+	@Test
+	public void testTwoIteratorsWithBothTwoElements() {
+		final List<String> leftList = Arrays.asList(new String[] { "A1", "A2" });
+		final List<String> rightList = Arrays.asList(new String[] { "B1", "B2" });
+		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(),
+				rightList.iterator());
+
+		Assert.assertTrue(pairingIterator.hasNext());
+
+		Pair<String, String> next = pairingIterator.next();
+		Assert.assertEquals("A1", next.getLeft());
+		Assert.assertEquals("B1", next.getRight());
+
+		Assert.assertTrue(pairingIterator.hasNext());
+		next = pairingIterator.next();
+		Assert.assertEquals("A2", next.getLeft());
+		Assert.assertEquals("B2", next.getRight());
+
+		Assert.assertFalse(pairingIterator.hasNext());
+	}
+
+	@Test
+	public void testTwoIteratorsWithDifferentSize() {
+		final List<String> leftList = Arrays.asList(new String[] { "A1", "A2", "A3" });
+		final List<String> rightList = Arrays.asList(new String[] { "B1", "B2" });
+		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(),
+				rightList.iterator());
+
+		Assert.assertTrue(pairingIterator.hasNext());
+
+		Pair<String, String> next = pairingIterator.next();
+		Assert.assertEquals("A1", next.getLeft());
+		Assert.assertEquals("B1", next.getRight());
+
+		Assert.assertTrue(pairingIterator.hasNext());
+
+		next = pairingIterator.next();
+		Assert.assertEquals("A2", next.getLeft());
+		Assert.assertEquals("B2", next.getRight());
+
+		Assert.assertTrue(pairingIterator.hasNext());
+		next = pairingIterator.next();
+		Assert.assertEquals("A3", next.getLeft());
+		Assert.assertEquals(null, next.getRight());
+
+		Assert.assertFalse(pairingIterator.hasNext());
+	}
+
+	@Test
+	public void testTwoIteratorsWithDifferentSize2() {
+		final List<String> leftList = Arrays.asList(new String[] { "A1", });
+		final List<String> rightList = Arrays.asList(new String[] { "B1", "B2" });
+		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(),
+				rightList.iterator());
+
+		Assert.assertTrue(pairingIterator.hasNext());
+
+		Pair<String, String> next = pairingIterator.next();
+		Assert.assertEquals("A1", next.getLeft());
+		Assert.assertEquals("B1", next.getRight());
+
+		Assert.assertTrue(pairingIterator.hasNext());
+
+		next = pairingIterator.next();
+		Assert.assertEquals(null, next.getLeft());
+		Assert.assertEquals("B2", next.getRight());
+
+		Assert.assertFalse(pairingIterator.hasNext());
+	}
+
+	@Test
+	public void testTwoIteratorsWithNullValues() {
+		final List<String> leftList = Arrays.asList(new String[] { null, "A2" });
+		final List<String> rightList = Arrays.asList(new String[] { "B1", null });
+		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftList.iterator(),
+				rightList.iterator());
+
+		Assert.assertTrue(pairingIterator.hasNext());
+
+		Pair<String, String> next = pairingIterator.next();
+		Assert.assertEquals(null, next.getLeft());
+		Assert.assertEquals("B1", next.getRight());
+
+		Assert.assertTrue(pairingIterator.hasNext());
+		next = pairingIterator.next();
+		Assert.assertEquals("A2", next.getLeft());
+		Assert.assertEquals(null, next.getRight());
+
+		Assert.assertFalse(pairingIterator.hasNext());
+	}
+
+	@Test
+	public void testRemoveWithOneNullIterator() {
+		final List<String> leftList = new ArrayList<>();
+		leftList.add("A1");
+		final Iterator<String> leftIterator = leftList.iterator();
+		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(leftIterator, null);
+
+		pairingIterator.next();
+		pairingIterator.remove();
+		Assert.assertTrue(leftList.isEmpty());
+	}
+	
+	@Test
+	public void testRemoveWithOneNullIterator2() {
+		final List<String> rightList = new ArrayList<>();
+		rightList.add("A1");
+		final Iterator<String> rightIterator = rightList.iterator();
+		final PairingIterator<String, String> pairingIterator = new PairingIterator<>(null, rightIterator);
+
+		pairingIterator.next();
+		pairingIterator.remove();
+		Assert.assertTrue(rightList.isEmpty());
+	}
+
+	@Override
+	public Iterator<Pair<String, String>> makeEmptyIterator() {
+		return new PairingIterator<String, String>(IteratorUtils.<String>emptyIterator(),
+				IteratorUtils.<String>emptyIterator());
+	}
+
+	@Override
+	public Iterator<Pair<String, String>> makeObject() {
+		final List<String> leftList = new ArrayList<>();
+		leftList.add("A1");
+		leftList.add("A2");
+		leftList.add("A3");
+		final List<String> rightList = new ArrayList<>();
+		rightList.add("B1");
+		rightList.add("B2");
+		return new PairingIterator<>(leftList.iterator(), rightList.iterator());
+	}
+
+}


### PR DESCRIPTION
Hello, i implemented the improvement [COLLECTIONS-699](https://issues.apache.org/jira/projects/COLLECTIONS/issues/COLLECTIONS-699). Please review it. Attention: to implement the improvement i must set the dependency common-lang3 to provided. Is this a good idea? We could use a extra dto for that, but i think thats not the way the common libs should be implemented?