### PR TITLE
Add lambdas function to provide default values in MapUtils

### DIFF
--- a/src/main/java/org/apache/commons/collections4/MapUtils.java
+++ b/src/main/java/org/apache/commons/collections4/MapUtils.java
@@ -16,38 +16,14 @@
  */
 package org.apache.commons.collections4;
 
+import org.apache.commons.collections4.map.*;
+
 import java.io.PrintStream;
 import java.text.NumberFormat;
 import java.text.ParseException;
-import java.util.ArrayDeque;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.ResourceBundle;
-import java.util.SortedMap;
-import java.util.TreeMap;
 import java.util.function.Function;
-
-import org.apache.commons.collections4.map.AbstractMapDecorator;
-import org.apache.commons.collections4.map.AbstractSortedMapDecorator;
-import org.apache.commons.collections4.map.FixedSizeMap;
-import org.apache.commons.collections4.map.FixedSizeSortedMap;
-import org.apache.commons.collections4.map.LazyMap;
-import org.apache.commons.collections4.map.LazySortedMap;
-import org.apache.commons.collections4.map.ListOrderedMap;
-import org.apache.commons.collections4.map.MultiValueMap;
-import org.apache.commons.collections4.map.PredicatedMap;
-import org.apache.commons.collections4.map.PredicatedSortedMap;
-import org.apache.commons.collections4.map.TransformedMap;
-import org.apache.commons.collections4.map.TransformedSortedMap;
-import org.apache.commons.collections4.map.UnmodifiableMap;
-import org.apache.commons.collections4.map.UnmodifiableSortedMap;
 
 /**
  * Provides utility methods and decorators for
@@ -376,16 +352,6 @@ public class MapUtils {
         return defaultValue;
     }
 
-    /*public static <K, V> V getObject(final Map<K, V> map, final K key, final Function<K,V> defaultProvider) {
-        if (map != null) {
-            final V answer = map.get(key);
-            if (answer != null) {
-                return answer;
-            }
-        }
-        return defaultProvider != null ? defaultProvider.apply(key) : null;
-    }*/
-
     /**
      * Looks up the given key in the given map, converting the result into
      * a string, using the default value if the conversion fails.
@@ -405,7 +371,21 @@ public class MapUtils {
         }
         return answer;
     }
-    public static <K> String getString(final Map<? super K, ?> map, final K key, final Function<K,String> defaultProvider) {
+
+    /**
+     * Looks up the given key in the given map, converting the result into
+     * a string, using the defaultProvider to produce the default value if the conversion fails.
+     *
+     * @param <K>  the key type
+     * @param map  the map whose value to look up
+     * @param key  the key of the value to look up in that map
+     * @param defaultProvider  what to produce the default value if the value is null or if the
+     *   conversion fails
+     * @return  the value in the map as a string, or defaultValue produced by the defaultProvider if the
+     *   original value is null, the map is null or the string conversion fails
+     * @since 4.5
+     */
+    public static <K> String getString(final Map<? super K, ?> map, final K key, final Function<K, String> defaultProvider) {
         String answer = getString(map, key);
         if (answer == null) {
             answer = defaultProvider != null ? defaultProvider.apply(key) : null;
@@ -433,7 +413,21 @@ public class MapUtils {
         return answer;
     }
 
-    public static <K> Boolean getBoolean(final Map<? super K, ?> map, final K key, final Function<K,Boolean> defaultProvider) {
+
+    /**
+     * Looks up the given key in the given map, converting the result into
+     * a boolean, using the defaultProvider to produce the default value if the conversion fails.
+     *
+     * @param <K>  the key type
+     * @param map  the map whose value to look up
+     * @param key  the key of the value to look up in that map
+     * @param defaultProvider  what to produce the default value if the value is null or if the
+     *   conversion fails
+     * @return  the value in the map as a boolean, or defaultValue produced by the defaultProvider if the
+     *   original value is null, the map is null or the boolean conversion fails
+     * @since 4.5
+     */
+    public static <K> Boolean getBoolean(final Map<? super K, ?> map, final K key, final Function<K, Boolean> defaultProvider) {
         Boolean answer = getBoolean(map, key);
         if (answer == null) {
             answer = defaultProvider != null ? defaultProvider.apply(key) : null;
@@ -461,7 +455,21 @@ public class MapUtils {
         return answer;
     }
 
-    public static <K> Number getNumber(final Map<? super K, ?> map, final K key, final Function<K,Number> defaultProvider) {
+
+    /**
+     * Looks up the given key in the given map, converting the result into
+     * a number, using the defaultProvider to produce the default value if the conversion fails.
+     *
+     * @param <K>  the key type
+     * @param map  the map whose value to look up
+     * @param key  the key of the value to look up in that map
+     * @param defaultProvider  what to produce the default value if the value is null or if the
+     *   conversion fails
+     * @return  the value in the map as a number, or defaultValue produced by the defaultProvider if the
+     *   original value is null, the map is null or the number conversion fails
+     * @since 4.5
+     */
+    public static <K> Number getNumber(final Map<? super K, ?> map, final K key, final Function<K, Number> defaultProvider) {
         Number answer = getNumber(map, key);
         if (answer == null) {
             answer = defaultProvider != null ? defaultProvider.apply(key) : null;
@@ -488,7 +496,21 @@ public class MapUtils {
         }
         return answer;
     }
-    public static <K> Byte getByte(final Map<? super K, ?> map, final K key, final Function<K,Byte> defaultProvider) {
+
+    /**
+     * Looks up the given key in the given map, converting the result into
+     * a byte, using the defaultProvider to produce the default value if the conversion fails.
+     *
+     * @param <K>  the key type
+     * @param map  the map whose value to look up
+     * @param key  the key of the value to look up in that map
+     * @param defaultProvider  what to produce the default value if the value is null or if the
+     *   conversion fails
+     * @return  the value in the map as a number, or defaultValue produced by the defaultProvider if the
+     *   original value is null, the map is null or the number conversion fails
+     * @since 4.5
+     */
+    public static <K> Byte getByte(final Map<? super K, ?> map, final K key, final Function<K, Byte> defaultProvider) {
         Byte answer = getByte(map, key);
         if (answer == null) {
             answer = defaultProvider != null ? defaultProvider.apply(key) : null;
@@ -515,7 +537,21 @@ public class MapUtils {
         }
         return answer;
     }
-    public static <K> Short getShort(final Map<? super K, ?> map, final K key, final Function<K,Short> defaultProvider) {
+
+    /**
+     * Looks up the given key in the given map, converting the result into
+     * a short, using the defaultProvider to produce the default value if the conversion fails.
+     *
+     * @param <K>  the key type
+     * @param map  the map whose value to look up
+     * @param key  the key of the value to look up in that map
+     * @param defaultProvider  what to produce the default value if the value is null or if the
+     *   conversion fails
+     * @return  the value in the map as a number, or defaultValue produced by the defaultProvider if the
+     *   original value is null, the map is null or the number conversion fails
+     * @since 4.5
+     */
+    public static <K> Short getShort(final Map<? super K, ?> map, final K key, final Function<K, Short> defaultProvider) {
         Short answer = getShort(map, key);
         if (answer == null) {
             answer = defaultProvider != null ? defaultProvider.apply(key) : null;
@@ -543,6 +579,19 @@ public class MapUtils {
         return answer;
     }
 
+    /**
+     * Looks up the given key in the given map, converting the result into
+     * an integer, using the defaultProvider to produce the default value if the conversion fails.
+     *
+     * @param <K>  the key type
+     * @param map  the map whose value to look up
+     * @param key  the key of the value to look up in that map
+     * @param defaultProvider  what to produce the default value if the value is null or if the
+     *   conversion fails
+     * @return  the value in the map as a number, or defaultValue produced by the defaultProvider if the
+     *   original value is null, the map is null or the number conversion fails
+     * @since 4.5
+     */
     public static <K> Integer getInteger(final Map<? super K, ?> map, final K key, final Function<K, Integer> defaultProvider) {
         Integer answer = getInteger(map, key);
         if (answer == null) {
@@ -570,7 +619,21 @@ public class MapUtils {
         }
         return answer;
     }
-    public static <K> Long getLong(final Map<? super K, ?> map, final K key, final Function<K,Long> defaultProvider) {
+
+    /**
+     * Looks up the given key in the given map, converting the result into
+     * a Long, using the defaultProvider to produce the default value if the conversion fails.
+     *
+     * @param <K>  the key type
+     * @param map  the map whose value to look up
+     * @param key  the key of the value to look up in that map
+     * @param defaultProvider  what to produce the default value if the value is null or if the
+     *   conversion fails
+     * @return  the value in the map as a number, or defaultValue produced by the defaultProvider if the
+     *   original value is null, the map is null or the number conversion fails
+     * @since 4.5
+     */
+    public static <K> Long getLong(final Map<? super K, ?> map, final K key, final Function<K, Long> defaultProvider) {
         Long answer = getLong(map, key);
         if (answer == null) {
             answer = defaultProvider != null ? defaultProvider.apply(key) : null;
@@ -597,7 +660,21 @@ public class MapUtils {
         }
         return answer;
     }
-    public static <K> Float getFloat(final Map<? super K, ?> map, final K key, final Function<K,Float> defaultProvider) {
+
+    /**
+     * Looks up the given key in the given map, converting the result into
+     * a float, using the defaultProvider to produce the default value if the conversion fails.
+     *
+     * @param <K>  the key type
+     * @param map  the map whose value to look up
+     * @param key  the key of the value to look up in that map
+     * @param defaultProvider  what to produce the default value if the value is null or if the
+     *   conversion fails
+     * @return  the value in the map as a number, or defaultValue produced by the defaultProvider if the
+     *   original value is null, the map is null or the number conversion fails
+     * @since 4.5
+     */
+    public static <K> Float getFloat(final Map<? super K, ?> map, final K key, final Function<K, Float> defaultProvider) {
         Float answer = getFloat(map, key);
         if (answer == null) {
             answer = defaultProvider != null ? defaultProvider.apply(key) : null;
@@ -625,7 +702,20 @@ public class MapUtils {
         return answer;
     }
 
-    public static <K> Double getDouble(final Map<? super K, ?> map, final K key, final Function<K,Double> defaultProvider) {
+    /**
+     * Looks up the given key in the given map, converting the result into
+     * a double, using the defaultProvider to produce the default value if the conversion fails.
+     *
+     * @param <K>  the key type
+     * @param map  the map whose value to look up
+     * @param key  the key of the value to look up in that map
+     * @param defaultProvider  what to produce the default value if the value is null or if the
+     *   conversion fails
+     * @return  the value in the map as a number, or defaultValue produced by the defaultProvider if the
+     *   original value is null, the map is null or the number conversion fails
+     * @since 4.5
+     */
+    public static <K> Double getDouble(final Map<? super K, ?> map, final K key, final Function<K, Double> defaultProvider) {
         Double answer = getDouble(map, key);
         if (answer == null) {
             answer = defaultProvider != null ? defaultProvider.apply(key) : null;
@@ -653,7 +743,20 @@ public class MapUtils {
         return answer;
     }
 
-    public static <K> Map<?, ?> getMap(final Map<? super K, ?> map, final K key, final Function<K,Map<?, ?>> defaultProvider) {
+    /**
+     * Looks up the given key in the given map, converting the result into
+     * a map, using the defaultProvider to produce the default value if the conversion fails.
+     *
+     * @param <K>  the key type
+     * @param map  the map whose value to look up
+     * @param key  the key of the value to look up in that map
+     * @param defaultProvider  what to produce the default value if the value is null or if the
+     *   conversion fails
+     * @return  the value in the map as a number, or defaultValue produced by the defaultProvider if the
+     *   original value is null, the map is null or the map conversion fails
+     * @since 4.5
+     */
+    public static <K> Map<?, ?> getMap(final Map<? super K, ?> map, final K key, final Function<K, Map<?, ?>> defaultProvider) {
         Map<?, ?> answer = getMap(map, key);
         if (answer == null) {
             answer = defaultProvider != null ? defaultProvider.apply(key) : null;
@@ -817,10 +920,34 @@ public class MapUtils {
         return booleanObject.booleanValue();
     }
 
-    public static <K> boolean getBooleanValue(final Map<? super K, ?> map, final K key, final Function<K,Boolean> defaultProvider) {
+
+    /**
+     * Gets a boolean from a Map in a null-safe manner,
+     * using the default value produced by the defaultProvider if the conversion fails.
+     * <p>
+     * If the value is a <code>Boolean</code> its value is returned.
+     * If the value is a <code>String</code> and it equals 'true' ignoring case
+     * then <code>true</code> is returned, otherwise <code>false</code>.
+     * If the value is a <code>Number</code> an integer zero value returns
+     * <code>false</code> and non-zero returns <code>true</code>.
+     * Otherwise, defaultValue produced by the <code>defaultProvider</code> is returned.
+     *
+     * @param <K>  the key type
+     * @param map  the map to use
+     * @param key  the key to look up
+     * @param defaultProvider  produce the default value to return if the value is null or if the conversion fails
+     * @return the value in the Map as a Boolean, default value produced by the <code>defaultProvider</code> if null map input
+     * @since 4.5
+     */
+    public static <K> boolean getBooleanValue(final Map<? super K, ?> map, final K key, final Function<K, Boolean> defaultProvider) {
         final Boolean booleanObject = getBoolean(map, key);
         if (booleanObject == null) {
-            return defaultProvider != null ? defaultProvider.apply(key).booleanValue() : false;
+            if (defaultProvider != null) {
+                final Boolean booleanObjectProduced = defaultProvider.apply(key);
+                return booleanObjectProduced != null && booleanObjectProduced;
+            } else {
+                return false;
+            }
         }
         return booleanObject.booleanValue();
     }
@@ -845,10 +972,29 @@ public class MapUtils {
         return byteObject.byteValue();
     }
 
-    public static <K> byte getByteValue(final Map<? super K, ?> map, final K key, final Function<K,Byte> defaultProvider) {
+    /**
+     * Gets a byte from a Map in a null-safe manner,
+     * using the default value produced by the defaultProvider if the conversion fails.
+     * <p>
+     * The byte is obtained from the results of {@link #getNumber(Map,Object)}.
+     *
+     * @param <K>  the key type
+     * @param map  the map to use
+     * @param key  the key to look up
+     * @param defaultProvider  produce the default value to return if the value is null or if the conversion fails
+     * @return the value in the Map as a byte, default value produced by the <code>defaultProvider</code> if null map input
+     *
+     * @since 4.5
+     */
+    public static <K> byte getByteValue(final Map<? super K, ?> map, final K key, final Function<K, Byte> defaultProvider) {
         final Byte byteObject = getByte(map, key);
         if (byteObject == null) {
-            return defaultProvider.apply(key).byteValue();
+            if (defaultProvider != null) {
+                final Byte byteObjectProduced = defaultProvider.apply(key);
+                return byteObjectProduced != null ? byteObjectProduced : 0;
+            } else {
+                return 0;
+            }
         }
         return byteObject.byteValue();
     }
@@ -873,10 +1019,28 @@ public class MapUtils {
         return shortObject.shortValue();
     }
 
-    public static <K> short getShortValue(final Map<? super K, ?> map, final K key, final Function<K,Short> defaultProvider) {
+    /**
+     * Gets a short from a Map in a null-safe manner,
+     * using the default value produced by the defaultProvider if the conversion fails.
+     * <p>
+     * The short is obtained from the results of {@link #getNumber(Map,Object)}.
+     *
+     * @param <K>  the key type
+     * @param map  the map to use
+     * @param key  the key to look up
+     * @param defaultProvider  produce the default value to return if the value is null or if the conversion fails
+     * @return the value in the Map as a short, default value produced by the <code>defaultProvider</code> if null map input
+     * @since 4.5
+     */
+    public static <K> short getShortValue(final Map<? super K, ?> map, final K key, final Function<K, Short> defaultProvider) {
         final Short shortObject = getShort(map, key);
         if (shortObject == null) {
-            return defaultProvider.apply(key).shortValue();
+            if (defaultProvider != null) {
+                final Short shortObjectProduced = defaultProvider.apply(key);
+                return shortObjectProduced != null ? shortObjectProduced : 0;
+            } else {
+                return 0;
+            }
         }
         return shortObject.shortValue();
     }
@@ -901,10 +1065,29 @@ public class MapUtils {
         return integerObject.intValue();
     }
 
+    /**
+     * Gets an int from a Map in a null-safe manner,
+     * using the default value produced by the defaultProvider if the conversion fails.
+     * <p>
+     * The int is obtained from the results of {@link #getNumber(Map,Object)}.
+     *
+     * @param <K>  the key type
+     * @param map  the map to use
+     * @param key  the key to look up
+     * @param defaultProvider  produce the default value to return if the value is null or if the conversion fails
+     * @return the value in the Map as an int, default value produced by the <code>defaultProvider</code> if null map input
+     *
+     * @since 4.5
+     */
     public static <K> int getIntValue(final Map<? super K, ?> map, final K key, final Function<K,Integer> defaultProvider) {
         final Integer integerObject = getInteger(map, key);
         if (integerObject == null) {
-            return defaultProvider.apply(key).intValue();
+            if (defaultProvider != null) {
+                final Integer intObjectProduced = defaultProvider.apply(key);
+                return intObjectProduced != null ? intObjectProduced : 0;
+            } else {
+                return 0;
+            }
         }
         return integerObject.intValue();
     }
@@ -929,10 +1112,28 @@ public class MapUtils {
         return longObject.longValue();
     }
 
+    /**
+     * Gets a long from a Map in a null-safe manner,
+     * using the default value produced by the defaultProvider if the conversion fails.
+     * <p>
+     * The long is obtained from the results of {@link #getNumber(Map,Object)}.
+     *
+     * @param <K>  the key type
+     * @param map  the map to use
+     * @param key  the key to look up
+     * @param defaultProvider  produce the default value to return if the value is null or if the conversion fails
+     * @return the value in the Map as a long, default value produced by the <code>defaultProvider</code> if null map input
+     * @since 4.5
+     */
     public static <K> long getLongValue(final Map<? super K, ?> map, final K key, final Function<K,Long> defaultProvider) {
         final Long longObject = getLong(map, key);
         if (longObject == null) {
-            return defaultProvider.apply(key).longValue();
+            if (defaultProvider != null) {
+                final Long longObjectProduced = defaultProvider.apply(key);
+                return longObjectProduced != null ? longObjectProduced : 0L;
+            } else {
+                return 0L;
+            }
         }
         return longObject.longValue();
     }
@@ -957,10 +1158,28 @@ public class MapUtils {
         return floatObject.floatValue();
     }
 
-    public static <K> float getFloatValue(final Map<? super K, ?> map, final K key, final Function<K,Float> defaultProvider) {
+    /**
+     * Gets a float from a Map in a null-safe manner,
+     * using the default value produced by the defaultProvider if the conversion fails.
+     * <p>
+     * The float is obtained from the results of {@link #getNumber(Map,Object)}.
+     *
+     * @param <K>  the key type
+     * @param map  the map to use
+     * @param key  the key to look up
+     * @param defaultProvider  produce the default value to return if the value is null or if the conversion fails
+     * @return the value in the Map as a float, default value produced by the <code>defaultProvider</code> if null map input
+     * @since 4.5
+     */
+    public static <K> float getFloatValue(final Map<? super K, ?> map, final K key, final Function<K, Float> defaultProvider) {
         final Float floatObject = getFloat(map, key);
         if (floatObject == null) {
-            return defaultProvider.apply(key).floatValue();
+            if (defaultProvider != null) {
+                final Float floatObjectProduced = defaultProvider.apply(key);
+                return floatObjectProduced != null ? floatObjectProduced : 0.0F;
+            } else {
+                return 0.0F;
+            }
         }
         return floatObject.floatValue();
     }
@@ -985,10 +1204,28 @@ public class MapUtils {
         return doubleObject.doubleValue();
     }
 
-    public static <K> double getDoubleValue(final Map<? super K, ?> map, final K key, final Function<K,Double> doubleProvider) {
+    /**
+     * Gets a double from a Map in a null-safe manner,
+     * using the default value produced by the defaultProvider if the conversion fails.
+     * <p>
+     * The double is obtained from the results of {@link #getNumber(Map,Object)}.
+     *
+     * @param <K>  the key type
+     * @param map  the map to use
+     * @param key  the key to look up
+     * @param defaultProvider  produce the default value to return if the value is null or if the conversion fails
+     * @return the value in the Map as a double, default value produced by the <code>defaultProvider</code> if null map input
+     * @since 4.5
+     */
+    public static <K> double getDoubleValue(final Map<? super K, ?> map, final K key, final Function<K, Double> defaultProvider) {
         final Double doubleObject = getDouble(map, key);
         if (doubleObject == null) {
-            return doubleProvider.apply(key).doubleValue();
+            if (defaultProvider != null) {
+                final Double doubleObjectProduced = defaultProvider.apply(key);
+                return doubleObjectProduced != null ? doubleObjectProduced : 0.0D;
+            } else {
+                return 0.0D;
+            }
         }
         return doubleObject.doubleValue();
     }

--- a/src/main/java/org/apache/commons/collections4/MapUtils.java
+++ b/src/main/java/org/apache/commons/collections4/MapUtils.java
@@ -32,6 +32,7 @@ import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Function;
 
 import org.apache.commons.collections4.map.AbstractMapDecorator;
 import org.apache.commons.collections4.map.AbstractSortedMapDecorator;
@@ -375,6 +376,16 @@ public class MapUtils {
         return defaultValue;
     }
 
+    /*public static <K, V> V getObject(final Map<K, V> map, final K key, final Function<K,V> defaultProvider) {
+        if (map != null) {
+            final V answer = map.get(key);
+            if (answer != null) {
+                return answer;
+            }
+        }
+        return defaultProvider != null ? defaultProvider.apply(key) : null;
+    }*/
+
     /**
      * Looks up the given key in the given map, converting the result into
      * a string, using the default value if the conversion fails.
@@ -391,6 +402,13 @@ public class MapUtils {
         String answer = getString(map, key);
         if (answer == null) {
             answer = defaultValue;
+        }
+        return answer;
+    }
+    public static <K> String getString(final Map<? super K, ?> map, final K key, final Function<K,String> defaultProvider) {
+        String answer = getString(map, key);
+        if (answer == null) {
+            answer = defaultProvider != null ? defaultProvider.apply(key) : null;
         }
         return answer;
     }
@@ -415,6 +433,14 @@ public class MapUtils {
         return answer;
     }
 
+    public static <K> Boolean getBoolean(final Map<? super K, ?> map, final K key, final Function<K,Boolean> defaultProvider) {
+        Boolean answer = getBoolean(map, key);
+        if (answer == null) {
+            answer = defaultProvider != null ? defaultProvider.apply(key) : null;
+        }
+        return answer;
+    }
+
     /**
      * Looks up the given key in the given map, converting the result into
      * a number, using the default value if the conversion fails.
@@ -431,6 +457,14 @@ public class MapUtils {
         Number answer = getNumber(map, key);
         if (answer == null) {
             answer = defaultValue;
+        }
+        return answer;
+    }
+
+    public static <K> Number getNumber(final Map<? super K, ?> map, final K key, final Function<K,Number> defaultProvider) {
+        Number answer = getNumber(map, key);
+        if (answer == null) {
+            answer = defaultProvider != null ? defaultProvider.apply(key) : null;
         }
         return answer;
     }
@@ -454,6 +488,13 @@ public class MapUtils {
         }
         return answer;
     }
+    public static <K> Byte getByte(final Map<? super K, ?> map, final K key, final Function<K,Byte> defaultProvider) {
+        Byte answer = getByte(map, key);
+        if (answer == null) {
+            answer = defaultProvider != null ? defaultProvider.apply(key) : null;
+        }
+        return answer;
+    }
 
     /**
      * Looks up the given key in the given map, converting the result into
@@ -471,6 +512,13 @@ public class MapUtils {
         Short answer = getShort(map, key);
         if (answer == null) {
             answer = defaultValue;
+        }
+        return answer;
+    }
+    public static <K> Short getShort(final Map<? super K, ?> map, final K key, final Function<K,Short> defaultProvider) {
+        Short answer = getShort(map, key);
+        if (answer == null) {
+            answer = defaultProvider != null ? defaultProvider.apply(key) : null;
         }
         return answer;
     }
@@ -495,6 +543,14 @@ public class MapUtils {
         return answer;
     }
 
+    public static <K> Integer getInteger(final Map<? super K, ?> map, final K key, final Function<K, Integer> defaultProvider) {
+        Integer answer = getInteger(map, key);
+        if (answer == null) {
+            answer = defaultProvider != null ? defaultProvider.apply(key) : null;
+        }
+        return answer;
+    }
+
     /**
      * Looks up the given key in the given map, converting the result into
      * a long, using the default value if the conversion fails.
@@ -511,6 +567,13 @@ public class MapUtils {
         Long answer = getLong(map, key);
         if (answer == null) {
             answer = defaultValue;
+        }
+        return answer;
+    }
+    public static <K> Long getLong(final Map<? super K, ?> map, final K key, final Function<K,Long> defaultProvider) {
+        Long answer = getLong(map, key);
+        if (answer == null) {
+            answer = defaultProvider != null ? defaultProvider.apply(key) : null;
         }
         return answer;
     }
@@ -531,6 +594,13 @@ public class MapUtils {
         Float answer = getFloat(map, key);
         if (answer == null) {
             answer = defaultValue;
+        }
+        return answer;
+    }
+    public static <K> Float getFloat(final Map<? super K, ?> map, final K key, final Function<K,Float> defaultProvider) {
+        Float answer = getFloat(map, key);
+        if (answer == null) {
+            answer = defaultProvider != null ? defaultProvider.apply(key) : null;
         }
         return answer;
     }
@@ -555,6 +625,14 @@ public class MapUtils {
         return answer;
     }
 
+    public static <K> Double getDouble(final Map<? super K, ?> map, final K key, final Function<K,Double> defaultProvider) {
+        Double answer = getDouble(map, key);
+        if (answer == null) {
+            answer = defaultProvider != null ? defaultProvider.apply(key) : null;
+        }
+        return answer;
+    }
+
     /**
      * Looks up the given key in the given map, converting the result into
      * a map, using the default value if the conversion fails.
@@ -571,6 +649,14 @@ public class MapUtils {
         Map<?, ?> answer = getMap(map, key);
         if (answer == null) {
             answer = defaultValue;
+        }
+        return answer;
+    }
+
+    public static <K> Map<?, ?> getMap(final Map<? super K, ?> map, final K key, final Function<K,Map<?, ?>> defaultProvider) {
+        Map<?, ?> answer = getMap(map, key);
+        if (answer == null) {
+            answer = defaultProvider != null ? defaultProvider.apply(key) : null;
         }
         return answer;
     }
@@ -731,6 +817,14 @@ public class MapUtils {
         return booleanObject.booleanValue();
     }
 
+    public static <K> boolean getBooleanValue(final Map<? super K, ?> map, final K key, final Function<K,Boolean> defaultProvider) {
+        final Boolean booleanObject = getBoolean(map, key);
+        if (booleanObject == null) {
+            return defaultProvider != null ? defaultProvider.apply(key).booleanValue() : false;
+        }
+        return booleanObject.booleanValue();
+    }
+
     /**
      * Gets a byte from a Map in a null-safe manner,
      * using the default value if the conversion fails.
@@ -747,6 +841,14 @@ public class MapUtils {
         final Byte byteObject = getByte(map, key);
         if (byteObject == null) {
             return defaultValue;
+        }
+        return byteObject.byteValue();
+    }
+
+    public static <K> byte getByteValue(final Map<? super K, ?> map, final K key, final Function<K,Byte> defaultProvider) {
+        final Byte byteObject = getByte(map, key);
+        if (byteObject == null) {
+            return defaultProvider.apply(key).byteValue();
         }
         return byteObject.byteValue();
     }
@@ -771,6 +873,14 @@ public class MapUtils {
         return shortObject.shortValue();
     }
 
+    public static <K> short getShortValue(final Map<? super K, ?> map, final K key, final Function<K,Short> defaultProvider) {
+        final Short shortObject = getShort(map, key);
+        if (shortObject == null) {
+            return defaultProvider.apply(key).shortValue();
+        }
+        return shortObject.shortValue();
+    }
+
     /**
      * Gets an int from a Map in a null-safe manner,
      * using the default value if the conversion fails.
@@ -787,6 +897,14 @@ public class MapUtils {
         final Integer integerObject = getInteger(map, key);
         if (integerObject == null) {
             return defaultValue;
+        }
+        return integerObject.intValue();
+    }
+
+    public static <K> int getIntValue(final Map<? super K, ?> map, final K key, final Function<K,Integer> defaultProvider) {
+        final Integer integerObject = getInteger(map, key);
+        if (integerObject == null) {
+            return defaultProvider.apply(key).intValue();
         }
         return integerObject.intValue();
     }
@@ -811,6 +929,14 @@ public class MapUtils {
         return longObject.longValue();
     }
 
+    public static <K> long getLongValue(final Map<? super K, ?> map, final K key, final Function<K,Long> defaultProvider) {
+        final Long longObject = getLong(map, key);
+        if (longObject == null) {
+            return defaultProvider.apply(key).longValue();
+        }
+        return longObject.longValue();
+    }
+
     /**
      * Gets a float from a Map in a null-safe manner,
      * using the default value if the conversion fails.
@@ -831,6 +957,14 @@ public class MapUtils {
         return floatObject.floatValue();
     }
 
+    public static <K> float getFloatValue(final Map<? super K, ?> map, final K key, final Function<K,Float> defaultProvider) {
+        final Float floatObject = getFloat(map, key);
+        if (floatObject == null) {
+            return defaultProvider.apply(key).floatValue();
+        }
+        return floatObject.floatValue();
+    }
+
     /**
      * Gets a double from a Map in a null-safe manner,
      * using the default value if the conversion fails.
@@ -847,6 +981,14 @@ public class MapUtils {
         final Double doubleObject = getDouble(map, key);
         if (doubleObject == null) {
             return defaultValue;
+        }
+        return doubleObject.doubleValue();
+    }
+
+    public static <K> double getDoubleValue(final Map<? super K, ?> map, final K key, final Function<K,Double> doubleProvider) {
+        final Double doubleObject = getDouble(map, key);
+        if (doubleObject == null) {
+            return doubleProvider.apply(key).doubleValue();
         }
         return doubleObject.doubleValue();
     }
@@ -998,11 +1140,11 @@ public class MapUtils {
             final Object childValue = entry.getValue();
             if (childValue instanceof Map && !lineage.contains(childValue)) {
                 verbosePrintInternal(
-                    out,
-                    childKey == null ? "null" : childKey,
-                    (Map<?, ?>) childValue,
-                    lineage,
-                    debug);
+                        out,
+                        childKey == null ? "null" : childKey,
+                        (Map<?, ?>) childValue,
+                        lineage,
+                        debug);
             } else {
                 printIndent(out, lineage.size());
                 out.print(childKey);
@@ -1010,16 +1152,16 @@ public class MapUtils {
 
                 final int lineageIndex =
                         IterableUtils.indexOf(lineage,
-                                              PredicateUtils.equalPredicate(childValue));
+                                PredicateUtils.equalPredicate(childValue));
                 if (lineageIndex == -1) {
                     out.print(childValue);
                 } else if (lineage.size() - 1 == lineageIndex) {
                     out.print("(this Map)");
                 } else {
                     out.print(
-                        "(ancestor["
-                            + (lineage.size() - 1 - lineageIndex - 1)
-                            + "] Map)");
+                            "(ancestor["
+                                    + (lineage.size() - 1 - lineageIndex - 1)
+                                    + "] Map)");
                 }
 
                 if (debug && childValue != null) {
@@ -1319,8 +1461,8 @@ public class MapUtils {
      * @throws NullPointerException  if the Map is null
      */
     public static <K, V> IterableMap<K, V> transformedMap(final Map<K, V> map,
-            final Transformer<? super K, ? extends K> keyTransformer,
-            final Transformer<? super V, ? extends V> valueTransformer) {
+                                                          final Transformer<? super K, ? extends K> keyTransformer,
+                                                          final Transformer<? super V, ? extends V> valueTransformer) {
         return TransformedMap.transformingMap(map, keyTransformer, valueTransformer);
     }
 
@@ -1412,7 +1554,7 @@ public class MapUtils {
      * @throws NullPointerException  if the Map or Transformer is null
      */
     public static <K, V> IterableMap<K, V> lazyMap(final Map<K, V> map,
-            final Transformer<? super K, ? extends V> transformerFactory) {
+                                                   final Transformer<? super K, ? extends V> transformerFactory) {
         return LazyMap.lazyMap(map, transformerFactory);
     }
 
@@ -1467,7 +1609,7 @@ public class MapUtils {
      */
     @Deprecated
     public static <K, V, C extends Collection<V>> MultiValueMap<K, V> multiValueMap(final Map<K, C> map,
-            final Class<C> collectionClass) {
+                                                                                    final Class<C> collectionClass) {
         return MultiValueMap.multiValueMap(map, collectionClass);
     }
 
@@ -1488,7 +1630,7 @@ public class MapUtils {
      */
     @Deprecated
     public static <K, V, C extends Collection<V>> MultiValueMap<K, V> multiValueMap(final Map<K, C> map,
-            final Factory<C> collectionFactory) {
+                                                                                    final Factory<C> collectionFactory) {
         return MultiValueMap.multiValueMap(map, collectionFactory);
     }
 
@@ -1556,7 +1698,7 @@ public class MapUtils {
      * @throws NullPointerException  if the SortedMap is null
      */
     public static <K, V> SortedMap<K, V> predicatedSortedMap(final SortedMap<K, V> map,
-            final Predicate<? super K> keyPred, final Predicate<? super V> valuePred) {
+                                                             final Predicate<? super K> keyPred, final Predicate<? super V> valuePred) {
         return PredicatedSortedMap.predicatedSortedMap(map, keyPred, valuePred);
     }
 
@@ -1584,8 +1726,8 @@ public class MapUtils {
      * @throws NullPointerException  if the SortedMap is null
      */
     public static <K, V> SortedMap<K, V> transformedSortedMap(final SortedMap<K, V> map,
-            final Transformer<? super K, ? extends K> keyTransformer,
-            final Transformer<? super V, ? extends V> valueTransformer) {
+                                                              final Transformer<? super K, ? extends K> keyTransformer,
+                                                              final Transformer<? super V, ? extends V> valueTransformer) {
         return TransformedSortedMap.transformingSortedMap(map, keyTransformer, valueTransformer);
     }
 
@@ -1678,7 +1820,7 @@ public class MapUtils {
      * @throws NullPointerException  if the Map or Transformer is null
      */
     public static <K, V> SortedMap<K, V> lazySortedMap(final SortedMap<K, V> map,
-            final Transformer<? super K, ? extends V> transformerFactory) {
+                                                       final Transformer<? super K, ? extends V> transformerFactory) {
         return LazySortedMap.lazySortedMap(map, transformerFactory);
     }
 
@@ -1792,7 +1934,7 @@ public class MapUtils {
             throw new NullPointerException("Map must not be null");
         }
         return sortedMap instanceof IterableSortedMap ? (IterableSortedMap<K, V>) sortedMap :
-                                                        new AbstractSortedMapDecorator<K, V>(sortedMap) {};
+                new AbstractSortedMapDecorator<K, V>(sortedMap) {};
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
@@ -1128,7 +1128,7 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
         assertEquals(null, MapUtils.getString(null,"key"));
         assertEquals("default", MapUtils.getString(in,"noKey", "default"));
         assertEquals("default", MapUtils.getString(in,"noKey", (key)->{
-            if ("nokey".equals(key)) {
+            if ("noKey".equals(key)) {
                 return "default";
             } else {
                 return "";

--- a/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
@@ -39,6 +39,7 @@ import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.function.Function;
 
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
 import org.apache.commons.collections4.junit.AbstractAvailableLocalesTest;
@@ -182,9 +183,9 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
 
         // sub array
         test = MapUtils.putAll(new HashMap<String, String>(), new String[][] {
-            {"RED", "#FF0000"},
-            {"GREEN", "#00FF00"},
-            {"BLUE", "#0000FF"}
+                {"RED", "#FF0000"},
+                {"GREEN", "#00FF00"},
+                {"BLUE", "#0000FF"}
         });
         assertEquals(true, test.containsKey("RED"));
         assertEquals("#FF0000", test.get("RED"));
@@ -196,36 +197,36 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
 
         try {
             MapUtils.putAll(new HashMap<String, String>(), new String[][] {
-                {"RED", "#FF0000"},
-                null,
-                {"BLUE", "#0000FF"}
+                    {"RED", "#FF0000"},
+                    null,
+                    {"BLUE", "#0000FF"}
             });
             fail();
         } catch (final IllegalArgumentException ex) {}
 
         try {
             MapUtils.putAll(new HashMap<String, String>(), new String[][] {
-                {"RED", "#FF0000"},
-                {"GREEN"},
-                {"BLUE", "#0000FF"}
+                    {"RED", "#FF0000"},
+                    {"GREEN"},
+                    {"BLUE", "#0000FF"}
             });
             fail();
         } catch (final IllegalArgumentException ex) {}
 
         try {
             MapUtils.putAll(new HashMap<String, String>(), new String[][] {
-                {"RED", "#FF0000"},
-                {},
-                {"BLUE", "#0000FF"}
+                    {"RED", "#FF0000"},
+                    {},
+                    {"BLUE", "#0000FF"}
             });
             fail();
         } catch (final IllegalArgumentException ex) {}
 
         // flat array
         test = MapUtils.putAll(new HashMap<String, String>(), new String[] {
-            "RED", "#FF0000",
-            "GREEN", "#00FF00",
-            "BLUE", "#0000FF"
+                "RED", "#FF0000",
+                "GREEN", "#00FF00",
+                "BLUE", "#0000FF"
         });
         assertEquals(true, test.containsKey("RED"));
         assertEquals("#FF0000", test.get("RED"));
@@ -236,10 +237,10 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
         assertEquals(3, test.size());
 
         test = MapUtils.putAll(new HashMap<String, String>(), new String[] {
-            "RED", "#FF0000",
-            "GREEN", "#00FF00",
-            "BLUE", "#0000FF",
-            "PURPLE" // ignored
+                "RED", "#FF0000",
+                "GREEN", "#00FF00",
+                "BLUE", "#0000FF",
+                "PURPLE" // ignored
         });
         assertEquals(true, test.containsKey("RED"));
         assertEquals("#FF0000", test.get("RED"));
@@ -254,9 +255,9 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
 
         // map entry
         test = MapUtils.putAll(new HashMap<String, String>(), new Object[] {
-            new DefaultMapEntry<>("RED", "#FF0000"),
-            new DefaultMapEntry<>("GREEN", "#00FF00"),
-            new DefaultMapEntry<>("BLUE", "#0000FF")
+                new DefaultMapEntry<>("RED", "#FF0000"),
+                new DefaultMapEntry<>("GREEN", "#00FF00"),
+                new DefaultMapEntry<>("BLUE", "#0000FF")
         });
         assertEquals(true, test.containsKey("RED"));
         assertEquals("#FF0000", test.get("RED"));
@@ -268,9 +269,9 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
 
         // key value
         test = MapUtils.putAll(new HashMap<String, String>(), new Object[] {
-            new DefaultKeyValue<>("RED", "#FF0000"),
-            new DefaultKeyValue<>("GREEN", "#00FF00"),
-            new DefaultKeyValue<>("BLUE", "#0000FF")
+                new DefaultKeyValue<>("RED", "#FF0000"),
+                new DefaultKeyValue<>("GREEN", "#00FF00"),
+                new DefaultKeyValue<>("BLUE", "#0000FF")
         });
         assertEquals(true, test.containsKey("RED"));
         assertEquals("#FF0000", test.get("RED"));
@@ -953,9 +954,17 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
         assertEquals(2.0, MapUtils.getDoubleValue(in,"key", 0.0), 0);
         assertEquals(2.0, MapUtils.getDoubleValue(in,"key"), 0);
         assertEquals(1.0, MapUtils.getDoubleValue(in,"noKey", 1.0), 0);
+        assertEquals(5.0, MapUtils.getDoubleValue(in,"noKey", (key)->{
+            //sometimes the default value need to be calculated,such as System.currentTimeMillis()
+            return 5.0D;
+        }),0);
+
         assertEquals(0, MapUtils.getDoubleValue(in,"noKey"), 0);
         assertEquals(2.0, MapUtils.getDouble(in,"key", 0.0), 0);
         assertEquals(1.0, MapUtils.getDouble(in,"noKey", 1.0), 0);
+        assertEquals(1.0, MapUtils.getDouble(in,"noKey", (key)->{
+            return 1.0;
+        }), 0);
 
 
         final Map<String, String> inStr = new HashMap<>();
@@ -973,9 +982,15 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
         assertEquals(2.0, MapUtils.getFloatValue(in,"key", 0.0f), 0);
         assertEquals(2.0, MapUtils.getFloatValue(in,"key"), 0);
         assertEquals(1.0, MapUtils.getFloatValue(in,"noKey", 1.0f), 0);
+        assertEquals(1.0, MapUtils.getFloatValue(in,"noKey", (key)->{
+            return 1.0F;
+        }), 0);
         assertEquals(0, MapUtils.getFloatValue(in,"noKey"), 0);
         assertEquals(2.0, MapUtils.getFloat(in,"key", 0.0f), 0);
         assertEquals(1.0, MapUtils.getFloat(in,"noKey", 1.0f), 0);
+        assertEquals(1.0, MapUtils.getFloat(in,"noKey", (key)->{
+            return 1.0F;
+        }), 0);
 
         final Map<String, String> inStr = new HashMap<>();
         final char decimalSeparator = getDecimalSeparator();
@@ -992,9 +1007,15 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
         assertEquals(2.0, MapUtils.getLongValue(in,"key", 0L), 0);
         assertEquals(2.0, MapUtils.getLongValue(in,"key"), 0);
         assertEquals(1, MapUtils.getLongValue(in,"noKey", 1L), 0);
+        assertEquals(1, MapUtils.getLongValue(in,"noKey", (key)->{
+            return 1L;
+        }), 0);
         assertEquals(0, MapUtils.getLongValue(in,"noKey"), 0);
         assertEquals(2.0, MapUtils.getLong(in,"key", 0L), 0);
         assertEquals(1, MapUtils.getLong(in,"noKey", 1L), 0);
+        assertEquals(1, MapUtils.getLong(in,"noKey", (key)->{
+            return 1L;
+        }), 0);
 
         final Map<String, String> inStr = new HashMap<>();
         inStr.put("str1", "2");
@@ -1012,9 +1033,15 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
         assertEquals(2, MapUtils.getIntValue(in,"key", 0), 0);
         assertEquals(2, MapUtils.getIntValue(in,"key"), 0);
         assertEquals(0, MapUtils.getIntValue(in,"noKey", 0), 0);
+        assertEquals(0, MapUtils.getIntValue(in,"noKey", (key)->{
+            return 0;
+        }), 0);
         assertEquals(0, MapUtils.getIntValue(in,"noKey"), 0);
         assertEquals(2, MapUtils.getInteger(in,"key", 0), 0);
         assertEquals(0, MapUtils.getInteger(in,"noKey", 0), 0);
+        assertEquals(0, MapUtils.getInteger(in,"noKey", (key)->{
+            return 0;
+        }), 0);
 
         final Map<String, String> inStr = new HashMap<>();
         inStr.put("str1", "2");
@@ -1031,9 +1058,15 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
         assertEquals(val, MapUtils.getShortValue(in,"key", val), 0);
         assertEquals(val, MapUtils.getShortValue(in,"key"), 0);
         assertEquals(val, MapUtils.getShortValue(in,"noKey", val), 0);
+        assertEquals(val, MapUtils.getShortValue(in,"noKey", (key)->{
+            return val;
+        }), 0);
         assertEquals(0, MapUtils.getShortValue(in,"noKey"), 0);
         assertEquals(val, MapUtils.getShort(in,"key", val), 0);
         assertEquals(val,MapUtils.getShort(in,"noKey", val), 0);
+        assertEquals(val,MapUtils.getShort(in,"noKey", (key)->{
+            return val;
+        }), 0);
 
         final Map<String, String> inStr = new HashMap<>();
         inStr.put("str1", "10");
@@ -1050,9 +1083,15 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
         assertEquals(val, MapUtils.getByteValue(in,"key", val), 0);
         assertEquals(val, MapUtils.getByteValue(in,"key"), 0);
         assertEquals(val, MapUtils.getByteValue(in,"noKey", val), 0);
+        assertEquals(val, MapUtils.getByteValue(in,"noKey", (key)->{
+            return (byte)100;
+        }), 0);
         assertEquals(0, MapUtils.getByteValue(in,"noKey"), 0);
         assertEquals(val, MapUtils.getByte(in,"key", val), 0);
         assertEquals(val, MapUtils.getByte(in,"noKey", val), 0);
+        assertEquals(val, MapUtils.getByte(in,"noKey", (key)->{
+            return val;
+        }), 0);
 
 
         final Map<String, String> inStr = new HashMap<>();
@@ -1069,6 +1108,13 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
 
         assertEquals(val.intValue(), MapUtils.getNumber(in,"key", val).intValue(), 0);
         assertEquals(val.intValue(), MapUtils.getNumber(in,"noKey", val).intValue(), 0);
+        assertEquals(val.intValue(), MapUtils.getNumber(in,"noKey", (key)->{
+            if (true) {
+                return val;
+            } else {
+                return null;
+            }
+        }).intValue(), 0);
 
     }
 
@@ -1081,6 +1127,13 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
         assertEquals("str", MapUtils.getString(in,"key"));
         assertEquals(null, MapUtils.getString(null,"key"));
         assertEquals("default", MapUtils.getString(in,"noKey", "default"));
+        assertEquals("default", MapUtils.getString(in,"noKey", (key)->{
+            if ("nokey".equals(key)) {
+                return "default";
+            } else {
+                return "";
+            }
+        }));
         assertEquals("default", MapUtils.getString(null,"noKey", "default"));
 
     }
@@ -1095,7 +1148,6 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
         assertEquals(null, MapUtils.getObject(null,"key"));
         assertEquals("default", MapUtils.getObject(in,"noKey", "default"));
         assertEquals("default", MapUtils.getObject(null,"noKey", "default"));
-
     }
 
     @Test
@@ -1106,9 +1158,19 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
         assertTrue(MapUtils.getBooleanValue(in,"key", true));
         assertTrue(MapUtils.getBooleanValue(in,"key"));
         assertTrue(MapUtils.getBooleanValue(in,"noKey", true));
+        assertTrue(MapUtils.getBooleanValue(in,"noKey", (key)->{
+            return true;
+        }));
         assertTrue(!MapUtils.getBooleanValue(in,"noKey"));
         assertTrue(MapUtils.getBoolean(in,"key", true));
         assertTrue(MapUtils.getBoolean(in,"noKey", true));
+        assertTrue(MapUtils.getBoolean(in,"noKey", (key)->{
+            if (System.currentTimeMillis() > 0) {
+                return true;
+            } else {
+                return false;
+            }
+        }));
         assertEquals(null, MapUtils.getBoolean(null,"noKey"));
 
 
@@ -1128,12 +1190,12 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
         final Map<String, String> valMap = new HashMap<>();
         valMap.put("key1", "value1");
         in.put("key1", valMap);
-        final Map<?, ?> outValue =  MapUtils.getMap(in,"key1", null);
+        final Map<?, ?> outValue =  MapUtils.getMap(in,"key1", (Map<?, ?>) null);
 
         assertEquals("value1", outValue.get("key1"));
         assertEquals(null, outValue.get("key2"));
-        assertEquals(null, MapUtils.getMap(in,"key2", null));
-        assertEquals(null, MapUtils.getMap(null,"key2", null));
+        assertEquals(null, MapUtils.getMap(in, "key2", (Map<?, ?>) null));
+        assertEquals(null, MapUtils.getMap(null, "key2", (Map<?, ?>) null));
     }
 
     @Test
@@ -1149,9 +1211,9 @@ public class MapUtilsTest extends AbstractAvailableLocalesTest {
 
     @Test
     public void testOrderedMap() {
-    	final Map<String, String> inMap = new HashMap<>();
-    	inMap.put("key1", "value1");
-    	inMap.put("key2", "value2");
+        final Map<String, String> inMap = new HashMap<>();
+        inMap.put("key1", "value1");
+        inMap.put("key2", "value2");
         final Map<String, String> map = MapUtils.orderedMap(inMap);
         assertTrue("returned object should be a OrderedMap", map instanceof OrderedMap);
     }


### PR DESCRIPTION
For the code MapUtils.getString(map, key, defaultValue);, the default value is not always a constant. Sometimes we may need to do some calculate. Sometimes I do it like this:

MapUtils.getLong(map, key, getDefaultValue());
private Long getDefaultValue() {
    return System.currentTimeMillis();
}

you see, now the problem is that even if the value associated with the key exists, the getDefaultValue method will still be invoked and excuted which is a kind of waste.

As we can use lambdas in Java8 or above, there is a better way to do it now.

MapUtils.getLong(map, key, (key)->{
        return System.currentTimeMillis();
});

by passing a lambdas to provide the default value, the lambdas will only be excuted when the value does not exist.