### PR TITLE
[Collections-727] fix the potential misleading comment

### DIFF
--- a/src/main/java/org/apache/commons/collections4/iterators/CollatingIterator.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/CollatingIterator.java
@@ -174,7 +174,7 @@ public class CollatingIterator<E> implements Iterator<E> {
      *
      * @param index index of the Iterator to replace
      * @param iterator Iterator to place at the given index
-     * @throws IndexOutOfBoundsException if index &lt; 0 or index &gt; size()
+     * @throws IndexOutOfBoundsException if index &lt; 0 or index &gt;= size()
      * @throws IllegalStateException if iteration has started
      * @throws NullPointerException if the iterator is null
      */


### PR DESCRIPTION
change the index boundary from `> size()` to` >= size()`
for the `setIterator(final int index, final Iterator<? extends E> iterator)` method in the class `org.apache.commons.collections4.iterators.CollatingIterator<E>`.
