### PR TITLE
Added additional tests for map classes based on mutation results

### DIFF
--- a/src/test/java/org/apache/commons/collections4/collection/TransformedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/TransformedCollectionTest.java
@@ -39,9 +39,17 @@ public class TransformedCollectionTest extends AbstractCollectionTest<Object> {
             return Integer.valueOf((String) input);
         }
     }
+    
+    private static class ToLowerCase implements Transformer<Object, Object> {
+        @Override
+        public Object transform(final Object input) {
+            return ((String) input).toLowerCase();
+        }
+    }
 
     public static final Transformer<Object, Object> NOOP_TRANSFORMER = TransformerUtils.nopTransformer();
     public static final Transformer<Object, Object> STRING_TO_INTEGER_TRANSFORMER = new StringToInteger();
+    public static final Transformer<Object, Object> TO_LOWER_CASE_TRANSFORMER = new ToLowerCase();
 
     public TransformedCollectionTest(final String testName) {
         super(testName);

--- a/src/test/java/org/apache/commons/collections4/map/LazySortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LazySortedMapTest.java
@@ -22,6 +22,7 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import org.apache.commons.collections4.Factory;
 import org.apache.commons.collections4.FactoryUtils;
@@ -38,7 +39,16 @@ import org.junit.Test;
 @SuppressWarnings("boxing")
 public class LazySortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
 
+	private class ReverseStringComparator implements Comparator<String> {
+		@Override
+		public int compare(String arg0, String arg1) {
+			return arg1.compareTo(arg0);
+		}
+	}
+	
     private static final Factory<Integer> oneFactory = FactoryUtils.constantFactory(1);
+    
+    protected final Comparator<String> reverseStringComparator = new ReverseStringComparator();
 
     public LazySortedMapTest(final String testName) {
         super(testName);
@@ -94,6 +104,25 @@ public class LazySortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
         final Comparator<?> c = map.comparator();
         assertTrue("natural order, so comparator should be null",
             c == null);
+    }
+    
+    public void testReverseSortOrder() {
+        final SortedMap<String, Number> map = lazySortedMap(new ConcurrentSkipListMap<String, Number>(reverseStringComparator), oneFactory);
+        map.put("A",  5);
+        map.get("B"); // Entry with value "One" created
+        map.put("C", 8);
+        assertEquals("Last key should be A", "A", map.lastKey());
+        assertEquals("First key should be C", "C", map.firstKey());
+        assertEquals("First key in tail map should be B",
+            "B", map.tailMap("B").firstKey());
+        assertEquals("Last key in head map should be B",
+            "B", map.headMap("A").lastKey());
+        assertEquals("Last key in submap should be B",
+            "B", map.subMap("C","A").lastKey());
+
+        final Comparator<?> c = map.comparator();
+        assertTrue("natural order, so comparator should be null",
+            c == reverseStringComparator);
     }
 
     public void testTransformerDecorate() {

--- a/src/test/java/org/apache/commons/collections4/map/PredicatedSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PredicatedSortedMapTest.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
@@ -34,9 +35,18 @@ import org.apache.commons.collections4.functors.TruePredicate;
  */
 public class PredicatedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
 
+	private class ReverseStringComparator implements Comparator<K> {
+		@Override
+		public int compare(K arg0, K arg1) {
+			return ((String) arg1).compareTo((String)arg0);
+		}
+	}
+	
     protected static final Predicate<Object> truePredicate = TruePredicate.truePredicate();
 
     protected static final Predicate<Object> testPredicate = o -> o instanceof String;
+    
+    protected final Comparator<K> reverseStringComparator = new ReverseStringComparator();
 
     public PredicatedSortedMapTest(final String testName) {
         super(testName);
@@ -55,6 +65,10 @@ public class PredicatedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
 
     public SortedMap<K, V> makeTestMap() {
         return decorateMap(new TreeMap<K, V>(), testPredicate, testPredicate);
+    }
+    
+    public SortedMap<K, V> makeTestMapWithComparator() {
+        return decorateMap(new ConcurrentSkipListMap<K, V>(reverseStringComparator), testPredicate, testPredicate);
     }
 
     @Override
@@ -163,6 +177,38 @@ public class PredicatedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
         final Comparator<? super K> c = map.comparator();
         assertTrue("natural order, so comparator should be null",
             c == null);
+    }
+    
+    @SuppressWarnings("unchecked")
+    public void testReverseSortOrder() {
+        final SortedMap<K, V> map = makeTestMapWithComparator();
+        map.put((K) "A",  (V) "a");
+        map.put((K) "B", (V) "b");
+        try {
+            map.put(null, (V) "c");
+            fail("Null key should raise IllegalArgument");
+        } catch (final IllegalArgumentException e) {
+            // expected
+        }
+        map.put((K) "C", (V) "c");
+        try {
+            map.put((K) "D", null);
+            fail("Null value should raise IllegalArgument");
+        } catch (final IllegalArgumentException e) {
+            // expected
+        }
+        assertEquals("Last key should be A", "A", map.lastKey());
+        assertEquals("First key should be C", "C", map.firstKey());
+        assertEquals("First key in tail map should be B",
+            "B", map.tailMap((K) "B").firstKey());
+        assertEquals("Last key in head map should be B",
+            "B", map.headMap((K) "A").lastKey());
+        assertEquals("Last key in submap should be B",
+           "B", map.subMap((K) "C",(K) "A").lastKey());
+
+        final Comparator<? super K> c = map.comparator();
+        assertTrue("reverse order, so comparator should be reverseStringComparator",
+            c == reverseStringComparator);
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/map/TransformedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/TransformedMapTest.java
@@ -125,14 +125,14 @@ public class TransformedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         final Map<K, V> trans = TransformedMap
                 .transformedMap(
                         base,
-                        null,
+                        (Transformer<? super K, ? extends K>) TransformedCollectionTest.TO_LOWER_CASE_TRANSFORMER,
                         (Transformer<? super V, ? extends V>) TransformedCollectionTest.STRING_TO_INTEGER_TRANSFORMER);
         assertEquals(3, trans.size());
-        assertEquals(Integer.valueOf(1), trans.get("A"));
-        assertEquals(Integer.valueOf(2), trans.get("B"));
-        assertEquals(Integer.valueOf(3), trans.get("C"));
+        assertEquals(Integer.valueOf(1), trans.get("a"));
+        assertEquals(Integer.valueOf(2), trans.get("b"));
+        assertEquals(Integer.valueOf(3), trans.get("c"));
         trans.put((K) "D", (V) "4");
-        assertEquals(Integer.valueOf(4), trans.get("D"));
+        assertEquals(Integer.valueOf(4), trans.get("d"));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
I used this project as a learning tool for getting familiar with [Pitest](http://pitest.org/) mutation testing and picked a few test classes to improve based on the result. I picked the below classes because the current test suite provides 100% line coverage, but PIT found surviving mutants.

### Transformed Map
In the `TransformedMapTest` class, the `testFactory_decorateTransform` method did not provide a key transformer. In `TransformedMap::transformedMap` the call to `decorated.clear()` is only necessary if the key transformer changes the key set. This adds a test with a key transformer.

### Lazy Sorted Map and Predicated Map
Both `LazySortedMap` and `PredicatedMap` have tests that check if the comparator is null, but never check for a non-null value. The added tests check that if a non-null comparator is used then it is properly returned. 