### PR TITLE
Fix Javadoc code example in BulkTest

### DIFF
--- a/src/test/java/org/apache/commons/collections4/BulkTest.java
+++ b/src/test/java/org/apache/commons/collections4/BulkTest.java
@@ -80,11 +80,11 @@ import junit.framework.TestSuite;
  *      }
  *
  *      public BulkTest bulkTestKeySet() {
- *          return new TestSet(makeFullMap().keySet());
+ *          return new SetTest(makeFullMap().keySet());
  *      }
  *
  *      public BulkTest bulkTestEntrySet() {
- *          return new TestSet(makeFullMap().entrySet());
+ *          return new SetTest(makeFullMap().entrySet());
  *      }
  *  }
  *  </Pre>


### PR DESCRIPTION
The incorrect variable name will mislead readers.