### PR TITLE
[COLLECTIONS-734] Update EntryIterator.remove() to fix bug

### DIFF
--- a/src/main/java/org/apache/commons/collections4/map/Flat3Map.java
+++ b/src/main/java/org/apache/commons/collections4/map/Flat3Map.java
@@ -946,8 +946,8 @@ public class Flat3Map<K, V> implements IterableMap<K, V>, Serializable, Cloneabl
             if (currentEntry == null) {
                 throw new IllegalStateException(AbstractHashedMap.REMOVE_INVALID);
             }
-            currentEntry.setRemoved(true);
             parent.remove(currentEntry.getKey());
+            currentEntry.setRemoved(true);
             nextIndex--;
             currentEntry = null;
         }

--- a/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
@@ -336,6 +336,23 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals("NewValue", map.get(THREE));
     }
 
+    public void testEntrySet() {
+        final Flat3Map<K, V> map = new Flat3Map<>();
+        map.put((K) "A", (V) "one");
+        map.put((K) "B", (V) "two");
+        map.put((K) "C", (V) "three");
+        Iterator<Map.Entry<K, V>> it = map.entrySet().iterator();
+
+        Map.Entry<K, V> mapEntry1 = it.next();
+        Map.Entry<K, V> mapEntry2 = it.next();
+        Map.Entry<K, V> mapEntry3 = it.next();
+        it.remove();
+        assertEquals(2, map.size());
+        assertEquals("one", map.get((K) "A"));
+        assertEquals("two", map.get((K) "B"));
+        assertEquals(null, map.get((K) "C"));
+    }
+
     //-----------------------------------------------------------------------
     @Override
     public BulkTest bulkTestMapIterator() {


### PR DESCRIPTION
[COLLECTIONS-734](https://issues.apache.org/jira/projects/COLLECTIONS/issues/COLLECTIONS-734?filter=allopenissues)
In EntryIterator.remove() method, it should call currentEntry.getKey() first, then call currentEntry.setRemoved(true).