### PR TITLE
[COLLECTIONS-737] The test FluentIterableTest.size should be splitted

### DIFF
--- a/src/main/java/org/apache/commons/collections4/IterableUtils.java
+++ b/src/main/java/org/apache/commons/collections4/IterableUtils.java
@@ -804,6 +804,9 @@ public class IterableUtils {
      * @return the number of elements contained in the iterable
      */
     public static int size(final Iterable<?> iterable) {
+        if (iterable == null) {
+            return 0;
+        }
         if (iterable instanceof Collection<?>) {
             return ((Collection<?>) iterable).size();
         }

--- a/src/test/java/org/apache/commons/collections4/FluentIterableTest.java
+++ b/src/test/java/org/apache/commons/collections4/FluentIterableTest.java
@@ -415,13 +415,17 @@ public class FluentIterableTest {
     }
 
     @Test
-    public void size() {
+    public void ofNull() {
         try {
-            FluentIterable.of((Iterable<?>) null).size();
+            FluentIterable.of((Iterable<?>) null);
             fail("expecting NullPointerException");
         } catch (final NullPointerException npe) {
             // expected
         }
+    }
+
+    @Test
+    public void size() {
         assertEquals(0, FluentIterable.of(emptyIterable).size());
         assertEquals(IterableUtils.toList(iterableOdd).size(), FluentIterable.of(iterableOdd).size());
     }

--- a/src/test/java/org/apache/commons/collections4/FluentIterableTest.java
+++ b/src/test/java/org/apache/commons/collections4/FluentIterableTest.java
@@ -415,16 +415,6 @@ public class FluentIterableTest {
     }
 
     @Test
-    public void ofNull() {
-        try {
-            FluentIterable.of((Iterable<?>) null);
-            fail("expecting NullPointerException");
-        } catch (final NullPointerException npe) {
-            // expected
-        }
-    }
-
-    @Test
     public void size() {
         assertEquals(0, FluentIterable.of(emptyIterable).size());
         assertEquals(IterableUtils.toList(iterableOdd).size(), FluentIterable.of(iterableOdd).size());

--- a/src/test/java/org/apache/commons/collections4/IterableUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/IterableUtilsTest.java
@@ -579,4 +579,9 @@ public class IterableUtilsTest {
             // expected
         }
     }
+
+    @Test
+    public void size() {
+        assertEquals(0, IterableUtils.size(null));
+    }
 }


### PR DESCRIPTION
Extracted the first part of FluentIterableTest.size to a sperate test FluentIterableTest.ofNull

Fixes [COLLECTIONS-737](https://issues.apache.org/jira/browse/COLLECTIONS-737)