### PR TITLE
[COLLECTIONS-738] Remove the redundant assertNull in IterableUtilsTest.find

### DIFF
--- a/src/main/java/org/apache/commons/collections4/IterableUtils.java
+++ b/src/main/java/org/apache/commons/collections4/IterableUtils.java
@@ -606,7 +606,7 @@ public class IterableUtils {
      *
      * @param <E> the element type
      * @param iterable  the iterable to search, may be null
-     * @param predicate  the predicate to use, may not be null
+     * @param predicate  the predicate to use, must not be null
      * @return the first element of the iterable which matches the predicate or null if none could be found
      * @throws NullPointerException if predicate is null
      */

--- a/src/main/java/org/apache/commons/collections4/IterableUtils.java
+++ b/src/main/java/org/apache/commons/collections4/IterableUtils.java
@@ -195,8 +195,8 @@ public class IterableUtils {
      * corresponding input iterator supports it.
      *
      * @param <E> the element type
-     * @param a  the first iterable, may not be null
-     * @param b  the second iterable, may not be null
+     * @param a  the first iterable, must not be null
+     * @param b  the second iterable, must not be null
      * @return a filtered view on the specified iterable
      * @throws NullPointerException if either of the provided iterables is null
      */
@@ -622,7 +622,7 @@ public class IterableUtils {
      *
      * @param <E> the element type
      * @param iterable  the iterable to search, may be null
-     * @param predicate  the predicate to use, may not be null
+     * @param predicate  the predicate to use, must not be null
      * @return the index of the first element which matches the predicate or -1 if none matches
      * @throws NullPointerException if predicate is null
      */

--- a/src/main/java/org/apache/commons/collections4/IteratorUtils.java
+++ b/src/main/java/org/apache/commons/collections4/IteratorUtils.java
@@ -1262,7 +1262,7 @@ public class IteratorUtils {
      *
      * @param <E> the element type
      * @param iterator  the iterator to search, may be null
-     * @param predicate  the predicate to use, may not be null
+     * @param predicate  the predicate to use, must not be null
      * @return the first element of the iterator which matches the predicate or null if none could be found
      * @throws NullPointerException if predicate is null
      * @since 4.1

--- a/src/test/java/org/apache/commons/collections4/IterableUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/IterableUtilsTest.java
@@ -274,7 +274,7 @@ public class IterableUtilsTest {
         assertTrue(test == null);
         assertNull(IterableUtils.find(null,testPredicate));
         try {
-            assertNull(IterableUtils.find(iterableA, null));
+            IterableUtils.find(iterableA, null);
             fail("expecting NullPointerException");
         } catch (final NullPointerException npe) {
             // expected


### PR DESCRIPTION
As described in the JIRA issue [COLLECTIONS-738](https://issues.apache.org/jira/browse/COLLECTIONS-738)