### PR TITLE
Fix links to release notes and update contents for 4.4

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -73,7 +73,7 @@ The <a href="scm.html">source repository</a> can be
 <p>
 The latest version is 4.4 -
 <a href="https://commons.apache.org/collections/download_collections.cgi">Download now!</a><br />
-It is built for Java 8 and later, and the <a href="release_4_3.html">release notes</a> are also available.
+It is built for Java 8 and later, and the <a href="release_4_4.html">release notes</a> are also available.
 </p>
 <p>
 For previous releases, see the <a href="http://archive.apache.org/dist/commons/collections/">Apache Archive</a>

--- a/src/site/xdoc/release_4_4.xml
+++ b/src/site/xdoc/release_4_4.xml
@@ -44,13 +44,14 @@ All users are strongly encouraged to updated to this release.
      package do not implement the Serializable interface anymore (see COLLECTIONS-580)</li>
 </ul>
 
-<center><h3>Major changes since 4.2</h3></center>
+<center><h3>Major changes since 4.3</h3></center>
 <ul>
-<li>Updates the platform requirement from Java 7 to 8</li>
-<li>Add Automatic-Module-Name MANIFEST entry for Java 9 compatibility</li>
-<li>Added a few new APIs.</li>
+<li>Implement Collection's removeIf()</li>
+<li>Create a PropertiesFactory and SortedPropertiesFactory</li>
+<li>Support Transformer for LazyList</li>
+<li>Make use of FunctionalInterface</li>
 </ul>
-
+   
 <h3>Security Changes</h3>
 <p>
 None.

--- a/src/site/xdoc/release_4_4.xml
+++ b/src/site/xdoc/release_4_4.xml
@@ -51,7 +51,7 @@ All users are strongly encouraged to updated to this release.
 <li>Support Transformer for LazyList</li>
 <li>Make use of FunctionalInterface</li>
 </ul>
-   
+
 <h3>Security Changes</h3>
 <p>
 None.


### PR DESCRIPTION
The link on the main page still points to 4.3 and the 4.4 release notes still list the changes from 4.3.