### PR TITLE
add Simple bloom filter

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bloomfilter/BitSetBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/BitSetBloomFilter.java
@@ -25,7 +25,7 @@ import org.apache.commons.collections4.bloomfilter.hasher.Shape;
 import org.apache.commons.collections4.bloomfilter.hasher.StaticHasher;
 
 /**
- * A bloom filter using a Java BitSet to track enabled bits. This is a standard
+ * A bloom filter uses a Java BitSet to track enabled bits. This is a standard
  * implementation and should work well for most Bloom filters.
  * @since 4.5
  */

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
@@ -78,7 +78,7 @@ public class SimpleBloomFilter<T> extends BitSetBloomFilter implements BloomFilt
     /**
      * Constructs a SimpleBloomFilter from the shape and function. This constructor
      * creates an empty Bloom filter.
-     * </p><p>
+     * <p>
      * If the object {@code T} is to be considered as a
      * single item in the filter then function must create the {@code SimpleBuilder}
      * and only call a single {@code with()} method. In this use case the

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
@@ -33,30 +33,38 @@ import org.apache.commons.collections4.bloomfilter.hasher.function.Murmur128x64C
 public class SimpleBloomFilter<T> extends BitSetBloomFilter implements BloomFilter {
 
     /**
-     * The function that converts the instance of T to the SimpleBuilder. <p> If the
+     * The function that converts the instance of T to the SimpleBuilder.
+     * <p>
+     * If the
      * object T is to be considered as a single item in the filter then function
      * must create the {@code SimpleBuilder} and only call a single {@code with()}
-     * method.</p> <p> If the object T is to be considered as several items then the
+     * method.
+     * </p> <p>
+     * If the object T is to be considered as several items then the
      * function must create the {@code SimpleBuilder} and call the {@code with()}
      * method once for each item.</p>
      */
     private Function<T, SimpleBuilder> func;
 
     /**
-     * Constructs a SimpleBloomFilter from the shape and function.
+     * Constructs a SimpleBloomFilter from the shape and function containing the
+     * items specified in the hasher.
      *
      * <p> The function {@code func} converts the instance of {@code T} into the
-     * SimpleBuilder. </p><p> If the object {@code T} is to be considered as a
+     * SimpleBuilder.
+     * </p><p>
+     * If the object {@code T} is to be considered as a
      * single item in the filter then function must create the {@code SimpleBuilder}
      * and only call a single {@code with()} method. In this use case the
      * {@code Shape} is generally configured with the number of items equal to the
-     * expected number of {@code T} to be added to the Bloom filter.</p> <p> If the
-     * object {@code T} is to be considered as several items then the function must
+     * expected number of {@code T} to be added to the Bloom filter.
+     * </p> <p>
+     * If the object {@code T} is to be considered as several items then the function must
      * create the {@code SimpleBuilder} and call the {@code with()} method once for
      * each item. In this use case the {@code Shape} is generally configured with
      * the number of items equal to the expected number of {@code T} multiplied by
-     * the number of times {@code with()} is called.</p> </p>
-     *
+     * the number of times {@code with()} is called.
+     * </p>
      * @param hasher the Hasher to use.
      * @param shape  the Shape of the Bloom filter.
      * @param func   a Function to convert T to a SimpleBuilder.
@@ -70,6 +78,20 @@ public class SimpleBloomFilter<T> extends BitSetBloomFilter implements BloomFilt
     /**
      * Constructs a SimpleBloomFilter from the shape and function. This constructor
      * creates an empty Bloom filter.
+     * </p><p>
+     * If the object {@code T} is to be considered as a
+     * single item in the filter then function must create the {@code SimpleBuilder}
+     * and only call a single {@code with()} method. In this use case the
+     * {@code Shape} is generally configured with the number of items equal to the
+     * expected number of {@code T} to be added to the Bloom filter.
+     * </p> <p>
+     * If the object {@code T} is to be considered as several items then the function must
+     * create the {@code SimpleBuilder} and call the {@code with()} method once for
+     * each item. In this use case the {@code Shape} is generally configured with
+     * the number of items equal to the expected number of {@code T} multiplied by
+     * the number of times {@code with()} is called.
+     * </p>
+
      * @param shape the Shape of the Bloom filter.
      * @param func  a Function to convert T to a SimpleBuilder.
      * @see #func
@@ -85,7 +107,7 @@ public class SimpleBloomFilter<T> extends BitSetBloomFilter implements BloomFilt
      * <p>Note: This method should return {@code true} even if no additional bit
      * indexes were enabled. A {@code false} result indicates that this filter is
      * not ensured to contain the {@code data}.
-     *
+     * </p>
      * @param data the data to merge.
      * @return true if the merge was successful
      * @throws IllegalArgumentException if the shape of the other filter does not

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
@@ -33,24 +33,34 @@ import org.apache.commons.collections4.bloomfilter.hasher.function.Murmur128x64C
 public class SimpleBloomFilter<T> extends BitSetBloomFilter implements BloomFilter {
 
     /**
-     * The function that converts the instance of T to the SimpleBuilder.
-     * <p>
-     * If the object T is to be considered as a single item in the filter then
-     * function must create the {@code SimpleBuilder} and only call a single {@code with()}
-     * method.</p>
-     * <p>
-     * If the object T is to be considered as several items then the function must
-     * create the {@code SimpleBuilder} and call the {@code with()} method once for each item.</p>
+     * The function that converts the instance of T to the SimpleBuilder. <p> If the
+     * object T is to be considered as a single item in the filter then function
+     * must create the {@code SimpleBuilder} and only call a single {@code with()}
+     * method.</p> <p> If the object T is to be considered as several items then the
+     * function must create the {@code SimpleBuilder} and call the {@code with()}
+     * method once for each item.</p>
      */
     private Function<T, SimpleBuilder> func;
 
     /**
-     * Constructs a SimpleBloomFilter from the shape and function.  This constructor
-     * creates an empty Bloom filter.
+     * Constructs a SimpleBloomFilter from the shape and function.
+     *
+     * <p> The function {@code func} converts the instance of {@code T} into the
+     * SimpleBuilder. </p><p> If the object {@code T} is to be considered as a
+     * single item in the filter then function must create the {@code SimpleBuilder}
+     * and only call a single {@code with()} method. In this use case the
+     * {@code Shape} is generally configured with the number of items equal to the
+     * expected number of {@code T} to be added to the Bloom filter.</p> <p> If the
+     * object {@code T} is to be considered as several items then the function must
+     * create the {@code SimpleBuilder} and call the {@code with()} method once for
+     * each item. In this use case the {@code Shape} is generally configured with
+     * the number of items equal to the expected number of {@code T} multiplied by
+     * the number of times {@code with()} is called.</p> </p>
+     *
      * @param hasher the Hasher to use.
-     * @param shape the Shape of the Bloom filter.
-     * @param func a Function to convert T to a SimpleBuilder.
-     * @see #func
+     * @param shape  the Shape of the Bloom filter.
+     * @param func   a Function to convert T to a SimpleBuilder.
+     *
      */
     public SimpleBloomFilter(Hasher hasher, Shape shape, Function<T, SimpleBuilder> func) {
         super(hasher, shape);
@@ -58,10 +68,10 @@ public class SimpleBloomFilter<T> extends BitSetBloomFilter implements BloomFilt
     }
 
     /**
-     * Constructs a SimpleBloomFilter from the shape and function.  This constructor
+     * Constructs a SimpleBloomFilter from the shape and function. This constructor
      * creates an empty Bloom filter.
      * @param shape the Shape of the Bloom filter.
-     * @param func a Function to convert T to a SimpleBuilder.
+     * @param func  a Function to convert T to a SimpleBuilder.
      * @see #func
      */
     public SimpleBloomFilter(Shape shape, Function<T, SimpleBuilder> func) {
@@ -70,56 +80,44 @@ public class SimpleBloomFilter<T> extends BitSetBloomFilter implements BloomFilt
     }
 
     /**
-     * Constructs a SimpleBloomFilter from the shape, function and a data object.
-     * This constructor creates an Bloom filter populated with the data from the
-     * {@code data} parameter.
-     * @param shape the Shape of the Bloom filter.
-     * @param func a Function to convert T to a SimpleBuilder.
-     * @param data the data object to populate the filter with.
-     * @see #func
-     */
-    public SimpleBloomFilter(Shape shape, Function<T, SimpleBuilder> func, T data) {
-        this(shape, func);
-        this.merge( data );
-    }
-
-    /**
      * Merges a data object into this filter.
      *
-     * <p>Note: This method should return {@code true} even if no additional bit indexes were
-     * enabled. A {@code false} result indicates that this filter is not ensured to contain
-     * the {@code data}.
+     * <p>Note: This method should return {@code true} even if no additional bit
+     * indexes were enabled. A {@code false} result indicates that this filter is
+     * not ensured to contain the {@code data}.
      *
      * @param data the data to merge.
      * @return true if the merge was successful
-     * @throws IllegalArgumentException if the shape of the other filter does not match
-     * the shape of this filter
+     * @throws IllegalArgumentException if the shape of the other filter does not
+     *                                  match the shape of this filter
      */
-    public boolean merge( T data ) {
-        return this.merge( this.func.apply( data ).build() );
+    public boolean merge(T data) {
+        return this.merge(this.func.apply(data).build());
     }
 
-
     /**
-     * Returns {@code true} if this filter contains the object.
-     * Specifically this returns {@code true} if this filter is enabled for all bit indexes
-     * identified by the hashing of the object {@code data}.
+     * Returns {@code true} if this filter contains the object. Specifically this
+     * returns {@code true} if this filter is enabled for all bit indexes identified
+     * by the hashing of the object {@code data}.
      *
      * @param data the data to check for.
-     * @return true if this filter is enabled for all bits specified by the data object.
+     * @return true if this filter is enabled for all bits specified by the data
+     *         object.
      */
-    public boolean contains( T data ) {
-        return this.contains( this.func.apply( data ).build() );
+    public boolean contains(T data) {
+        return this.contains(this.func.apply(data).build());
     }
 
     /**
-     * A Hasher.Builder for the SimpleBloom filter.
-     * This builder uses the Murmur 128 x64 cyclic hash.
+     * A Hasher.Builder for the SimpleBloom filter. This builder uses the Murmur 128
+     * x64 cyclic hash.
      *
      * @see Murmur128x64Cyclic
      */
     public static class SimpleBuilder extends DynamicHasher.Builder {
-
+        /**
+         * Constructs a SimpleBuilder.
+         */
         public SimpleBuilder() {
             super(new Murmur128x64Cyclic());
         }

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
@@ -1,0 +1,85 @@
+package org.apache.commons.collections4.bloomfilter;
+
+import java.util.function.Function;
+
+import org.apache.commons.collections4.bloomfilter.hasher.DynamicHasher;
+import org.apache.commons.collections4.bloomfilter.hasher.Hasher;
+import org.apache.commons.collections4.bloomfilter.hasher.Shape;
+import org.apache.commons.collections4.bloomfilter.hasher.function.Murmur128x64Cyclic;
+
+/**
+ * A bloom filter that uses a BitSetBloomFilter to create a Bloom filter that
+ * can merge instances of a specific class.
+ *
+ * @param <T> The Class to merge.
+ * @since 4.5
+ */
+public class SimpleBloomFilter<T> extends BitSetBloomFilter implements BloomFilter {
+
+    /**
+     * The function that converts the instance of T to the SimpleBuilder.
+     * <p>
+     * If the object T is to be considered as a single item in the filter then
+     * function must create the {@code SimpleBuilder} and only call a single {@code with()}
+     * method.</p>
+     * <p>
+     * If the object T is to be considered as several items then the function must
+     * create the {@code SimpleBuilder} and call the {@code with()} method once for each item.</p>
+     */
+    private Function<T,SimpleBuilder> func;
+
+    /**
+     * Constructs a SimpleBloomFilter from the shape and function.  This constructor
+     * creates an empty Bloom filter.
+     * @param shape the Shape of the Bloom filter.
+     * @param func a Function to convert T to a SimpleBuilder.
+     * @see #func
+     */
+    public SimpleBloomFilter(Shape shape, Function<T,SimpleBuilder> func) {
+        super(shape);
+        this.func = func;
+    }
+
+    /**
+     * Constructs a SimpleBloomFilter from the shape, function and a data object.
+     * This constructor creates an Bloom filter populated with the data from the
+     * {@code data} parameter.
+     * @param shape the Shape of the Bloom filter.
+     * @param func a Function to convert T to a SimpleBuilder.
+     * @param data the data object to populate the filter with.
+     * @see #func
+     */
+    public SimpleBloomFilter(Shape shape, Function<T,SimpleBuilder> func, T data) {
+        this(shape, func);
+        this.merge( data );
+    }
+
+    /**
+     * Merges a data object into this filter.
+     *
+     * <p>Note: This method should return {@code true} even if no additional bit indexes were
+     * enabled. A {@code false} result indicates that this filter is not ensured to contain
+     * the {@code data}.
+     *
+     * @param data the data to merge.
+     * @return true if the merge was successful
+     * @throws IllegalArgumentException if the shape of the other filter does not match
+     * the shape of this filter
+     */
+    public boolean merge( T data ) {
+        return this.merge( this.func.apply( data ).build() );
+    }
+
+    /**
+     * A Hasher.Builder for the SimpleBloom filter.
+     * This builder uses the Murmur 128 x64 cyclic hash.
+     *
+     * @see Murmur128x64Cyclic
+     */
+    public static class SimpleBuilder extends DynamicHasher.Builder implements Hasher.Builder {
+
+        public SimpleBuilder() {
+            super(new Murmur128x64Cyclic());
+        }
+    }
+}

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.commons.collections4.bloomfilter;
 
 import java.util.function.Function;
@@ -26,7 +42,20 @@ public class SimpleBloomFilter<T> extends BitSetBloomFilter implements BloomFilt
      * If the object T is to be considered as several items then the function must
      * create the {@code SimpleBuilder} and call the {@code with()} method once for each item.</p>
      */
-    private Function<T,SimpleBuilder> func;
+    private Function<T, SimpleBuilder> func;
+
+    /**
+     * Constructs a SimpleBloomFilter from the shape and function.  This constructor
+     * creates an empty Bloom filter.
+     * @param hasher the Hasher to use.
+     * @param shape the Shape of the Bloom filter.
+     * @param func a Function to convert T to a SimpleBuilder.
+     * @see #func
+     */
+    public SimpleBloomFilter(Hasher hasher, Shape shape, Function<T, SimpleBuilder> func) {
+        super(hasher, shape);
+        this.func = func;
+    }
 
     /**
      * Constructs a SimpleBloomFilter from the shape and function.  This constructor
@@ -35,7 +64,7 @@ public class SimpleBloomFilter<T> extends BitSetBloomFilter implements BloomFilt
      * @param func a Function to convert T to a SimpleBuilder.
      * @see #func
      */
-    public SimpleBloomFilter(Shape shape, Function<T,SimpleBuilder> func) {
+    public SimpleBloomFilter(Shape shape, Function<T, SimpleBuilder> func) {
         super(shape);
         this.func = func;
     }
@@ -49,7 +78,7 @@ public class SimpleBloomFilter<T> extends BitSetBloomFilter implements BloomFilt
      * @param data the data object to populate the filter with.
      * @see #func
      */
-    public SimpleBloomFilter(Shape shape, Function<T,SimpleBuilder> func, T data) {
+    public SimpleBloomFilter(Shape shape, Function<T, SimpleBuilder> func, T data) {
         this(shape, func);
         this.merge( data );
     }
@@ -70,13 +99,26 @@ public class SimpleBloomFilter<T> extends BitSetBloomFilter implements BloomFilt
         return this.merge( this.func.apply( data ).build() );
     }
 
+
+    /**
+     * Returns {@code true} if this filter contains the object.
+     * Specifically this returns {@code true} if this filter is enabled for all bit indexes
+     * identified by the hashing of the object {@code data}.
+     *
+     * @param data the data to check for.
+     * @return true if this filter is enabled for all bits specified by the data object.
+     */
+    public boolean contains( T data ) {
+        return this.contains( this.func.apply( data ).build() );
+    }
+
     /**
      * A Hasher.Builder for the SimpleBloom filter.
      * This builder uses the Murmur 128 x64 cyclic hash.
      *
      * @see Murmur128x64Cyclic
      */
-    public static class SimpleBuilder extends DynamicHasher.Builder implements Hasher.Builder {
+    public static class SimpleBuilder extends DynamicHasher.Builder {
 
         public SimpleBuilder() {
             super(new Murmur128x64Cyclic());

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/hasher/DynamicHasher.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/hasher/DynamicHasher.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.collections4.bloomfilter.hasher;
 
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -32,7 +31,7 @@ public class DynamicHasher implements Hasher {
      * The builder for DynamicHashers.
      * @since 4.5
      */
-    public static class Builder implements Hasher.Builder {
+    public static class Builder implements Hasher.Builder<DynamicHasher, DynamicHasher.Builder> {
 
         /**
          * The list of items (each as a byte[]) that are to be hashed.
@@ -69,17 +68,6 @@ public class DynamicHasher implements Hasher {
             return this;
         }
 
-        @Override
-        public DynamicHasher.Builder with(CharSequence item, Charset charset) {
-            Hasher.Builder.super.with(item, charset);
-            return this;
-        }
-
-        @Override
-        public DynamicHasher.Builder withUnencoded(CharSequence item) {
-            Hasher.Builder.super.withUnencoded(item);
-            return this;
-        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/hasher/Hasher.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/hasher/Hasher.java
@@ -144,7 +144,7 @@ public interface Hasher {
          * using little-endian order.
          * @param data the double to add.
          * @return a reference to this object
-         * @see #wait(long)
+         * @see #with(long)
          */
         default B with(double data) {
             return with( Double.doubleToRawLongBits(data) );
@@ -166,7 +166,6 @@ public interface Hasher {
          * Adds a char into the hasher as 2 bytes using little-endian order.
          * @param data the char to add.
          * @return a reference to this object
-         * @see ByteBuffer#putChar
          */
         default  B with(char data) {
             return with(new byte[]{(byte) (data      ),

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/hasher/Hasher.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/hasher/Hasher.java
@@ -56,9 +56,11 @@ public interface Hasher {
      * to the builder will add an entire item to the final hasher created by the
      * {@link #build()} method.</p>
      *
+     * @param H the Hasher implementation that the builder will build.
+     * @param B the Builder implementation that is returned from the {@code with()} methods.
      * @since 4.5
      */
-    interface Builder {
+    interface Builder<H extends Hasher, B extends Hasher.Builder<H, ?>> {
 
         /**
          * Builds the hasher from all the items.
@@ -67,7 +69,7 @@ public interface Hasher {
          *
          * @return the fully constructed hasher
          */
-        Hasher build();
+        H build();
 
         /**
          * Adds a byte array item to the hasher.
@@ -75,7 +77,7 @@ public interface Hasher {
          * @param item the item to add
          * @return a reference to this object
          */
-        Builder with(byte[] item);
+        B with(byte[] item);
 
         /**
          * Adds a character sequence item to the hasher using the specified {@code charset}
@@ -85,7 +87,7 @@ public interface Hasher {
          * @param charset the character set
          * @return a reference to this object
          */
-        default Builder with(CharSequence item, Charset charset) {
+        default B with(CharSequence item, Charset charset) {
             return with(item.toString().getBytes(charset));
         }
 
@@ -96,7 +98,7 @@ public interface Hasher {
          * @param item the item to add
          * @return a reference to this object
          */
-        default Builder withUnencoded(CharSequence item) {
+        default B withUnencoded(CharSequence item) {
             int length = item.length();
             final byte[] bytes = new byte[length * 2];
             for (int i = 0; i < length; i++) {
@@ -114,7 +116,7 @@ public interface Hasher {
          * @return a reference to this object
          * @see ByteBuffer#putInt
          */
-        default Builder with(int data) {
+        default B with(int data) {
             return with( ByteBuffer.allocate(Integer.BYTES).putInt( data ).array());
         }
 
@@ -125,7 +127,7 @@ public interface Hasher {
          * @return a reference to this object
          * @see ByteBuffer#putLong
          */
-        default Builder with(long data) {
+        default B with(long data) {
             return with( ByteBuffer.allocate(Long.BYTES).putLong( data ).array());
         }
 
@@ -136,7 +138,7 @@ public interface Hasher {
          * @return a reference to this object
          * @see ByteBuffer#putDouble
          */
-        default Builder with(double data) {
+        default B with(double data) {
             return with( ByteBuffer.allocate(Double.BYTES).putDouble( data ).array());
         }
 
@@ -147,7 +149,7 @@ public interface Hasher {
          * @return a reference to this object
          * @see ByteBuffer#putFloat
          */
-        default Builder with(float data) {
+        default B with(float data) {
             return with( ByteBuffer.allocate(Float.BYTES).putFloat( data ).array());
         }
 
@@ -158,8 +160,8 @@ public interface Hasher {
          * @return a reference to this object
          * @see ByteBuffer#putChar
          */
-        default  Builder with(char data) {
-            return with( ByteBuffer.allocate(Character.BYTES).putFloat( data ).array());
+        default  B with(char data) {
+            return with( ByteBuffer.allocate(Character.BYTES).putChar( data ).array());
         }
 
         /**
@@ -169,8 +171,8 @@ public interface Hasher {
          * @return a reference to this object
          * @see ByteBuffer#putShort
          */
-        default Builder with(short data) {
-            return with( ByteBuffer.allocate(Short.BYTES).putFloat( data ).array());
+        default B with(short data) {
+            return with( ByteBuffer.allocate(Short.BYTES).putShort( data ).array());
         }
 
         /**
@@ -178,7 +180,7 @@ public interface Hasher {
          * @param data the BigInteger to add.
          * @return a reference to this object
          */
-        default Builder with(BigInteger data) {
+        default B with(BigInteger data) {
             return with( data.toByteArray() );
         }
 
@@ -189,7 +191,7 @@ public interface Hasher {
          * @param data the BigDecimal to add.
          * @return a reference to this object
          */
-        default Builder with(BigDecimal data) {
+        default B with(BigDecimal data) {
             byte[] value = data.unscaledValue().toByteArray();
             return with( ByteBuffer.allocate( Integer.BYTES+value.length )
                     .putInt( data.scale() ).put( value ).array() );

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/hasher/Hasher.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/hasher/Hasher.java
@@ -56,8 +56,8 @@ public interface Hasher {
      * to the builder will add an entire item to the final hasher created by the
      * {@link #build()} method.</p>
      *
-     * @param H the Hasher implementation that the builder will build.
-     * @param B the Builder implementation that is returned from the {@code with()} methods.
+     * @param <H> the Hasher implementation that the builder will build.
+     * @param <B> the Builder implementation that is returned from the {@code with()} methods.
      * @since 4.5
      */
     interface Builder<H extends Hasher, B extends Hasher.Builder<H, ?>> {

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/hasher/Hasher.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/hasher/Hasher.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.bloomfilter.hasher;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.PrimitiveIterator;
 
@@ -51,7 +54,7 @@ public interface Hasher {
      * <p>A hasher represents one or more items of arbitrary byte size. The builder
      * contains methods to collect byte representations of items. Each method to add
      * to the builder will add an entire item to the final hasher created by the
-     * {@link #build()} method.
+     * {@link #build()} method.</p>
      *
      * @since 4.5
      */
@@ -103,6 +106,95 @@ public interface Hasher {
             }
             return with(bytes);
         }
+
+        /**
+         * Adds an integer into the hasher.  The integer is converted into 4 bytes
+         * through the use of ByteBuffer.putInt.
+         * @param data the integer to add.
+         * @return a reference to this object
+         * @see ByteBuffer#putInt
+         */
+        default Builder with(int data) {
+            return with( ByteBuffer.allocate(Integer.BYTES).putInt( data ).array());
+        }
+
+        /**
+         * Adds a long into the hasher.  The long is converted into 8 bytes
+         * through the use of ByteBuffer.putLong.
+         * @param data the long to add.
+         * @return a reference to this object
+         * @see ByteBuffer#putLong
+         */
+        default Builder with(long data) {
+            return with( ByteBuffer.allocate(Long.BYTES).putLong( data ).array());
+        }
+
+        /**
+         * Adds a double into the hasher.  The double is converted into 8 bytes
+         * through the use of ByteBuffer.putDouble.
+         * @param data the double to add.
+         * @return a reference to this object
+         * @see ByteBuffer#putDouble
+         */
+        default Builder with(double data) {
+            return with( ByteBuffer.allocate(Double.BYTES).putDouble( data ).array());
+        }
+
+        /**
+         * Adds a float into the hasher.  The float is converted into 4 bytes
+         * through the use of ByteBuffer.putFloat.
+         * @param data the float to add.
+         * @return a reference to this object
+         * @see ByteBuffer#putFloat
+         */
+        default Builder with(float data) {
+            return with( ByteBuffer.allocate(Float.BYTES).putFloat( data ).array());
+        }
+
+        /**
+         * Adds a char into the hasher.  The char is converted into 2 bytes
+         * through the use of ByteBuffer.putChar.
+         * @param data the char to add.
+         * @return a reference to this object
+         * @see ByteBuffer#putChar
+         */
+        default  Builder with(char data) {
+            return with( ByteBuffer.allocate(Character.BYTES).putFloat( data ).array());
+        }
+
+        /**
+         * Adds a short into the hasher.  The short is converted into 2 bytes
+         * through the use of ByteBuffer.putShort.
+         * @param data the short to add.
+         * @return a reference to this object
+         * @see ByteBuffer#putShort
+         */
+        default Builder with(short data) {
+            return with( ByteBuffer.allocate(Short.BYTES).putFloat( data ).array());
+        }
+
+        /**
+         * Adds a BigInteger into the hasher.
+         * @param data the BigInteger to add.
+         * @return a reference to this object
+         */
+        default Builder with(BigInteger data) {
+            return with( data.toByteArray() );
+        }
+
+        /**
+         * Adds a BigDecimal into the hasher.
+         * The scale of the BigDecimal is placed in the buffer followed by the
+         * byte array for the unscaled value.
+         * @param data the BigDecimal to add.
+         * @return a reference to this object
+         */
+        default Builder with(BigDecimal data) {
+            byte[] value = data.unscaledValue().toByteArray();
+            return with( ByteBuffer.allocate( Integer.BYTES+value.length )
+                    .putInt( data.scale() ).put( value ).array() );
+        }
+
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilterMultipleItemTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilterMultipleItemTest.java
@@ -28,25 +28,24 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests for the {@link SimpleBloomFilter} when T represents a single
- * item in the filter.
+ * Tests for the {@link SimpleBloomFilter} when T represents a single item in
+ * the filter.
  */
 public class SimpleBloomFilterMultipleItemTest extends AbstractBloomFilterTest {
 
     public SimpleBloomFilterMultipleItemTest() {
-        shape = new Shape( new Murmur128x64Cyclic(), 3, 72, 17);
+        shape = new Shape(new Murmur128x64Cyclic(), 3, 72, 17);
     }
 
     protected Function<TypedObject, SimpleBuilder> getFunc() {
-        return new Function<TypedObject, SimpleBuilder>(){
+        return new Function<TypedObject, SimpleBuilder>() {
 
             @Override
             public SimpleBuilder apply(TypedObject t) {
-                return (SimpleBuilder) new SimpleBuilder()
-                        .withUnencoded( t.hello)
-                        .withUnencoded( t.world );
+                return (SimpleBuilder) new SimpleBuilder().withUnencoded(t.hello).withUnencoded(t.world);
 
-            }};
+            }
+        };
     }
 
     @Override
@@ -64,33 +63,31 @@ public class SimpleBloomFilterMultipleItemTest extends AbstractBloomFilterTest {
      */
     @Test
     public void mergeTTest() {
-        SimpleBloomFilter<TypedObject> bloomFilter = createEmptyFilter( shape );
-        bloomFilter.merge( new TypedObject() );
+        SimpleBloomFilter<TypedObject> bloomFilter = createEmptyFilter(shape);
+        bloomFilter.merge(new TypedObject());
 
-        Hasher hasher = new DynamicHasher.Builder(new Murmur128x64Cyclic() )
-                .withUnencoded("hello")
+        Hasher hasher = new DynamicHasher.Builder(new Murmur128x64Cyclic()).withUnencoded("hello")
                 .withUnencoded("world").build();
 
-        BloomFilter other = new BitSetBloomFilter( hasher, shape );
-        Assert.assertArrayEquals( other.getBits(), bloomFilter.getBits() );
+        BloomFilter other = new BitSetBloomFilter(hasher, shape);
+        Assert.assertArrayEquals(other.getBits(), bloomFilter.getBits());
 
     }
-
 
     /**
      * Tests that contains {@code TypedObject} works as expected.
      */
     @Test
     public void containsTTest() {
-        SimpleBloomFilter<TypedObject> bloomFilter = createEmptyFilter( shape );
-        bloomFilter.merge( new TypedObject() );
+        SimpleBloomFilter<TypedObject> bloomFilter = createEmptyFilter(shape);
+        bloomFilter.merge(new TypedObject());
 
         TypedObject t = new TypedObject();
 
-        Assert.assertTrue( bloomFilter.contains(t));
+        Assert.assertTrue(bloomFilter.contains(t));
 
-        t.hello="hola";
-        Assert.assertFalse( bloomFilter.contains( t ));
+        t.hello = "hola";
+        Assert.assertFalse(bloomFilter.contains(t));
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilterMultipleItemTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilterMultipleItemTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4.bloomfilter;
+
+import java.util.function.Function;
+
+import org.apache.commons.collections4.bloomfilter.SimpleBloomFilter.SimpleBuilder;
+import org.apache.commons.collections4.bloomfilter.SimpleBloomFilterTest.TypedObject;
+import org.apache.commons.collections4.bloomfilter.hasher.DynamicHasher;
+import org.apache.commons.collections4.bloomfilter.hasher.Hasher;
+import org.apache.commons.collections4.bloomfilter.hasher.Shape;
+import org.apache.commons.collections4.bloomfilter.hasher.function.Murmur128x64Cyclic;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link SimpleBloomFilter} when T represents a single
+ * item in the filter.
+ */
+public class SimpleBloomFilterMultipleItemTest extends AbstractBloomFilterTest {
+
+    public SimpleBloomFilterMultipleItemTest() {
+        shape = new Shape( new Murmur128x64Cyclic(), 3, 72, 17);
+    }
+
+    protected Function<TypedObject, SimpleBuilder> getFunc() {
+        return new Function<TypedObject, SimpleBuilder>(){
+
+            @Override
+            public SimpleBuilder apply(TypedObject t) {
+                return (SimpleBuilder) new SimpleBuilder()
+                        .withUnencoded( t.hello)
+                        .withUnencoded( t.world );
+
+            }};
+    }
+
+    @Override
+    protected SimpleBloomFilter<TypedObject> createEmptyFilter(final Shape shape) {
+        return new SimpleBloomFilter<TypedObject>(shape, getFunc());
+    }
+
+    @Override
+    protected SimpleBloomFilter<TypedObject> createFilter(final Hasher hasher, final Shape shape) {
+        return new SimpleBloomFilter<TypedObject>(hasher, shape, getFunc());
+    }
+
+    /**
+     * Tests that adding {@code TypedObject} adds as multiple items.
+     */
+    @Test
+    public void mergeTTest() {
+        SimpleBloomFilter<TypedObject> bloomFilter = createEmptyFilter( shape );
+        bloomFilter.merge( new TypedObject() );
+
+        Hasher hasher = new DynamicHasher.Builder(new Murmur128x64Cyclic() )
+                .withUnencoded("hello")
+                .withUnencoded("world").build();
+
+        BloomFilter other = new BitSetBloomFilter( hasher, shape );
+        Assert.assertArrayEquals( other.getBits(), bloomFilter.getBits() );
+
+    }
+
+
+    /**
+     * Tests that contains {@code TypedObject} works as expected.
+     */
+    @Test
+    public void containsTTest() {
+        SimpleBloomFilter<TypedObject> bloomFilter = createEmptyFilter( shape );
+        bloomFilter.merge( new TypedObject() );
+
+        TypedObject t = new TypedObject();
+
+        Assert.assertTrue( bloomFilter.contains(t));
+
+        t.hello="hola";
+        Assert.assertFalse( bloomFilter.contains( t ));
+    }
+
+    /**
+     * Simple class for use in testing testing {@code merge( T )}.
+     *
+     */
+    public class TypedObject {
+        String hello = "hello";
+        String world = "world";
+    }
+}

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilterTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4.bloomfilter;
+
+import java.util.function.Function;
+
+import org.apache.commons.collections4.bloomfilter.SimpleBloomFilter.SimpleBuilder;
+import org.apache.commons.collections4.bloomfilter.hasher.DynamicHasher;
+import org.apache.commons.collections4.bloomfilter.hasher.Hasher;
+import org.apache.commons.collections4.bloomfilter.hasher.Shape;
+import org.apache.commons.collections4.bloomfilter.hasher.function.Murmur128x64Cyclic;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for the {@link SimpleBloomFilter} when T represents a single
+ * item in the filter.
+ */
+public class SimpleBloomFilterTest extends AbstractBloomFilterTest {
+
+    public SimpleBloomFilterTest() {
+        shape = new Shape( new Murmur128x64Cyclic(), 3, 72, 17);
+    }
+
+    protected Function<TypedObject, SimpleBuilder> getFunc() {
+        return new Function<TypedObject, SimpleBuilder>(){
+
+            @Override
+            public SimpleBuilder apply(TypedObject t) {
+                return (SimpleBuilder) new SimpleBuilder()
+                        .withUnencoded( String.format( "%s %s", t.hello, t.world));
+
+            }};
+    }
+
+    @Override
+    protected SimpleBloomFilter<TypedObject> createEmptyFilter(final Shape shape) {
+        return new SimpleBloomFilter<TypedObject>(shape, getFunc());
+    }
+
+    @Override
+    protected SimpleBloomFilter<TypedObject> createFilter(final Hasher hasher, final Shape shape) {
+        return new SimpleBloomFilter<TypedObject>(hasher, shape, getFunc());
+    }
+
+    /**
+     * Tests that adding {@code TypedObject} adds as a single item.
+     */
+    @Test
+    public void mergeTTest() {
+        SimpleBloomFilter<TypedObject> bloomFilter = createEmptyFilter( shape );
+        bloomFilter.merge( new TypedObject() );
+
+        Hasher hasher = new DynamicHasher.Builder(new Murmur128x64Cyclic() ).withUnencoded("hello world").build();
+
+        BloomFilter other = new BitSetBloomFilter( hasher, shape );
+        Assert.assertArrayEquals( other.getBits(), bloomFilter.getBits() );
+
+    }
+
+    /**
+     * Tests that contains {@code TypedObject} works as expected.
+     */
+    @Test
+    public void containsTTest() {
+        SimpleBloomFilter<TypedObject> bloomFilter = createEmptyFilter( shape );
+        bloomFilter.merge( new TypedObject() );
+
+        TypedObject t = new TypedObject();
+
+        Assert.assertTrue( bloomFilter.contains(t));
+
+        t.hello="hola";
+        Assert.assertFalse( bloomFilter.contains( t ));
+    }
+    /**
+     * Simple class for use in testing testing {@code merge( T )}.
+     *
+     */
+    public class TypedObject {
+        String hello = "hello";
+        String world = "world";
+    }
+}

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/hasher/HasherBuilderTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/hasher/HasherBuilderTest.java
@@ -20,6 +20,9 @@ import org.apache.commons.collections4.bloomfilter.hasher.Hasher.Builder;
 import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.CharBuffer;
@@ -29,7 +32,8 @@ import java.util.ArrayList;
 
 /**
  * Tests the
- * {@link org.apache.commons.collections4.bloomfilter.hasher.Hasher.Builder Hasher.Builder}.
+ * {@link org.apache.commons.collections4.bloomfilter.hasher.Hasher.Builder
+ * Hasher.Builder}.
  */
 public class HasherBuilderTest {
 
@@ -58,10 +62,9 @@ public class HasherBuilderTest {
     public void withCharSequenceTest() {
         final String ascii = "plain";
         final String extended = getExtendedString();
-        for (final String s : new String[] {ascii, extended}) {
-            for (final Charset cs : new Charset[] {
-                StandardCharsets.ISO_8859_1, StandardCharsets.UTF_8, StandardCharsets.UTF_16
-            }) {
+        for (final String s : new String[] { ascii, extended }) {
+            for (final Charset cs : new Charset[] { StandardCharsets.ISO_8859_1, StandardCharsets.UTF_8,
+                StandardCharsets.UTF_16 }) {
                 TestBuilder builder = new TestBuilder();
                 builder.with(s, cs);
                 Assert.assertArrayEquals(s.getBytes(cs), builder.items.get(0));
@@ -76,7 +79,7 @@ public class HasherBuilderTest {
     public void withUnecodedCharSequenceTest() {
         final String ascii = "plain";
         final String extended = getExtendedString();
-        for (final String s : new String[] {ascii, extended}) {
+        for (final String s : new String[] { ascii, extended }) {
             final TestBuilder builder = new TestBuilder();
             builder.withUnencoded(s);
             final byte[] encoded = builder.items.get(0);
@@ -84,8 +87,7 @@ public class HasherBuilderTest {
             // Should be twice the length
             Assert.assertEquals(original.length * 2, encoded.length);
             // Should be little endian (lower bits first)
-            final CharBuffer buffer = ByteBuffer.wrap(encoded)
-                                                .order(ByteOrder.LITTLE_ENDIAN).asCharBuffer();
+            final CharBuffer buffer = ByteBuffer.wrap(encoded).order(ByteOrder.LITTLE_ENDIAN).asCharBuffer();
             for (int i = 0; i < original.length; i++) {
                 Assert.assertEquals(original[i], buffer.get(i));
             }
@@ -98,7 +100,7 @@ public class HasherBuilderTest {
      * @return the extended string
      */
     static String getExtendedString() {
-        final char[] data = {'e', 'x', 't', 'e', 'n', 'd', 'e', 'd', ' ',
+        final char[] data = { 'e', 'x', 't', 'e', 'n', 'd', 'e', 'd', ' ',
             // Add some characters that are non standard
             // non-ascii
             0xCA98,
@@ -108,4 +110,156 @@ public class HasherBuilderTest {
         };
         return String.valueOf(data);
     }
+
+    /**
+     * Test that adding an integer into the hasher works correctly
+     */
+    @Test
+    public void withIntTest() {
+        TestBuilder builder = new TestBuilder();
+        Integer[] values = { Integer.valueOf(0), Integer.MAX_VALUE, Integer.MIN_VALUE };
+        for (int i : values) {
+            builder.with(i);
+        }
+
+        for (int i = 0; i < values.length; i++) {
+            Assert.assertArrayEquals(ByteBuffer.allocate(Integer.BYTES).putInt(values[i]).array(),
+                    builder.items.get(i));
+        }
+    }
+
+    /**
+     * Test that adding a long into the hasher works correctly
+     */
+    @Test
+    public void withLongTest() {
+        TestBuilder builder = new TestBuilder();
+        Long[] values = { Long.valueOf(0), Long.MAX_VALUE, Long.MIN_VALUE };
+        for (long l : values) {
+            builder.with(l);
+        }
+
+        for (int i = 0; i < values.length; i++) {
+            Assert.assertArrayEquals(ByteBuffer.allocate(Long.BYTES).putLong(values[i]).array(), builder.items.get(i));
+        }
+    }
+
+    /**
+     * Test that adding a double into the hasher works correctly
+     */
+    @Test
+    public void withDoubleTest() {
+        TestBuilder builder = new TestBuilder();
+        Double[] values = { Double.valueOf(0.0), Double.MAX_VALUE, Double.MIN_VALUE, Double.MIN_NORMAL,
+            Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN };
+        for (double d : values) {
+            builder.with(d);
+        }
+
+        for (int i = 0; i < values.length; i++) {
+            Assert.assertArrayEquals(ByteBuffer.allocate(Double.BYTES).putDouble(values[i]).array(),
+                    builder.items.get(i));
+        }
+    }
+
+    /**
+     * Test that adding a float into the hasher works correctly
+     */
+    @Test
+    public void withFloatTest() {
+        TestBuilder builder = new TestBuilder();
+        Float[] values = { Float.valueOf(0.0f), Float.MAX_VALUE, Float.MIN_VALUE, Float.MIN_NORMAL,
+            Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY, Float.NaN };
+        for (float f : values) {
+            builder.with(f);
+        }
+
+        for (int i = 0; i < values.length; i++) {
+            Assert.assertArrayEquals(ByteBuffer.allocate(Float.BYTES).putFloat(values[i]).array(),
+                    builder.items.get(i));
+        }
+    }
+
+    /**
+     * Test that adding a character into the hasher works correctly
+     */
+    @Test
+    public void withCharTest() {
+        TestBuilder builder = new TestBuilder();
+        Character[] values = { Character.valueOf((char) 0), Character.MAX_HIGH_SURROGATE, Character.MAX_LOW_SURROGATE,
+            Character.MAX_SURROGATE, Character.MAX_VALUE, Character.MIN_HIGH_SURROGATE, Character.MIN_LOW_SURROGATE,
+            Character.MIN_SURROGATE, Character.MIN_VALUE };
+        for (char c : values) {
+            builder.with(c);
+        }
+
+        for (int i = 0; i < values.length; i++) {
+            Assert.assertArrayEquals(ByteBuffer.allocate(Character.BYTES).putChar(values[i]).array(),
+                    builder.items.get(i));
+        }
+    }
+
+    /**
+     * Test that adding a short into the hasher works correctly
+     */
+    @Test
+    public void withShortTest() {
+        TestBuilder builder = new TestBuilder();
+        Short[] values = { Short.valueOf((short) 0), Short.MAX_VALUE, Short.MIN_VALUE };
+        for (short s : values) {
+            builder.with(s);
+        }
+
+        for (int i = 0; i < values.length; i++) {
+            Assert.assertArrayEquals(ByteBuffer.allocate(Short.BYTES).putShort(values[i]).array(),
+                    builder.items.get(i));
+        }
+    }
+
+    /**
+     * Test that adding a BigInteger into the hasher works correctly
+     */
+    @Test
+    public void withBigIngeterTest() {
+        TestBuilder builder = new TestBuilder();
+        BigInteger[] values = { BigInteger.ZERO, BigInteger.ONE, BigInteger.TWO, BigInteger.TEN,
+                BigInteger.valueOf(Long.MAX_VALUE), BigInteger.valueOf(Long.MIN_VALUE),
+                BigInteger.valueOf(Long.MAX_VALUE).pow(3) };
+        for (BigInteger bi : values) {
+            builder.with(bi);
+        }
+
+        for (int i = 0; i < values.length; i++) {
+            Assert.assertArrayEquals(values[i].toByteArray(), builder.items.get(i));
+        }
+    }
+
+    /**
+     * Test that adding a BigDecimal into the hasher works correctly
+     */
+    @Test
+    public void withBigDecimalTest() {
+        TestBuilder builder = new TestBuilder();
+        // can not test Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, and
+        // Double.NaN
+        BigDecimal[] values = { BigDecimal.ZERO, BigDecimal.ONE, BigDecimal.TEN, BigDecimal.valueOf(Double.MAX_VALUE),
+                BigDecimal.valueOf(Double.MIN_VALUE), BigDecimal.valueOf(Double.MIN_NORMAL),
+                BigDecimal.valueOf(Long.MIN_VALUE, Integer.MIN_VALUE),
+                BigDecimal.valueOf(Long.MIN_VALUE, Integer.MAX_VALUE),
+                BigDecimal.valueOf(Long.MAX_VALUE, Integer.MIN_VALUE),
+                BigDecimal.valueOf(Long.MAX_VALUE, Integer.MAX_VALUE), };
+
+        for (BigDecimal bd : values) {
+            builder.with(bd);
+        }
+
+        for (int i = 0; i < values.length; i++) {
+            ByteBuffer buff = ByteBuffer.wrap(builder.items.get(i));
+            Assert.assertEquals("Error in value " + i, values[i].scale(), buff.getInt());
+            byte[] part = new byte[builder.items.get(i).length - Integer.BYTES];
+            buff.get(part);
+            Assert.assertArrayEquals("Error in value " + i, values[i].unscaledValue().toByteArray(), part);
+        }
+    }
+
 }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/hasher/HasherBuilderTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/hasher/HasherBuilderTest.java
@@ -40,7 +40,7 @@ public class HasherBuilderTest {
     /**
      * Simple class to collect byte[] items added to the builder.
      */
-    private static class TestBuilder implements Hasher.Builder {
+    private static class TestBuilder implements Hasher.Builder<Hasher, Hasher.Builder<Hasher, ?>> {
         ArrayList<byte[]> items = new ArrayList<>();
 
         @Override
@@ -49,7 +49,7 @@ public class HasherBuilderTest {
         }
 
         @Override
-        public Builder with(byte[] item) {
+        public Builder<Hasher, ?> with(byte[] item) {
             items.add(item);
             return this;
         }
@@ -101,12 +101,12 @@ public class HasherBuilderTest {
      */
     static String getExtendedString() {
         final char[] data = { 'e', 'x', 't', 'e', 'n', 'd', 'e', 'd', ' ',
-            // Add some characters that are non standard
-            // non-ascii
+                // Add some characters that are non standard
+                // non-ascii
             0xCA98,
-            // UTF-16 surrogate pair
+                // UTF-16 surrogate pair
             0xD803, 0xDE6D
-            // Add other cases here ...
+                // Add other cases here ...
         };
         return String.valueOf(data);
     }
@@ -123,7 +123,7 @@ public class HasherBuilderTest {
         }
 
         for (int i = 0; i < values.length; i++) {
-            Assert.assertArrayEquals(ByteBuffer.allocate(Integer.BYTES).putInt(values[i]).array(),
+            Assert.assertArrayEquals(ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).putInt(values[i]).array(),
                     builder.items.get(i));
         }
     }
@@ -140,7 +140,7 @@ public class HasherBuilderTest {
         }
 
         for (int i = 0; i < values.length; i++) {
-            Assert.assertArrayEquals(ByteBuffer.allocate(Long.BYTES).putLong(values[i]).array(), builder.items.get(i));
+            Assert.assertArrayEquals(ByteBuffer.allocate(Long.BYTES).order(ByteOrder.LITTLE_ENDIAN).putLong(values[i]).array(), builder.items.get(i));
         }
     }
 
@@ -157,7 +157,7 @@ public class HasherBuilderTest {
         }
 
         for (int i = 0; i < values.length; i++) {
-            Assert.assertArrayEquals(ByteBuffer.allocate(Double.BYTES).putDouble(values[i]).array(),
+            Assert.assertArrayEquals(ByteBuffer.allocate(Double.BYTES).order(ByteOrder.LITTLE_ENDIAN).putDouble(values[i]).array(),
                     builder.items.get(i));
         }
     }
@@ -175,7 +175,7 @@ public class HasherBuilderTest {
         }
 
         for (int i = 0; i < values.length; i++) {
-            Assert.assertArrayEquals(ByteBuffer.allocate(Float.BYTES).putFloat(values[i]).array(),
+            Assert.assertArrayEquals(ByteBuffer.allocate(Float.BYTES).order(ByteOrder.LITTLE_ENDIAN).putFloat(values[i]).array(),
                     builder.items.get(i));
         }
     }
@@ -194,7 +194,7 @@ public class HasherBuilderTest {
         }
 
         for (int i = 0; i < values.length; i++) {
-            Assert.assertArrayEquals(ByteBuffer.allocate(Character.BYTES).putChar(values[i]).array(),
+            Assert.assertArrayEquals(ByteBuffer.allocate(Character.BYTES).order( ByteOrder.LITTLE_ENDIAN).putChar(values[i]).array(),
                     builder.items.get(i));
         }
     }
@@ -211,7 +211,7 @@ public class HasherBuilderTest {
         }
 
         for (int i = 0; i < values.length; i++) {
-            Assert.assertArrayEquals(ByteBuffer.allocate(Short.BYTES).putShort(values[i]).array(),
+            Assert.assertArrayEquals(ByteBuffer.allocate(Short.BYTES).order(ByteOrder.LITTLE_ENDIAN).putShort(values[i]).array(),
                     builder.items.get(i));
         }
     }
@@ -222,9 +222,8 @@ public class HasherBuilderTest {
     @Test
     public void withBigIngeterTest() {
         TestBuilder builder = new TestBuilder();
-        BigInteger[] values = { BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN,
-                BigInteger.valueOf(Long.MAX_VALUE), BigInteger.valueOf(Long.MIN_VALUE),
-                BigInteger.valueOf(Long.MAX_VALUE).pow(3) };
+        BigInteger[] values = { BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN, BigInteger.valueOf(Long.MAX_VALUE),
+                BigInteger.valueOf(Long.MIN_VALUE), BigInteger.valueOf(Long.MAX_VALUE).pow(3) };
         for (BigInteger bi : values) {
             builder.with(bi);
         }
@@ -254,7 +253,7 @@ public class HasherBuilderTest {
         }
 
         for (int i = 0; i < values.length; i++) {
-            ByteBuffer buff = ByteBuffer.wrap(builder.items.get(i));
+            ByteBuffer buff = ByteBuffer.wrap(builder.items.get(i)).order(ByteOrder.LITTLE_ENDIAN);
             Assert.assertEquals("Error in value " + i, values[i].scale(), buff.getInt());
             byte[] part = new byte[builder.items.get(i).length - Integer.BYTES];
             buff.get(part);

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/hasher/HasherBuilderTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/hasher/HasherBuilderTest.java
@@ -222,7 +222,7 @@ public class HasherBuilderTest {
     @Test
     public void withBigIngeterTest() {
         TestBuilder builder = new TestBuilder();
-        BigInteger[] values = { BigInteger.ZERO, BigInteger.ONE, BigInteger.TWO, BigInteger.TEN,
+        BigInteger[] values = { BigInteger.ZERO, BigInteger.ONE, BigInteger.TEN,
                 BigInteger.valueOf(Long.MAX_VALUE), BigInteger.valueOf(Long.MIN_VALUE),
                 BigInteger.valueOf(Long.MAX_VALUE).pow(3) };
         for (BigInteger bi : values) {


### PR DESCRIPTION
This pull requests adds a generic `SimpleBloomFilter<T>`.  The user provides a `Function<T,SimpleBuilder>` implementation.  The class adds `bloomFilter.merge( T )` and `bloomFilter.contains( T )`.

Additional changes were made to Hasher.Builder to use generics:  `Hasher.Builder<H extends Hasher, B extends Builder>`.  This allows the default methods in the interface to work correctly when a minimal specific implementation is provided. 

Also added additional `with()` methods to `Hasher.Builder<H extends Hasher, B extends Builder>` to accept primitives (int, long, double, float, short, char) as well as BigInteger and BigDecimal.


