### PR TITLE
Removed constructors that set initial values

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bloomfilter/ArrayCountingBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/ArrayCountingBloomFilter.java
@@ -140,28 +140,6 @@ public class ArrayCountingBloomFilter extends AbstractBloomFilter implements Cou
         counts = new int[shape.getNumberOfBits()];
     }
 
-    /**
-     * Constructs a counting Bloom filter from a hasher and a shape.
-     *
-     * <p>The filter will be equal to the result of merging the hasher with an empty
-     * filter; specifically duplicate indexes in the hasher are ignored.
-     *
-     * @param hasher the hasher to build the filter from
-     * @param shape the shape of the filter
-     * @throws IllegalArgumentException if the hasher cannot generate indices for
-     * the shape
-     * @see #merge(Hasher)
-     */
-    public ArrayCountingBloomFilter(final Hasher hasher, final Shape shape) {
-        super(shape);
-        // Given the filter is empty we can optimise the operation of merge(hasher)
-        verifyHasher(hasher);
-        // Delay array allocation until after hasher is verified
-        counts = new int[shape.getNumberOfBits()];
-        // All counts are zero. Ignore duplicates by initialising to 1
-        hasher.iterator(shape).forEachRemaining((IntConsumer) idx -> counts[idx] = 1);
-    }
-
     @Override
     public int cardinality() {
         int size = 0;

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/BitSetBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/BitSetBloomFilter.java
@@ -37,18 +37,6 @@ public class BitSetBloomFilter extends AbstractBloomFilter {
     private final BitSet bitSet;
 
     /**
-     * Constructs a BitSetBloomFilter from a hasher and a shape.
-     *
-     * @param hasher the Hasher to use.
-     * @param shape the desired shape of the filter.
-     */
-    public BitSetBloomFilter(final Hasher hasher, final Shape shape) {
-        this(shape);
-        verifyHasher(hasher);
-        hasher.iterator(shape).forEachRemaining((IntConsumer) bitSet::set);
-    }
-
-    /**
      * Constructs an empty BitSetBloomFilter.
      *
      * @param shape the desired shape of the filter.

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/BitSetBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/BitSetBloomFilterTest.java
@@ -30,6 +30,8 @@ public class BitSetBloomFilterTest extends AbstractBloomFilterTest {
 
     @Override
     protected BitSetBloomFilter createFilter(final Hasher hasher, final Shape shape) {
-        return new BitSetBloomFilter(hasher, shape);
+        BitSetBloomFilter testFilter = new BitSetBloomFilter(shape);
+        testFilter.merge( hasher );
+        return testFilter;
     }
 }


### PR DESCRIPTION
fix for COLLECTIONS-763

Removes constructors that initialze the BloomFilter with data via the Hasher argument to the constructor.  The exception is the HasherBloomFilter which by definition wraps a Hasher.