### PR TITLE
[COLLECTIONS-766] fix ci build (or to say, fix everything that wrongly blocked the ci build.)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,21 @@ jdk:
   - openjdk-ea
 
 script:
+  - "if [ \"$TRAVIS_JDK_VERSION\" = \"openjdk8\" ]; then"
+  - mvn -V
+  - # japicmp requires a package
+  - mvn -V jar:jar japicmp:cmp -P japicmp
+  - else
   - mvn -V --no-transfer-progress
-  # japicmp requires a package
+  - # japicmp requires a package
   - mvn -V jar:jar japicmp:cmp -P japicmp --no-transfer-progress
+  - fi
 
 after_success:
-  # jacoco will run in the main script. Include the profile to submit to coveralls.
+  - "if [ \"$TRAVIS_JDK_VERSION\" = \"openjdk8\" ]; then"
+  - # jacoco will run in the main script. Include the profile to submit to coveralls.
+  - mvn -V jacoco:report coveralls:report -Ptravis-jacoco
+  - else
+  - # jacoco will run in the main script. Include the profile to submit to coveralls.
   - mvn -V jacoco:report coveralls:report -Ptravis-jacoco --no-transfer-progress
+  - fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,20 +30,20 @@ jdk:
 
 script:
   - "if [ \"$TRAVIS_JDK_VERSION\" = \"openjdk8\" ]; then"
-  - mvn -V
+  - mvn -V;
   - # japicmp requires a package
-  - mvn -V jar:jar japicmp:cmp -P japicmp
+  - mvn -V jar:jar japicmp:cmp -P japicmp;
   - else
-  - mvn -V --no-transfer-progress
+  - mvn -V --no-transfer-progress;
   - # japicmp requires a package
-  - mvn -V jar:jar japicmp:cmp -P japicmp --no-transfer-progress
-  - fi
+  - mvn -V jar:jar japicmp:cmp -P japicmp --no-transfer-progress;
+  - fi;
 
 after_success:
   - "if [ \"$TRAVIS_JDK_VERSION\" = \"openjdk8\" ]; then"
   - # jacoco will run in the main script. Include the profile to submit to coveralls.
-  - mvn -V jacoco:report coveralls:report -Ptravis-jacoco
-  - else
+  - mvn -V jacoco:report coveralls:report -Ptravis-jacoco;
+  - else;
   - # jacoco will run in the main script. Include the profile to submit to coveralls.
-  - mvn -V jacoco:report coveralls:report -Ptravis-jacoco --no-transfer-progress
-  - fi
+  - mvn -V jacoco:report coveralls:report -Ptravis-jacoco --no-transfer-progress;
+  - fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jdk:
 script:
   # japicmp requires a package
   - |
-    if [ "$TRAVIS_OS_NAME" = "linux-ppc64le" ];
+    if [ "$TRAVIS_OS_NAME" = "ppc64le" ];
     then
     mvn -V;
     mvn -V jar:jar japicmp:cmp -P japicmp;
@@ -43,7 +43,7 @@ script:
 after_success:
   # jacoco will run in the main script. Include the profile to submit to coveralls.
   - |
-    if [ "$TRAVIS_OS_NAME" = "linux-ppc64le" ];
+    if [ "$TRAVIS_OS_NAME" = "ppc64le" ];
     then
     mvn -V jacoco:report coveralls:report -Ptravis-jacoco;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,21 +29,23 @@ jdk:
   - openjdk-ea
 
 script:
-  - "if [ \"$TRAVIS_JDK_VERSION\" = \"openjdk8\" ]; then"
-  - mvn -V;
-  - # japicmp requires a package
-  - mvn -V jar:jar japicmp:cmp -P japicmp;
-  - else
-  - mvn -V --no-transfer-progress;
-  - # japicmp requires a package
-  - mvn -V jar:jar japicmp:cmp -P japicmp --no-transfer-progress;
-  - fi;
+  # japicmp requires a package
+  - |
+    if [ "$TRAVIS_JDK_VERSION" = "openjdk8" ];
+    then
+    mvn -V;
+    mvn -V jar:jar japicmp:cmp -P japicmp;
+    else
+    mvn -V --no-transfer-progress;
+    mvn -V jar:jar japicmp:cmp -P japicmp --no-transfer-progress;
+    fi;
 
 after_success:
-  - "if [ \"$TRAVIS_JDK_VERSION\" = \"openjdk8\" ]; then"
-  - # jacoco will run in the main script. Include the profile to submit to coveralls.
-  - mvn -V jacoco:report coveralls:report -Ptravis-jacoco;
-  - else;
-  - # jacoco will run in the main script. Include the profile to submit to coveralls.
-  - mvn -V jacoco:report coveralls:report -Ptravis-jacoco --no-transfer-progress;
-  - fi;
+  # jacoco will run in the main script. Include the profile to submit to coveralls.
+  - |
+    if [ "$TRAVIS_JDK_VERSION" = "openjdk8" ];
+    then
+    mvn -V jacoco:report coveralls:report -Ptravis-jacoco;
+    else
+    mvn -V jacoco:report coveralls:report -Ptravis-jacoco --no-transfer-progress;
+    fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jdk:
 script:
   # japicmp requires a package
   - |
-    if [ "$TRAVIS_JDK_VERSION" = "openjdk8" ];
+    if [ "$TRAVIS_OS_NAME" = "linux-ppc64le" ];
     then
     mvn -V;
     mvn -V jar:jar japicmp:cmp -P japicmp;
@@ -43,7 +43,7 @@ script:
 after_success:
   # jacoco will run in the main script. Include the profile to submit to coveralls.
   - |
-    if [ "$TRAVIS_JDK_VERSION" = "openjdk8" ];
+    if [ "$TRAVIS_OS_NAME" = "linux-ppc64le" ];
     then
     mvn -V jacoco:report coveralls:report -Ptravis-jacoco;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jdk:
 script:
   # japicmp requires a package
   - |
-    if [ "$TRAVIS_OS_NAME" = "ppc64le" ];
+    if [ "$TRAVIS_ARCH_NAME" = "ppc64le" ];
     then
     mvn -V;
     mvn -V jar:jar japicmp:cmp -P japicmp;
@@ -43,7 +43,7 @@ script:
 after_success:
   # jacoco will run in the main script. Include the profile to submit to coveralls.
   - |
-    if [ "$TRAVIS_OS_NAME" = "ppc64le" ];
+    if [ "$TRAVIS_ARCH_NAME" = "ppc64le" ];
     then
     mvn -V jacoco:report coveralls:report -Ptravis-jacoco;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,23 +29,10 @@ jdk:
   - openjdk-ea
 
 script:
+  - mvn -V
   # japicmp requires a package
-  - |
-    if [ "$TRAVIS_ARCH_NAME" = "ppc64le" ];
-    then
-    mvn -V;
-    mvn -V jar:jar japicmp:cmp -P japicmp;
-    else
-    mvn -V --no-transfer-progress;
-    mvn -V jar:jar japicmp:cmp -P japicmp --no-transfer-progress;
-    fi;
+  - mvn -V jar:jar japicmp:cmp -P japicmp
 
 after_success:
   # jacoco will run in the main script. Include the profile to submit to coveralls.
-  - |
-    if [ "$TRAVIS_ARCH_NAME" = "ppc64le" ];
-    then
-    mvn -V jacoco:report coveralls:report -Ptravis-jacoco;
-    else
-    mvn -V jacoco:report coveralls:report -Ptravis-jacoco --no-transfer-progress;
-    fi;
+  - mvn -V jacoco:report coveralls:report -Ptravis-jacoco

--- a/src/main/java/org/apache/commons/collections4/iterators/ListIteratorWrapper.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/ListIteratorWrapper.java
@@ -204,7 +204,7 @@ public class ListIteratorWrapper<E> implements ResettableListIterator<E> {
 
     /**
      * Removes the last element that was returned by {@link #next()} or {@link #previous()} from the underlying collection.
-     * This call can only be made once per call to {@code next} or {@code previous} and only if {@link #add()} was not called in between.
+     * This call can only be made once per call to {@code next} or {@code previous} and only if {@link #add(Object)} was not called in between.
      *
      * @throws IllegalStateException if {@code next} or {@code previous} have not been called before, or if {@code remove} or {@code add} have been called after the last call to {@code next} or {@code previous}
      */

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/hasher/DynamicHasherBuilderTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/hasher/DynamicHasherBuilderTest.java
@@ -46,7 +46,7 @@ public class DynamicHasherBuilderTest {
     public void buildTest_byteArray() {
         final byte[] bytes = testString.getBytes();
         final DynamicHasher hasher = builder.with(bytes).build();
-        final int expected = (int) Math.floorMod(hf.apply(bytes, 0), shape.getNumberOfBits());
+        final int expected = (int) Math.floorMod((long) hf.apply(bytes, 0), (long) shape.getNumberOfBits());
 
         final OfInt iter = hasher.iterator(shape);
 
@@ -80,7 +80,7 @@ public class DynamicHasherBuilderTest {
     public void buildTest_String() {
         final byte[] bytes = testString.getBytes(StandardCharsets.UTF_8);
         final DynamicHasher hasher = builder.with(testString, StandardCharsets.UTF_8).build();
-        final int expected = (int) Math.floorMod(hf.apply(bytes, 0), shape.getNumberOfBits());
+        final int expected = (int) Math.floorMod((long) hf.apply(bytes, 0), (long) shape.getNumberOfBits());
 
         final OfInt iter = hasher.iterator(shape);
 
@@ -96,7 +96,7 @@ public class DynamicHasherBuilderTest {
     public void buildTest_UnencodedString() {
         final byte[] bytes = testString.getBytes(StandardCharsets.UTF_16LE);
         final DynamicHasher hasher = builder.withUnencoded(testString).build();
-        final int expected = (int) Math.floorMod(hf.apply(bytes, 0), shape.getNumberOfBits());
+        final int expected = (int) Math.floorMod((long) hf.apply(bytes, 0), (long) shape.getNumberOfBits());
 
         final OfInt iter = hasher.iterator(shape);
 


### PR DESCRIPTION
Hi.
I noticed recent builds cannot pass build on jdk 11+ (actually, not very recent)
And I tracked it to find ther be a Math.floorMod(long,int) function newly added in 11, and which is not  on jdk8, on jdk8 the codes will invoke Math.floorMod(long,long) .
That is why animal sniffer will fail the build on 11+.
As it is just a test file, I've hided it by force casting to long.