### PR TITLE
prevent setCollection API In FixedSizeList

### DIFF
--- a/src/main/java/org/apache/commons/collections4/list/FixedSizeList.java
+++ b/src/main/java/org/apache/commons/collections4/list/FixedSizeList.java
@@ -159,6 +159,11 @@ public class FixedSizeList<E>
     public boolean retainAll(final Collection<?> coll) {
         throw unsupportedOperationException();
     }
+    
+    @Override
+    protected void setCollection(Collection<E> coll) {
+        throw unsupportedOperationException();
+    }
 
     @Override
     public E set(final int index, final E object) {


### PR DESCRIPTION
prevent `setCollection` API In FixedSizeList
`setCollection` can replace the whole list, it is better not to support the api.

```java
        List<String> initList = new ArrayList<String>() {{
            add("hello");
            add("world");
        }};

        FixedSizeList<String> fixedSizeList = new FixedSizeList<>(initList);
        //  size is 2
        System.out.println(fixedSizeList.size());

        List<String> replacedList = new ArrayList<String>() {{
            add("replaced");
            add("list");
            add("test");
        }};
        fixedSizeList.setCollection(replacedList);
        // size now change to 3
        System.out.println(fixedSizeList.size());
```