### PR TITLE
[COLLECTIONS-768] Fix flaky Flat3MapTest.testEntrySet()

### DIFF
--- a/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
@@ -352,11 +352,13 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         final Map.Entry<K, V> mapEntry1 = it.next();
         final Map.Entry<K, V> mapEntry2 = it.next();
         final Map.Entry<K, V> mapEntry3 = it.next();
+        V removedValue = mapEntry3.getValue();
         it.remove();
         assertEquals(2, map.size());
-        assertEquals("one", map.get("A"));
-        assertEquals("two", map.get("B"));
-        assertEquals(null, map.get("C"));
+        assertNotNull(removedValue);
+        assertEquals(removedValue.equals("one") ? null : "one", map.get("A"));
+        assertEquals(removedValue.equals("two") ? null : "two", map.get("B"));
+        assertEquals(removedValue.equals("three") ? null : "three", map.get("C"));
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
This patch checks on the removed map entry's value in three assertions, and does not wrongly assume the removed entry is `C=three` like the current test does. 

Detailed description: https://issues.apache.org/jira/browse/COLLECTIONS-768