### PR TITLE
[COLLECTIONS-771] Fix flaky AbstractMultiValuedMapTest#testToString

### DIFF
--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -675,7 +675,10 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         map.put((K) "B", (V) "U");
         map.put((K) "B", (V) "V");
         map.put((K) "B", (V) "W");
-        assertEquals("{A=[X, Y, Z], B=[U, V, W]}", map.toString());
+        assertTrue(
+            "{A=[X, Y, Z], B=[U, V, W]}".equals(map.toString()) ||
+            "{B=[U, V, W], A=[X, Y, Z]}".equals(map.toString())
+        );
 
         try {
             final MultiValuedMap<K, V> originalNull = null;
@@ -684,7 +687,10 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         } catch (final NullPointerException npe) {
             // expected
         }
-        assertEquals("{A=[X, Y, Z], B=[U, V, W]}", map.toString());
+        assertTrue(
+            "{A=[X, Y, Z], B=[U, V, W]}".equals(map.toString()) ||
+            "{B=[U, V, W], A=[X, Y, Z]}".equals(map.toString())
+        );
 
         map.remove("A");
         map.remove("B");


### PR DESCRIPTION
Issue description: https://issues.apache.org/jira/browse/COLLECTIONS-771

Assert `map.toString()` is equal to either one of the two possible string representations:
1. "{A=[X, Y, Z], B=[U, V, W]}"
2. "{B=[U, V, W], A=[X, Y, Z]}"