### PR TITLE
[COLLECTIONS-775] Fix flaky CollectionUtilsTest.getFromMap()

### DIFF
--- a/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
@@ -988,12 +988,10 @@ public class CollectionUtilsTest extends MockTestCase {
         expected.put("zeroKey", "zero");
         expected.put("oneKey", "one");
 
-        final Map<String, String> found = new HashMap<>();
         Map.Entry<String, String> entry = CollectionUtils.get(expected, 0);
-        found.put(entry.getKey(), entry.getValue());
+        assertTrue(entry.toString().equals("zeroKey=zero") || entry.toString().equals("oneKey=one"));
         entry = CollectionUtils.get(expected, 1);
-        found.put(entry.getKey(), entry.getValue());
-        assertEquals(expected, found);
+        assertTrue(entry.toString().equals("zeroKey=zero") || entry.toString().equals("oneKey=one"));
 
         // Map index out of range
         try {


### PR DESCRIPTION
Issue description: https://issues.apache.org/jira/browse/COLLECTIONS-775

This is a rather simple fix -- instead of adding `CollectionUtils.get(expected, 0)` and `CollectionUtils.get(expected, 1)` to a new HashMap (`found`) and compare the two maps, assert the 0 and 1 entries are either `zeroKey=zero` or `oneKey=one`. 