### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,6 @@ script:
 after_success:
   # jacoco will run in the main script. Include the profile to submit to coveralls.
   - mvn -V jacoco:report coveralls:report -Ptravis-jacoco
+
+git:
+  depth: 1


### PR DESCRIPTION
Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.