### PR TITLE
replace TestBuilder with mocking object to improve test design

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,6 +465,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${commons.mockito.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>${commons.junit.version}</version>
@@ -581,6 +587,7 @@
     <commons.clirr.version>2.8</commons.clirr.version>
     <commons.jacoco.version>0.8.7</commons.jacoco.version>
     <commons.junit.version>5.7.2</commons.junit.version>
+    <commons.mockito.version>3.9.0</commons.mockito.version>
 
     <!--Commons Release Plugin -->
     <commons.bc.version>4.4</commons.bc.version>


### PR DESCRIPTION
Fix [COLLECTIONS-798](https://issues.apache.org/jira/browse/COLLECTIONS-798)

### Description

#### Replace test class [TestBuilder](https://github.com/apache/commons-collections/blob/3aae82cbaaaf539bf3f54cd6a0679efc123f2c8e/src/test/java/org/apache/commons/collections4/bloomfilter/hasher/HasherBuilderTest.java#L41) by mocking object and improve test design.
<hr>

##### Motivation

 - Decouple test class `TestBuilder` from production interface `Builder`.
 - Make test logic more clear by using method stub instead of method overriding.
 - Make test condition more explict by use local variable in test case.

<hr>

##### Key changed/added classes in this PR
 - Created mocking object to replace test subclass `TestBuilder`, decoupled test from production code.
 - Extract `items` as a local variable to improve test logic and make test condition more explict.
 - Make test logic more clear by using method stub instead of method overriding.
 - Add Mockito dependency.

<hr>