### PR TITLE
COLLECTIONS-799 - Prevent modifications of `UnmodifiableNavigableSet`

### DIFF
--- a/src/main/java/org/apache/commons/collections4/set/UnmodifiableNavigableSet.java
+++ b/src/main/java/org/apache/commons/collections4/set/UnmodifiableNavigableSet.java
@@ -107,6 +107,22 @@ public final class UnmodifiableNavigableSet<E>
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * @since 4.5
+     */
+    @Override
+    public E pollFirst() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * @since 4.5
+     */
+    @Override
+    public E pollLast() {
+        throw new UnsupportedOperationException();
+    }
+
     @Override
     public boolean retainAll(final Collection<?> coll) {
         throw new UnsupportedOperationException();

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableNavigableSetTest.java
@@ -143,6 +143,23 @@ public class UnmodifiableNavigableSetTest<E> extends AbstractNavigableSetTest<E>
         } catch (final UnsupportedOperationException e) {
             // expected
         }
+
+        if (set instanceof NavigableSet) {
+            final NavigableSet<E> navigableSet = (NavigableSet<E>) set;
+
+            try {
+                navigableSet.pollFirst();
+                fail("Expecting UnsupportedOperationException.");
+            } catch (final UnsupportedOperationException e) {
+                // expected
+            }
+            try {
+                navigableSet.pollLast();
+                fail("Expecting UnsupportedOperationException.");
+            } catch (final UnsupportedOperationException e) {
+                // expected
+            }
+        }
     }
 
     public void testComparator() {


### PR DESCRIPTION
This prevents modifications via [`pollFirst()`](https://docs.oracle.com/javase/7/docs/api/java/util/NavigableSet.html#pollFirst()) and [`pollLast()`](https://docs.oracle.com/javase/7/docs/api/java/util/NavigableSet.html#pollLast()) for `UnmodifiableNavigableSet` instances.

https://issues.apache.org/jira/browse/COLLECTIONS-799
