### PR TITLE
COLLECTIONS-796  SetUniqueList.createSetBasedOnList doesn't add list elements to return value Export

### DIFF
--- a/src/main/java/org/apache/commons/collections4/IteratorUtils.java
+++ b/src/main/java/org/apache/commons/collections4/IteratorUtils.java
@@ -469,7 +469,7 @@ public class IteratorUtils {
      * @return an immutable version of the iterator
      */
     public static <E> ListIterator<E> unmodifiableListIterator(final ListIterator<E> listIterator) {
-        return UnmodifiableListIterator.umodifiableListIterator(listIterator);
+        return UnmodifiableListIterator.unmodifiableListIterator(listIterator);
     }
 
     /**

--- a/src/main/java/org/apache/commons/collections4/iterators/UnmodifiableListIterator.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/UnmodifiableListIterator.java
@@ -43,7 +43,7 @@ public final class UnmodifiableListIterator<E> implements ListIterator<E>, Unmod
      * @return a new unmodifiable list iterator
      * @throws NullPointerException if the iterator is null
      */
-    public static <E> ListIterator<E> umodifiableListIterator(final ListIterator<? extends E> iterator) {
+    public static <E> ListIterator<E> unmodifiableListIterator(final ListIterator<? extends E> iterator) {
         Objects.requireNonNull(iterator, "iterator");
         if (iterator instanceof Unmodifiable) {
             @SuppressWarnings("unchecked") // safe to upcast
@@ -51,6 +51,14 @@ public final class UnmodifiableListIterator<E> implements ListIterator<E>, Unmod
             return tmpIterator;
         }
         return new UnmodifiableListIterator<>(iterator);
+    }
+
+    /**
+     * use "org.apache.commons.collections4.iterators.UnmodifiableListIterator#unmodifiableListIterator" instead.
+     */
+    @Deprecated
+    public static <E> ListIterator<E> umodifiableListIterator(final ListIterator<? extends E> iterator) {
+        return unmodifiableListIterator(iterator);
     }
 
     /**

--- a/src/main/java/org/apache/commons/collections4/list/SetUniqueList.java
+++ b/src/main/java/org/apache/commons/collections4/list/SetUniqueList.java
@@ -352,6 +352,7 @@ public class SetUniqueList<E> extends AbstractSerializableListDecorator<E> {
                 subSet = new HashSet<>();
             }
         }
+        subSet.addAll(list);
         return subSet;
     }
 

--- a/src/main/java/org/apache/commons/collections4/list/UnmodifiableList.java
+++ b/src/main/java/org/apache/commons/collections4/list/UnmodifiableList.java
@@ -118,12 +118,12 @@ public final class UnmodifiableList<E>
 
     @Override
     public ListIterator<E> listIterator() {
-        return UnmodifiableListIterator.umodifiableListIterator(decorated().listIterator());
+        return UnmodifiableListIterator.unmodifiableListIterator(decorated().listIterator());
     }
 
     @Override
     public ListIterator<E> listIterator(final int index) {
-        return UnmodifiableListIterator.umodifiableListIterator(decorated().listIterator(index));
+        return UnmodifiableListIterator.unmodifiableListIterator(decorated().listIterator(index));
     }
 
     @Override

--- a/src/main/java/org/apache/commons/collections4/map/LinkedMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/LinkedMap.java
@@ -307,12 +307,12 @@ public class LinkedMap<K, V> extends AbstractLinkedMap<K, V> implements Serializ
 
         @Override
         public ListIterator<K> listIterator() {
-            return UnmodifiableListIterator.umodifiableListIterator(super.listIterator());
+            return UnmodifiableListIterator.unmodifiableListIterator(super.listIterator());
         }
 
         @Override
         public ListIterator<K> listIterator(final int fromIndex) {
-            return UnmodifiableListIterator.umodifiableListIterator(super.listIterator(fromIndex));
+            return UnmodifiableListIterator.unmodifiableListIterator(super.listIterator(fromIndex));
         }
 
         @Override

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableListIteratorTest.java
@@ -24,13 +24,14 @@ import java.util.ListIterator;
 
 import org.apache.commons.collections4.Unmodifiable;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 /**
  * Tests the UnmodifiableListIterator.
- *
  */
 public class UnmodifiableListIteratorTest<E> extends AbstractListIteratorTest<E> {
 
-    protected String[] testArray = { "One", "Two", "Three" };
+    protected String[] testArray = {"One", "Two", "Three"};
     protected List<E> testList;
 
     public UnmodifiableListIteratorTest(final String testName) {
@@ -49,12 +50,12 @@ public class UnmodifiableListIteratorTest<E> extends AbstractListIteratorTest<E>
 
     @Override
     public ListIterator<E> makeEmptyIterator() {
-        return UnmodifiableListIterator.umodifiableListIterator(Collections.<E>emptyList().listIterator());
+        return UnmodifiableListIterator.unmodifiableListIterator(Collections.<E>emptyList().listIterator());
     }
 
     @Override
     public ListIterator<E> makeObject() {
-        return UnmodifiableListIterator.umodifiableListIterator(testList.listIterator());
+        return UnmodifiableListIterator.unmodifiableListIterator(testList.listIterator());
     }
 
     @Override
@@ -78,15 +79,12 @@ public class UnmodifiableListIteratorTest<E> extends AbstractListIteratorTest<E>
 
     public void testDecorateFactory() {
         ListIterator<E> it = makeObject();
-        assertSame(it, UnmodifiableListIterator.umodifiableListIterator(it));
+        assertSame(it, UnmodifiableListIterator.unmodifiableListIterator(it));
 
         it = testList.listIterator();
-        assertTrue(it != UnmodifiableListIterator.umodifiableListIterator(it));
+        assertNotSame(it, UnmodifiableListIterator.unmodifiableListIterator(it));
 
-        try {
-            UnmodifiableListIterator.umodifiableListIterator(null);
-            fail();
-        } catch (final NullPointerException ex) {}
+        assertThrows(NullPointerException.class, () -> UnmodifiableListIterator.unmodifiableListIterator(null));
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
@@ -16,14 +16,10 @@
  */
 package org.apache.commons.collections4.list;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Set;
+import org.apache.commons.collections4.set.UnmodifiableSet;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.*;
 
 /**
  * JUnit tests.
@@ -558,6 +554,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
     public void testSubListIsUnmodifiable() {
         resetFull();
         final List<E> subList = getCollection().subList(1, 3);
+        Assertions.assertEquals(2, subList.size());
         try {
             subList.remove(0);
             fail("subList should be unmodifiable");
@@ -616,11 +613,31 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         }
     }
 
-//    public void testCreate() throws Exception {
-//        resetEmpty();
-//        writeExternalFormToDisk((java.io.Serializable) getCollection(), "src/test/resources/data/test/SetUniqueList.emptyCollection.version4.obj");
-//        resetFull();
-//        writeExternalFormToDisk((java.io.Serializable) getCollection(), "src/test/resources/data/test/SetUniqueList.fullCollection.version4.obj");
-//    }
+    @SuppressWarnings("unchecked")
+    public void testCreateSetBasedOnList() {
+        final List<String> list = new ArrayList<>();
+        list.add("One");
+        list.add("Two");
+        @SuppressWarnings("rawtypes") final SetUniqueList setUniqueList = (SetUniqueList) makeObject();
 
+        // Standard case with HashSet
+        final Set<String> setBasedOnList = setUniqueList.createSetBasedOnList(new HashSet<>(), list);
+        Assertions.assertEquals(list.size(), setBasedOnList.size());
+        list.forEach(item -> Assertions.assertTrue(setBasedOnList.contains(item)));
+
+        // Use different Set than HashSet
+        final Set<String> setBasedOnList1 = setUniqueList.createSetBasedOnList(new TreeSet(), list);
+        Assertions.assertEquals(list.size(), setBasedOnList1.size());
+        list.forEach(item -> Assertions.assertTrue(setBasedOnList1.contains(item)));
+
+        // throws internally NoSuchMethodException --> results in HashSet
+        final Set<String> setBasedOnList2 = setUniqueList.createSetBasedOnList(UnmodifiableSet.unmodifiableSet(new HashSet<>()), list);
+        Assertions.assertEquals(list.size(), setBasedOnList2.size());
+        list.forEach(item -> Assertions.assertTrue(setBasedOnList2.contains(item)));
+
+        // provide null values as Parameter
+        Assertions.assertThrows(NullPointerException.class, () -> setUniqueList.createSetBasedOnList(null, list));
+        Assertions.assertThrows(NullPointerException.class, () -> setUniqueList.createSetBasedOnList(new HashSet(), null));
+
+    }
 }

--- a/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
@@ -17,9 +17,12 @@
 package org.apache.commons.collections4.list;
 
 import org.apache.commons.collections4.set.UnmodifiableSet;
+import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 
 import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * JUnit tests.
@@ -190,7 +193,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         // repeat the test with a different class than HashSet;
         // which means subclassing SetUniqueList below
         list = new ArrayList<>();
-        uniqueList = new SetUniqueList307(list, new java.util.TreeSet<E>());
+        uniqueList = new SetUniqueList307(list, new TreeSet<E>());
 
         uniqueList.add((E) hello);
         uniqueList.add((E) world);
@@ -554,13 +557,8 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
     public void testSubListIsUnmodifiable() {
         resetFull();
         final List<E> subList = getCollection().subList(1, 3);
-        Assertions.assertEquals(2, subList.size());
-        try {
-            subList.remove(0);
-            fail("subList should be unmodifiable");
-        } catch (final UnsupportedOperationException e) {
-            // expected
-        }
+        assertEquals(2, subList.size());
+        assertThrows(UnsupportedOperationException.class, () -> subList.remove(0));
     }
 
     @SuppressWarnings("unchecked")
@@ -622,22 +620,22 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
 
         // Standard case with HashSet
         final Set<String> setBasedOnList = setUniqueList.createSetBasedOnList(new HashSet<>(), list);
-        Assertions.assertEquals(list.size(), setBasedOnList.size());
-        list.forEach(item -> Assertions.assertTrue(setBasedOnList.contains(item)));
+        assertEquals(list.size(), setBasedOnList.size());
+        list.forEach(item -> assertTrue(setBasedOnList.contains(item)));
 
         // Use different Set than HashSet
-        final Set<String> setBasedOnList1 = setUniqueList.createSetBasedOnList(new TreeSet(), list);
-        Assertions.assertEquals(list.size(), setBasedOnList1.size());
-        list.forEach(item -> Assertions.assertTrue(setBasedOnList1.contains(item)));
+        final Set<String> setBasedOnList1 = setUniqueList.createSetBasedOnList(new TreeSet<>(), list);
+        assertEquals(list.size(), setBasedOnList1.size());
+        list.forEach(item -> assertTrue(setBasedOnList1.contains(item)));
 
         // throws internally NoSuchMethodException --> results in HashSet
         final Set<String> setBasedOnList2 = setUniqueList.createSetBasedOnList(UnmodifiableSet.unmodifiableSet(new HashSet<>()), list);
-        Assertions.assertEquals(list.size(), setBasedOnList2.size());
-        list.forEach(item -> Assertions.assertTrue(setBasedOnList2.contains(item)));
+        assertEquals(list.size(), setBasedOnList2.size());
+        list.forEach(item -> assertTrue(setBasedOnList2.contains(item)));
 
         // provide null values as Parameter
-        Assertions.assertThrows(NullPointerException.class, () -> setUniqueList.createSetBasedOnList(null, list));
-        Assertions.assertThrows(NullPointerException.class, () -> setUniqueList.createSetBasedOnList(new HashSet(), null));
+        assertThrows(NullPointerException.class, () -> setUniqueList.createSetBasedOnList(null, list));
+        assertThrows(NullPointerException.class, () -> setUniqueList.createSetBasedOnList(new HashSet<>(), null));
 
     }
 }


### PR DESCRIPTION
* There seems no immediate reason why the addAll was removed in commit b1c45ac691d46a8c609f2534d2adfa59c0599527
* Tests added
* Functionality implemented again
* removed typo in UnmodifiableListIterator.unmodifiableListIterator (previous 'UnmodifiableListIterator.umodifiableListIterator')