### PR TITLE
SortedProperties should sort entrySet() as well as keys()

### DIFF
--- a/src/main/java/org/apache/commons/collections4/properties/SortedProperties.java
+++ b/src/main/java/org/apache/commons/collections4/properties/SortedProperties.java
@@ -17,10 +17,13 @@
 
 package org.apache.commons.collections4.properties;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -47,5 +50,16 @@ public class SortedProperties extends Properties {
         }
         Collections.sort(keys);
         return new IteratorEnumeration<>(keys.iterator());
+    }
+
+    @Override
+    public Set<Map.Entry<Object, Object>> entrySet() {
+        Enumeration<Object> keys = keys();
+        Set<Map.Entry<Object, Object>> entrySet = new LinkedHashSet<>();
+        while (keys.hasMoreElements()) {
+            Object key = keys.nextElement();
+            entrySet.add(new AbstractMap.SimpleEntry<>(key, getProperty((String) key)));
+        }
+        return entrySet;
     }
 }

--- a/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesTest.java
@@ -18,7 +18,11 @@
 package org.apache.commons.collections4.properties;
 
 import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
 
+import org.apache.commons.collections4.MultiSet;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -33,6 +37,20 @@ public class SortedPropertiesTest {
         final Enumeration<Object> keys = sortedProperties.keys();
         for (char ch = 'A'; ch <= 'Z'; ch++) {
             Assert.assertEquals(String.valueOf(ch), keys.nextElement());
+        }
+    }
+
+    @Test
+    public void testEntrySet() {
+        final SortedProperties sortedProperties = new SortedProperties();
+        for (char ch = 'Z'; ch >= 'A'; ch--) {
+            sortedProperties.put(String.valueOf(ch), "Value" + ch);
+        }
+        final Iterator<Map.Entry<Object, Object>> entries = sortedProperties.entrySet().iterator();
+        for (char ch = 'A'; ch <= 'Z'; ch++) {
+            Map.Entry<Object, Object> entry = entries.next();
+            Assert.assertEquals(String.valueOf(ch), entry.getKey());
+            Assert.assertEquals("Value" + ch, entry.getValue());
         }
     }
 }


### PR DESCRIPTION
At present the `SortedProperties` class overrides & sorts in the `keys()` method, but not the `entrySet()` method. This leads to inconsistencies depending on how the properties are retrieved (for example, when calling `write()` to write the properties to a file, Java 8 uses `keyset()` but Java 11+ uses `entrySet()` - same for other methods like `list()`.)

This PR guarantees the same ordering on `keys()` as `entrySet()`, removing this inconsistency.

(First contribution to this repository, so please feel free to point me in the correct direction if something is wrong!)