### PR TITLE
JUnit v5 Imports

### DIFF
--- a/src/test/java/org/apache/commons/collections4/BagUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/BagUtilsTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.collections4.bag.HashBag;
 import org.apache.commons.collections4.bag.PredicatedBag;

--- a/src/test/java/org/apache/commons/collections4/ClosureUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/ClosureUtilsTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/test/java/org/apache/commons/collections4/ListUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/ListUtilsTest.java
@@ -16,7 +16,14 @@
  */
 package org.apache.commons.collections4;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/apache/commons/collections4/PredicateUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/PredicateUtilsTest.java
@@ -18,7 +18,12 @@ package org.apache.commons.collections4;
 
 import static org.apache.commons.collections4.functors.NullPredicate.*;
 import static org.apache.commons.collections4.functors.TruePredicate.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/apache/commons/collections4/TrieUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/TrieUtilsTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.apache.commons.collections4.trie.PatriciaTrie;
 import org.apache.commons.collections4.trie.UnmodifiableTrie;

--- a/src/test/java/org/apache/commons/collections4/collection/CompositeCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/CompositeCollectionTest.java
@@ -24,7 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Predicate;
 
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -253,21 +253,21 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         final ArrayList<String> nullList = null;
         final CompositeCollection<String> cc = new CompositeCollection<>();
         cc.addComposited(nullList);
-        Assert.assertEquals(0, cc.size());
+        Assertions.assertEquals(0, cc.size());
     }
 
     public void testAddNullLists2Args() {
         final ArrayList<String> nullList = null;
         final CompositeCollection<String> cc = new CompositeCollection<>();
         cc.addComposited(nullList, nullList);
-        Assert.assertEquals(0, cc.size());
+        Assertions.assertEquals(0, cc.size());
     }
 
     public void testAddNullListsVarArgs() {
         final ArrayList<String> nullList = null;
         final CompositeCollection<String> cc = new CompositeCollection<>();
         cc.addComposited(nullList, nullList, nullList);
-        Assert.assertEquals(0, cc.size());
+        Assertions.assertEquals(0, cc.size());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/apache/commons/collections4/functors/AbstractCompositePredicateTest.java
+++ b/src/test/java/org/apache/commons/collections4/functors/AbstractCompositePredicateTest.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.collections4.Predicate;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -84,7 +84,7 @@ public abstract class AbstractCompositePredicateTest<T> extends AbstractMockPred
     public void singleElementArrayToGetInstance() {
         final Predicate<T> predicate = createMockPredicate(null);
         final Predicate<T> allPredicate = getPredicateInstance(predicate);
-        Assert.assertSame("expected argument to be returned by getInstance()", predicate, allPredicate);
+        Assertions.assertSame(predicate, allPredicate, "expected argument to be returned by getInstance()");
     }
 
     /**
@@ -95,7 +95,7 @@ public abstract class AbstractCompositePredicateTest<T> extends AbstractMockPred
         final Predicate<T> predicate = createMockPredicate(null);
         final Predicate<T> allPredicate = getPredicateInstance(
                 Collections.<Predicate<T>>singleton(predicate));
-        Assert.assertSame("expected argument to be returned by getInstance()", predicate, allPredicate);
+        Assertions.assertSame(predicate, allPredicate, "expected argument to be returned by getInstance()");
     }
 
     /**
@@ -143,4 +143,5 @@ public abstract class AbstractCompositePredicateTest<T> extends AbstractMockPred
         coll.add(null);
         assertThrows(NullPointerException.class, () -> getPredicateInstance(coll));
     }
+
 }

--- a/src/test/java/org/apache/commons/collections4/functors/AbstractPredicateTest.java
+++ b/src/test/java/org/apache/commons/collections4/functors/AbstractPredicateTest.java
@@ -17,11 +17,12 @@
 package org.apache.commons.collections4.functors;
 
 import org.apache.commons.collections4.Predicate;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public abstract class AbstractPredicateTest {
+
     protected Object cObject;
     protected String cString;
     protected Integer cInteger;
@@ -36,7 +37,7 @@ public abstract class AbstractPredicateTest {
     @Test
     public void predicateSanityTests() throws Exception {
         final Predicate<?> predicate = generatePredicate();
-        Assert.assertNotNull(predicate);
+        Assertions.assertNotNull(predicate);
     }
 
     /**
@@ -45,10 +46,11 @@ public abstract class AbstractPredicateTest {
     protected abstract Predicate<?> generatePredicate();
 
     protected <T> void assertPredicateFalse(final Predicate<T> predicate, final T testObject) {
-        Assert.assertFalse(predicate.evaluate(testObject));
+        Assertions.assertFalse(predicate.evaluate(testObject));
     }
 
     protected <T> void assertPredicateTrue(final Predicate<T> predicate, final T testObject) {
-        Assert.assertTrue(predicate.evaluate(testObject));
+        Assertions.assertTrue(predicate.evaluate(testObject));
     }
+
 }

--- a/src/test/java/org/apache/commons/collections4/iterators/ArrayListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ArrayListIteratorTest.java
@@ -19,11 +19,10 @@ package org.apache.commons.collections4.iterators;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * Test the ArrayListIterator class.
- *
  */
 public class ArrayListIteratorTest<E> extends ArrayIteratorTest<E> {
 
@@ -100,7 +99,7 @@ public class ArrayListIteratorTest<E> extends ArrayIteratorTest<E> {
             x++;
         }
 
-        assertArrayEquals("The two arrays should have the same value, i.e. {0,1,2}", testData, result);
+        assertArrayEquals(testData, result, "The two arrays should have the same value, i.e. {0,1,2}");
 
         // a call to set() before a call to next() or previous() should throw an IllegalStateException
         iter = makeArrayListIterator(testArray);

--- a/src/test/java/org/apache/commons/collections4/iterators/FilterListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/FilterListIteratorTest.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests the FilterListIterator class.

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorEnumerationTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorEnumerationTest.java
@@ -21,7 +21,11 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests the IteratorEnumeration.

--- a/src/test/java/org/apache/commons/collections4/iterators/LoopingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/LoopingIteratorTest.java
@@ -23,7 +23,10 @@ import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests the LoopingIterator class.

--- a/src/test/java/org/apache/commons/collections4/iterators/LoopingListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/LoopingListIteratorTest.java
@@ -22,7 +22,11 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests the LoopingListIterator class.

--- a/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayListIteratorTest.java
@@ -19,11 +19,10 @@ package org.apache.commons.collections4.iterators;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * Tests the ObjectArrayListIterator class.
- *
  */
 public class ObjectArrayListIteratorTest<E> extends ObjectArrayIteratorTest<E> {
 
@@ -97,7 +96,7 @@ public class ObjectArrayListIteratorTest<E> extends ObjectArrayIteratorTest<E> {
             x++;
         }
 
-        assertArrayEquals("The two arrays should have the same value, i.e. {0,1,2}", testData, result);
+        assertArrayEquals(testData, result, "The two arrays should have the same value, i.e. {0,1,2}");
 
         // a call to set() before a call to next() or previous() should throw an IllegalStateException
         iter = makeArrayListIterator((E[]) testArray);

--- a/src/test/java/org/apache/commons/collections4/keyvalue/AbstractMapEntryTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/AbstractMapEntryTest.java
@@ -20,7 +20,12 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Abstract tests that can be extended to test any Map.Entry implementation.

--- a/src/test/java/org/apache/commons/collections4/keyvalue/DefaultKeyValueTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/DefaultKeyValueTest.java
@@ -21,7 +21,11 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test the DefaultKeyValue class.

--- a/src/test/java/org/apache/commons/collections4/keyvalue/DefaultMapEntryTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/DefaultMapEntryTest.java
@@ -21,7 +21,8 @@ import java.util.Map;
 import org.apache.commons.collections4.KeyValue;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test the DefaultMapEntry class.

--- a/src/test/java/org/apache/commons/collections4/keyvalue/MultiKeyTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/MultiKeyTest.java
@@ -27,7 +27,14 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit tests for {@link org.apache.commons.collections4.keyvalue.MultiKey}.

--- a/src/test/java/org/apache/commons/collections4/keyvalue/TiedMapEntryTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/TiedMapEntryTest.java
@@ -20,7 +20,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Test the TiedMapEntry class.

--- a/src/test/java/org/apache/commons/collections4/keyvalue/UnmodifiableMapEntryTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/UnmodifiableMapEntryTest.java
@@ -22,7 +22,9 @@ import org.apache.commons.collections4.KeyValue;
 import org.apache.commons.collections4.Unmodifiable;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test the UnmodifiableMapEntry class.

--- a/src/test/java/org/apache/commons/collections4/list/Collections701Test.java
+++ b/src/test/java/org/apache/commons/collections4/list/Collections701Test.java
@@ -21,8 +21,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Tests for COLLECTIONS-701.
@@ -33,16 +33,16 @@ public class Collections701Test {
     public void testArrayList() {
         final List<Object> list = new ArrayList<>();
         list.add(list);
-        Assert.assertEquals(1, list.size());
-        Assert.assertEquals(list, list.get(0));
+        Assertions.assertEquals(1, list.size());
+        Assertions.assertEquals(list, list.get(0));
     }
 
     @Test
     public void testHashSet() {
         final Set<Object> set = new HashSet<>();
         set.add(set);
-        Assert.assertEquals(1, set.size());
-        Assert.assertEquals(set, set.iterator().next());
+        Assertions.assertEquals(1, set.size());
+        Assertions.assertEquals(set, set.iterator().next());
     }
 
     @Test
@@ -50,7 +50,8 @@ public class Collections701Test {
         final List<Object> source = new ArrayList<>();
         final List<Object> list = SetUniqueList.setUniqueList(source);
         list.add(list);
-        Assert.assertEquals(1, list.size());
-        Assert.assertEquals(list, list.get(0));
+        Assertions.assertEquals(1, list.size());
+        Assertions.assertEquals(list, list.get(0));
     }
+
 }

--- a/src/test/java/org/apache/commons/collections4/list/FixedSizeListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/FixedSizeListTest.java
@@ -16,11 +16,11 @@
  */
 package org.apache.commons.collections4.list;
 
-import org.junit.Assert;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
 
 /**
  * Extension of {@link AbstractListTest} for exercising the {@link FixedSizeList}
@@ -77,10 +77,10 @@ public class FixedSizeListTest<E> extends AbstractListTest<E> {
         final int sizeBefore = fixedSizeList.size();
         //
         final boolean changed = decoratedList.add("New Value");
-        Assert.assertTrue(changed);
+        Assertions.assertTrue(changed);
         //
-        Assert.assertEquals("Modifying an the underlying list is allowed",
-                sizeBefore + 1, fixedSizeList.size());
+        Assertions.assertEquals(sizeBefore + 1, fixedSizeList.size(),
+                "Modifying an the underlying list is allowed");
     }
 
     private FixedSizeList<String> initFixedSizeList() {
@@ -127,19 +127,20 @@ public class FixedSizeListTest<E> extends AbstractListTest<E> {
         final FixedSizeList<String> fixedSizeList = initFixedSizeList();
 
         final List<String> subFixedSizeList = fixedSizeList.subList(1, 1);
-        Assert.assertNotNull(subFixedSizeList);
-        Assert.assertEquals(0, subFixedSizeList.size());
+        Assertions.assertNotNull(subFixedSizeList);
+        Assertions.assertEquals(0, subFixedSizeList.size());
     }
 
     public void testIsFull() {
         final FixedSizeList<String> fixedSizeList = initFixedSizeList();
 
-        Assert.assertTrue(fixedSizeList.isFull());
+        Assertions.assertTrue(fixedSizeList.isFull());
     }
 
     public void testMaxSize() {
         final FixedSizeList<String> fixedSizeList = initFixedSizeList();
 
-        Assert.assertEquals(2, fixedSizeList.maxSize());
+        Assertions.assertEquals(2, fixedSizeList.maxSize());
     }
+
 }

--- a/src/test/java/org/apache/commons/collections4/properties/AbstractPropertiesFactoryTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/AbstractPropertiesFactoryTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.commons.collections4.properties;
 
 import java.io.BufferedReader;
@@ -24,9 +23,9 @@ import java.nio.file.Paths;
 import java.util.Properties;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -51,17 +50,17 @@ public abstract class AbstractPropertiesFactoryTest<T extends Properties> {
     }
 
     private void assertContents(final T properties) {
-        Assert.assertEquals("value1", properties.getProperty("key1"));
-        Assert.assertEquals("value2", properties.getProperty("key2"));
-        Assert.assertEquals("value3", properties.getProperty("key3"));
-        Assert.assertEquals("value4", properties.getProperty("key4"));
-        Assert.assertEquals("value5", properties.getProperty("key5"));
-        Assert.assertEquals("value6", properties.getProperty("key6"));
-        Assert.assertEquals("value7", properties.getProperty("key7"));
-        Assert.assertEquals("value8", properties.getProperty("key8"));
-        Assert.assertEquals("value9", properties.getProperty("key9"));
-        Assert.assertEquals("value10", properties.getProperty("key10"));
-        Assert.assertEquals("value11", properties.getProperty("key11"));
+        Assertions.assertEquals("value1", properties.getProperty("key1"));
+        Assertions.assertEquals("value2", properties.getProperty("key2"));
+        Assertions.assertEquals("value3", properties.getProperty("key3"));
+        Assertions.assertEquals("value4", properties.getProperty("key4"));
+        Assertions.assertEquals("value5", properties.getProperty("key5"));
+        Assertions.assertEquals("value6", properties.getProperty("key6"));
+        Assertions.assertEquals("value7", properties.getProperty("key7"));
+        Assertions.assertEquals("value8", properties.getProperty("key8"));
+        Assertions.assertEquals("value9", properties.getProperty("key9"));
+        Assertions.assertEquals("value10", properties.getProperty("key10"));
+        Assertions.assertEquals("value11", properties.getProperty("key11"));
     }
 
     private boolean isXmlTest() {
@@ -70,12 +69,12 @@ public abstract class AbstractPropertiesFactoryTest<T extends Properties> {
 
     @Test
     public void testInstance() {
-        Assert.assertNotNull(PropertiesFactory.INSTANCE);
+        Assertions.assertNotNull(PropertiesFactory.INSTANCE);
     }
 
     @Test
     public void testLoadClassLoaderMissingResource() throws Exception {
-        Assert.assertNull(factory.load(ClassLoader.getSystemClassLoader(), "missing/test" + fileExtension));
+        Assertions.assertNull(factory.load(ClassLoader.getSystemClassLoader(), "missing/test" + fileExtension));
     }
 
     @Test
@@ -127,4 +126,5 @@ public abstract class AbstractPropertiesFactoryTest<T extends Properties> {
     public void testLoadUrl() throws Exception {
         assertContents(factory.load(Paths.get(pathString).toUri().toURL()));
     }
+
 }

--- a/src/test/java/org/apache/commons/collections4/properties/PropertiesFactoryTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/PropertiesFactoryTest.java
@@ -19,8 +19,8 @@ package org.apache.commons.collections4.properties;
 
 import java.util.Properties;
 
-import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 public class PropertiesFactoryTest extends AbstractPropertiesFactoryTest<Properties> {
 
@@ -31,6 +31,7 @@ public class PropertiesFactoryTest extends AbstractPropertiesFactoryTest<Propert
     @Override
     @Test
     public void testInstance() {
-        Assert.assertNotNull(PropertiesFactory.INSTANCE);
+        Assertions.assertNotNull(PropertiesFactory.INSTANCE);
     }
+
 }

--- a/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesFactoryTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesFactoryTest.java
@@ -14,11 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.commons.collections4.properties;
 
-import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 public class SortedPropertiesFactoryTest extends AbstractPropertiesFactoryTest<SortedProperties> {
 
@@ -29,6 +28,7 @@ public class SortedPropertiesFactoryTest extends AbstractPropertiesFactoryTest<S
     @Override
     @Test
     public void testInstance() {
-        Assert.assertNotNull(SortedPropertiesFactory.INSTANCE);
+        Assertions.assertNotNull(SortedPropertiesFactory.INSTANCE);
     }
+
 }

--- a/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesTest.java
@@ -14,15 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.commons.collections4.properties;
 
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 public class SortedPropertiesTest {
 
@@ -35,8 +34,8 @@ public class SortedPropertiesTest {
         final Iterator<Map.Entry<Object, Object>> entries = sortedProperties.entrySet().iterator();
         for (char ch = 'A'; ch <= 'Z'; ch++) {
             final Map.Entry<Object, Object> entry = entries.next();
-            Assert.assertEquals(String.valueOf(ch), entry.getKey());
-            Assert.assertEquals("Value" + ch, entry.getValue());
+            Assertions.assertEquals(String.valueOf(ch), entry.getKey());
+            Assertions.assertEquals("Value" + ch, entry.getValue());
         }
     }
 
@@ -48,7 +47,8 @@ public class SortedPropertiesTest {
         }
         final Enumeration<Object> keys = sortedProperties.keys();
         for (char ch = 'A'; ch <= 'Z'; ch++) {
-            Assert.assertEquals(String.valueOf(ch), keys.nextElement());
+            Assertions.assertEquals(String.valueOf(ch), keys.nextElement());
         }
     }
+
 }

--- a/src/test/java/org/apache/commons/collections4/trie/PatriciaTrieTest.java
+++ b/src/test/java/org/apache/commons/collections4/trie/PatriciaTrieTest.java
@@ -31,7 +31,7 @@ import junit.framework.Test;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Trie;
 import org.apache.commons.collections4.map.AbstractSortedMapTest;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 
 /**
  * JUnit tests for the PatriciaTrie.
@@ -80,210 +80,210 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
         Map.Entry<String, String> entry;
 
         map = trie.prefixMap("Al");
-        Assert.assertEquals(8, map.size());
-        Assert.assertEquals("Alabama", map.firstKey());
-        Assert.assertEquals("Alliese", map.lastKey());
-        Assert.assertEquals("Albertoo", map.get("Albertoo"));
-        Assert.assertNotNull(trie.get("Xavier"));
-        Assert.assertNull(map.get("Xavier"));
-        Assert.assertNull(trie.get("Alice"));
-        Assert.assertNull(map.get("Alice"));
+        Assertions.assertEquals(8, map.size());
+        Assertions.assertEquals("Alabama", map.firstKey());
+        Assertions.assertEquals("Alliese", map.lastKey());
+        Assertions.assertEquals("Albertoo", map.get("Albertoo"));
+        Assertions.assertNotNull(trie.get("Xavier"));
+        Assertions.assertNull(map.get("Xavier"));
+        Assertions.assertNull(trie.get("Alice"));
+        Assertions.assertNull(map.get("Alice"));
         iterator = map.values().iterator();
-        Assert.assertEquals("Alabama", iterator.next());
-        Assert.assertEquals("Albert", iterator.next());
-        Assert.assertEquals("Alberto", iterator.next());
-        Assert.assertEquals("Albertoo", iterator.next());
-        Assert.assertEquals("Alberts", iterator.next());
-        Assert.assertEquals("Alien", iterator.next());
-        Assert.assertEquals("Allie", iterator.next());
-        Assert.assertEquals("Alliese", iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        Assertions.assertEquals("Alabama", iterator.next());
+        Assertions.assertEquals("Albert", iterator.next());
+        Assertions.assertEquals("Alberto", iterator.next());
+        Assertions.assertEquals("Albertoo", iterator.next());
+        Assertions.assertEquals("Alberts", iterator.next());
+        Assertions.assertEquals("Alien", iterator.next());
+        Assertions.assertEquals("Allie", iterator.next());
+        Assertions.assertEquals("Alliese", iterator.next());
+        Assertions.assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("Albert");
         iterator = map.keySet().iterator();
-        Assert.assertEquals("Albert", iterator.next());
-        Assert.assertEquals("Alberto", iterator.next());
-        Assert.assertEquals("Albertoo", iterator.next());
-        Assert.assertEquals("Alberts", iterator.next());
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals(4, map.size());
-        Assert.assertEquals("Albert", map.firstKey());
-        Assert.assertEquals("Alberts", map.lastKey());
-        Assert.assertNull(trie.get("Albertz"));
+        Assertions.assertEquals("Albert", iterator.next());
+        Assertions.assertEquals("Alberto", iterator.next());
+        Assertions.assertEquals("Albertoo", iterator.next());
+        Assertions.assertEquals("Alberts", iterator.next());
+        Assertions.assertFalse(iterator.hasNext());
+        Assertions.assertEquals(4, map.size());
+        Assertions.assertEquals("Albert", map.firstKey());
+        Assertions.assertEquals("Alberts", map.lastKey());
+        Assertions.assertNull(trie.get("Albertz"));
         map.put("Albertz", "Albertz");
-        Assert.assertEquals("Albertz", trie.get("Albertz"));
-        Assert.assertEquals(5, map.size());
-        Assert.assertEquals("Albertz", map.lastKey());
+        Assertions.assertEquals("Albertz", trie.get("Albertz"));
+        Assertions.assertEquals(5, map.size());
+        Assertions.assertEquals("Albertz", map.lastKey());
         iterator = map.keySet().iterator();
-        Assert.assertEquals("Albert", iterator.next());
-        Assert.assertEquals("Alberto", iterator.next());
-        Assert.assertEquals("Albertoo", iterator.next());
-        Assert.assertEquals("Alberts", iterator.next());
-        Assert.assertEquals("Albertz", iterator.next());
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals("Albertz", map.remove("Albertz"));
+        Assertions.assertEquals("Albert", iterator.next());
+        Assertions.assertEquals("Alberto", iterator.next());
+        Assertions.assertEquals("Albertoo", iterator.next());
+        Assertions.assertEquals("Alberts", iterator.next());
+        Assertions.assertEquals("Albertz", iterator.next());
+        Assertions.assertFalse(iterator.hasNext());
+        Assertions.assertEquals("Albertz", map.remove("Albertz"));
 
         map = trie.prefixMap("Alberto");
-        Assert.assertEquals(2, map.size());
-        Assert.assertEquals("Alberto", map.firstKey());
-        Assert.assertEquals("Albertoo", map.lastKey());
+        Assertions.assertEquals(2, map.size());
+        Assertions.assertEquals("Alberto", map.firstKey());
+        Assertions.assertEquals("Albertoo", map.lastKey());
         entryIterator = map.entrySet().iterator();
         entry = entryIterator.next();
-        Assert.assertEquals("Alberto", entry.getKey());
-        Assert.assertEquals("Alberto", entry.getValue());
+        Assertions.assertEquals("Alberto", entry.getKey());
+        Assertions.assertEquals("Alberto", entry.getValue());
         entry = entryIterator.next();
-        Assert.assertEquals("Albertoo", entry.getKey());
-        Assert.assertEquals("Albertoo", entry.getValue());
-        Assert.assertFalse(entryIterator.hasNext());
+        Assertions.assertEquals("Albertoo", entry.getKey());
+        Assertions.assertEquals("Albertoo", entry.getValue());
+        Assertions.assertFalse(entryIterator.hasNext());
         trie.put("Albertoad", "Albertoad");
-        Assert.assertEquals(3, map.size());
-        Assert.assertEquals("Alberto", map.firstKey());
-        Assert.assertEquals("Albertoo", map.lastKey());
+        Assertions.assertEquals(3, map.size());
+        Assertions.assertEquals("Alberto", map.firstKey());
+        Assertions.assertEquals("Albertoo", map.lastKey());
         entryIterator = map.entrySet().iterator();
         entry = entryIterator.next();
-        Assert.assertEquals("Alberto", entry.getKey());
-        Assert.assertEquals("Alberto", entry.getValue());
+        Assertions.assertEquals("Alberto", entry.getKey());
+        Assertions.assertEquals("Alberto", entry.getValue());
         entry = entryIterator.next();
-        Assert.assertEquals("Albertoad", entry.getKey());
-        Assert.assertEquals("Albertoad", entry.getValue());
+        Assertions.assertEquals("Albertoad", entry.getKey());
+        Assertions.assertEquals("Albertoad", entry.getValue());
         entry = entryIterator.next();
-        Assert.assertEquals("Albertoo", entry.getKey());
-        Assert.assertEquals("Albertoo", entry.getValue());
-        Assert.assertFalse(entryIterator.hasNext());
-        Assert.assertEquals("Albertoo", trie.remove("Albertoo"));
-        Assert.assertEquals("Alberto", map.firstKey());
-        Assert.assertEquals("Albertoad", map.lastKey());
-        Assert.assertEquals(2, map.size());
+        Assertions.assertEquals("Albertoo", entry.getKey());
+        Assertions.assertEquals("Albertoo", entry.getValue());
+        Assertions.assertFalse(entryIterator.hasNext());
+        Assertions.assertEquals("Albertoo", trie.remove("Albertoo"));
+        Assertions.assertEquals("Alberto", map.firstKey());
+        Assertions.assertEquals("Albertoad", map.lastKey());
+        Assertions.assertEquals(2, map.size());
         entryIterator = map.entrySet().iterator();
         entry = entryIterator.next();
-        Assert.assertEquals("Alberto", entry.getKey());
-        Assert.assertEquals("Alberto", entry.getValue());
+        Assertions.assertEquals("Alberto", entry.getKey());
+        Assertions.assertEquals("Alberto", entry.getValue());
         entry = entryIterator.next();
-        Assert.assertEquals("Albertoad", entry.getKey());
-        Assert.assertEquals("Albertoad", entry.getValue());
-        Assert.assertFalse(entryIterator.hasNext());
-        Assert.assertEquals("Albertoad", trie.remove("Albertoad"));
+        Assertions.assertEquals("Albertoad", entry.getKey());
+        Assertions.assertEquals("Albertoad", entry.getValue());
+        Assertions.assertFalse(entryIterator.hasNext());
+        Assertions.assertEquals("Albertoad", trie.remove("Albertoad"));
         trie.put("Albertoo", "Albertoo");
 
         map = trie.prefixMap("X");
-        Assert.assertEquals(2, map.size());
-        Assert.assertFalse(map.containsKey("Albert"));
-        Assert.assertTrue(map.containsKey("Xavier"));
-        Assert.assertFalse(map.containsKey("Xalan"));
+        Assertions.assertEquals(2, map.size());
+        Assertions.assertFalse(map.containsKey("Albert"));
+        Assertions.assertTrue(map.containsKey("Xavier"));
+        Assertions.assertFalse(map.containsKey("Xalan"));
         iterator = map.values().iterator();
-        Assert.assertEquals("Xavier", iterator.next());
-        Assert.assertEquals("XyZ", iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        Assertions.assertEquals("Xavier", iterator.next());
+        Assertions.assertEquals("XyZ", iterator.next());
+        Assertions.assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("An");
-        Assert.assertEquals(1, map.size());
-        Assert.assertEquals("Anna", map.firstKey());
-        Assert.assertEquals("Anna", map.lastKey());
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertEquals("Anna", map.firstKey());
+        Assertions.assertEquals("Anna", map.lastKey());
         iterator = map.keySet().iterator();
-        Assert.assertEquals("Anna", iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        Assertions.assertEquals("Anna", iterator.next());
+        Assertions.assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("Ban");
-        Assert.assertEquals(1, map.size());
-        Assert.assertEquals("Banane", map.firstKey());
-        Assert.assertEquals("Banane", map.lastKey());
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertEquals("Banane", map.firstKey());
+        Assertions.assertEquals("Banane", map.lastKey());
         iterator = map.keySet().iterator();
-        Assert.assertEquals("Banane", iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        Assertions.assertEquals("Banane", iterator.next());
+        Assertions.assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("Am");
-        Assert.assertFalse(map.isEmpty());
-        Assert.assertEquals(3, map.size());
-        Assert.assertEquals("Amber", trie.remove("Amber"));
+        Assertions.assertFalse(map.isEmpty());
+        Assertions.assertEquals(3, map.size());
+        Assertions.assertEquals("Amber", trie.remove("Amber"));
         iterator = map.keySet().iterator();
-        Assert.assertEquals("Amma", iterator.next());
-        Assert.assertEquals("Ammun", iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        Assertions.assertEquals("Amma", iterator.next());
+        Assertions.assertEquals("Ammun", iterator.next());
+        Assertions.assertFalse(iterator.hasNext());
         iterator = map.keySet().iterator();
         map.put("Amber", "Amber");
-        Assert.assertEquals(3, map.size());
+        Assertions.assertEquals(3, map.size());
         try {
             iterator.next();
-            Assert.fail("CME expected");
+            Assertions.fail("CME expected");
         } catch(final ConcurrentModificationException expected) {}
-        Assert.assertEquals("Amber", map.firstKey());
-        Assert.assertEquals("Ammun", map.lastKey());
+        Assertions.assertEquals("Amber", map.firstKey());
+        Assertions.assertEquals("Ammun", map.lastKey());
 
         map = trie.prefixMap("Ak\0");
-        Assert.assertTrue(map.isEmpty());
+        Assertions.assertTrue(map.isEmpty());
 
         map = trie.prefixMap("Ak");
-        Assert.assertEquals(2, map.size());
-        Assert.assertEquals("Akka", map.firstKey());
-        Assert.assertEquals("Akko", map.lastKey());
+        Assertions.assertEquals(2, map.size());
+        Assertions.assertEquals("Akka", map.firstKey());
+        Assertions.assertEquals("Akko", map.lastKey());
         map.put("Ak", "Ak");
-        Assert.assertEquals("Ak", map.firstKey());
-        Assert.assertEquals("Akko", map.lastKey());
-        Assert.assertEquals(3, map.size());
+        Assertions.assertEquals("Ak", map.firstKey());
+        Assertions.assertEquals("Akko", map.lastKey());
+        Assertions.assertEquals(3, map.size());
         trie.put("Al", "Al");
-        Assert.assertEquals(3, map.size());
-        Assert.assertEquals("Ak", map.remove("Ak"));
-        Assert.assertEquals("Akka", map.firstKey());
-        Assert.assertEquals("Akko", map.lastKey());
-        Assert.assertEquals(2, map.size());
+        Assertions.assertEquals(3, map.size());
+        Assertions.assertEquals("Ak", map.remove("Ak"));
+        Assertions.assertEquals("Akka", map.firstKey());
+        Assertions.assertEquals("Akko", map.lastKey());
+        Assertions.assertEquals(2, map.size());
         iterator = map.keySet().iterator();
-        Assert.assertEquals("Akka", iterator.next());
-        Assert.assertEquals("Akko", iterator.next());
-        Assert.assertFalse(iterator.hasNext());
-        Assert.assertEquals("Al", trie.remove("Al"));
+        Assertions.assertEquals("Akka", iterator.next());
+        Assertions.assertEquals("Akko", iterator.next());
+        Assertions.assertFalse(iterator.hasNext());
+        Assertions.assertEquals("Al", trie.remove("Al"));
 
         map = trie.prefixMap("Akka");
-        Assert.assertEquals(1, map.size());
-        Assert.assertEquals("Akka", map.firstKey());
-        Assert.assertEquals("Akka", map.lastKey());
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertEquals("Akka", map.firstKey());
+        Assertions.assertEquals("Akka", map.lastKey());
         iterator = map.keySet().iterator();
-        Assert.assertEquals("Akka", iterator.next());
-        Assert.assertFalse(iterator.hasNext());
+        Assertions.assertEquals("Akka", iterator.next());
+        Assertions.assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("Ab");
-        Assert.assertTrue(map.isEmpty());
-        Assert.assertEquals(0, map.size());
+        Assertions.assertTrue(map.isEmpty());
+        Assertions.assertEquals(0, map.size());
         try {
             final Object o = map.firstKey();
-            Assert.fail("got a first key: " + o);
+            Assertions.fail("got a first key: " + o);
         } catch(final NoSuchElementException nsee) {}
         try {
             final Object o = map.lastKey();
-            Assert.fail("got a last key: " + o);
+            Assertions.fail("got a last key: " + o);
         } catch(final NoSuchElementException nsee) {}
         iterator = map.values().iterator();
-        Assert.assertFalse(iterator.hasNext());
+        Assertions.assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("Albertooo");
-        Assert.assertTrue(map.isEmpty());
-        Assert.assertEquals(0, map.size());
+        Assertions.assertTrue(map.isEmpty());
+        Assertions.assertEquals(0, map.size());
         try {
             final Object o = map.firstKey();
-            Assert.fail("got a first key: " + o);
+            Assertions.fail("got a first key: " + o);
         } catch(final NoSuchElementException nsee) {}
         try {
             final Object o = map.lastKey();
-            Assert.fail("got a last key: " + o);
+            Assertions.fail("got a last key: " + o);
         } catch(final NoSuchElementException nsee) {}
         iterator = map.values().iterator();
-        Assert.assertFalse(iterator.hasNext());
+        Assertions.assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("");
-        Assert.assertSame(trie, map); // stricter than necessary, but a good check
+        Assertions.assertSame(trie, map); // stricter than necessary, but a good check
 
         map = trie.prefixMap("\0");
-        Assert.assertTrue(map.isEmpty());
-        Assert.assertEquals(0, map.size());
+        Assertions.assertTrue(map.isEmpty());
+        Assertions.assertEquals(0, map.size());
         try {
             final Object o = map.firstKey();
-            Assert.fail("got a first key: " + o);
+            Assertions.fail("got a first key: " + o);
         } catch(final NoSuchElementException nsee) {}
         try {
             final Object o = map.lastKey();
-            Assert.fail("got a last key: " + o);
+            Assertions.fail("got a last key: " + o);
         } catch(final NoSuchElementException nsee) {}
         iterator = map.values().iterator();
-        Assert.assertFalse(iterator.hasNext());
+        Assertions.assertFalse(iterator.hasNext());
     }
 
     public void testPrefixMapRemoval() {
@@ -301,31 +301,31 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
         }
 
         SortedMap<String, String> map = trie.prefixMap("Al");
-        Assert.assertEquals(8, map.size());
+        Assertions.assertEquals(8, map.size());
         Iterator<String> iter = map.keySet().iterator();
-        Assert.assertEquals("Alabama", iter.next());
-        Assert.assertEquals("Albert", iter.next());
-        Assert.assertEquals("Alberto", iter.next());
-        Assert.assertEquals("Albertoo", iter.next());
-        Assert.assertEquals("Alberts", iter.next());
-        Assert.assertEquals("Alien", iter.next());
+        Assertions.assertEquals("Alabama", iter.next());
+        Assertions.assertEquals("Albert", iter.next());
+        Assertions.assertEquals("Alberto", iter.next());
+        Assertions.assertEquals("Albertoo", iter.next());
+        Assertions.assertEquals("Alberts", iter.next());
+        Assertions.assertEquals("Alien", iter.next());
         iter.remove();
-        Assert.assertEquals(7, map.size());
-        Assert.assertEquals("Allie", iter.next());
-        Assert.assertEquals("Alliese", iter.next());
-        Assert.assertFalse(iter.hasNext());
+        Assertions.assertEquals(7, map.size());
+        Assertions.assertEquals("Allie", iter.next());
+        Assertions.assertEquals("Alliese", iter.next());
+        Assertions.assertFalse(iter.hasNext());
 
         map = trie.prefixMap("Ak");
-        Assert.assertEquals(2, map.size());
+        Assertions.assertEquals(2, map.size());
         iter = map.keySet().iterator();
-        Assert.assertEquals("Akka", iter.next());
+        Assertions.assertEquals("Akka", iter.next());
         iter.remove();
-        Assert.assertEquals(1, map.size());
-        Assert.assertEquals("Akko", iter.next());
+        Assertions.assertEquals(1, map.size());
+        Assertions.assertEquals("Akko", iter.next());
         if (iter.hasNext()) {
-            Assert.fail("shouldn't have next (but was: " + iter.next() + ")");
+            Assertions.fail("shouldn't have next (but was: " + iter.next() + ")");
         }
-        Assert.assertFalse(iter.hasNext());
+        Assertions.assertFalse(iter.hasNext());
     }
 
     public void testPrefixMapSizes() {
@@ -442,4 +442,5 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
 //            (java.io.Serializable) map,
 //            "src/test/resources/data/test/PatriciaTrie.fullCollection.version4.obj");
 //    }
+
 }


### PR DESCRIPTION
Upgrade JUnit v4 Assert to JUnit v5 Assertions.
Any class extending a TestCase will use Assertions.assert...(
Any class not extending a TestCase will use static imports.  