### PR TITLE
COLLECTIONS-777 JUnit v5 assertThrows no3

### DIFF
--- a/src/test/java/org/apache/commons/collections4/ArrayStackTest.java
+++ b/src/test/java/org/apache/commons/collections4/ArrayStackTest.java
@@ -16,13 +16,14 @@
  */
 package org.apache.commons.collections4;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.EmptyStackException;
 
 import junit.framework.Test;
 
 /**
  * Tests ArrayStack.
- *
  */
 @SuppressWarnings("deprecation") // we test a deprecated class
 public class ArrayStackTest<E> extends AbstractArrayListTest<E> {
@@ -45,20 +46,9 @@ public class ArrayStackTest<E> extends AbstractArrayListTest<E> {
         assertTrue("New stack is empty", stack.empty());
         assertEquals("New stack has size zero", 0, stack.size());
 
-        try {
-            stack.peek();
-            fail("peek() should have thrown EmptyStackException");
-        } catch (final EmptyStackException e) {
-            // Expected result
-        }
+        assertThrows(EmptyStackException.class, () -> stack.peek());
 
-        try {
-            stack.pop();
-            fail("pop() should have thrown EmptyStackException");
-        } catch (final EmptyStackException e) {
-            // Expected result
-        }
-
+        assertThrows(EmptyStackException.class, () -> stack.pop());
     }
 
     @SuppressWarnings("unchecked")
@@ -87,7 +77,6 @@ public class ArrayStackTest<E> extends AbstractArrayListTest<E> {
         assertEquals("Popped item is 'First Item'",
                      "First Item", (String) stack.pop());
         assertEquals("Stack size is zero", 0, stack.size());
-
     }
 
     @Override
@@ -103,7 +92,6 @@ public class ArrayStackTest<E> extends AbstractArrayListTest<E> {
                      2, stack.search("First Item"));
         assertEquals("Cannot find 'Missing Item'",
                      -1, stack.search("Missing Item"));
-
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/EnumerationUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/EnumerationUtilsTest.java
@@ -17,9 +17,9 @@
 package org.apache.commons.collections4;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Enumeration;
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests EnumerationUtils.
- *
  */
 public class EnumerationUtilsTest {
 
@@ -51,12 +50,9 @@ public class EnumerationUtilsTest {
         assertEquals("one", EnumerationUtils.get(en, 1));
 
         // Enumerator, non-existent entry
-        try {
-            EnumerationUtils.get(en, 3);
-            fail("Expecting IndexOutOfBoundsException.");
-        } catch (final IndexOutOfBoundsException e) {
-            // expected
-        }
+        Enumeration<String> finalEn = en;
+        assertThrows(IndexOutOfBoundsException.class, () -> EnumerationUtils.get(finalEn, 3));
+
         assertFalse(en.hasMoreElements());
     }
 
@@ -76,12 +72,7 @@ public class EnumerationUtilsTest {
 
     @Test
     public void testAsIterableForNull() {
-        try {
-            EnumerationUtils.asIterable((Enumeration) null).iterator().next();
-            fail("Expecting NullPointerException");
-        } catch (final NullPointerException ex) {
-            // success
-        }
+        assertThrows(NullPointerException.class, () -> EnumerationUtils.asIterable((Enumeration) null).iterator().next());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/MultiMapUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/MultiMapUtilsTest.java
@@ -19,8 +19,8 @@ package org.apache.commons.collections4;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,22 +43,16 @@ public class MultiMapUtilsTest {
     public void testEmptyUnmodifiableMultiValuedMap() {
         final MultiValuedMap map = MultiMapUtils.EMPTY_MULTI_VALUED_MAP;
         assertTrue(map.isEmpty());
-        try {
-            map.put("key", "value");
-            fail("Should throw UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+
+        assertThrows(UnsupportedOperationException.class, () -> map.put("key", "value"));
     }
 
     @Test
     public void testTypeSafeEmptyMultiValuedMap() {
         final MultiValuedMap<String, String> map = MultiMapUtils.<String, String>emptyMultiValuedMap();
         assertTrue(map.isEmpty());
-        try {
-            map.put("key", "value");
-            fail("Should throw UnsupportedOperationException");
-        } catch (final UnsupportedOperationException e) {
-        }
+
+        assertThrows(UnsupportedOperationException.class, () -> map.put("key", "value"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/PredicateUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/PredicateUtilsTest.java
@@ -23,7 +23,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,16 +57,10 @@ public class PredicateUtilsTest extends AbstractPredicateTest {
     public void testExceptionPredicate() {
         assertNotNull(PredicateUtils.exceptionPredicate());
         assertSame(PredicateUtils.exceptionPredicate(), PredicateUtils.exceptionPredicate());
-        try {
-            PredicateUtils.exceptionPredicate().evaluate(null);
-        } catch (final FunctorException ex) {
-            try {
-                PredicateUtils.exceptionPredicate().evaluate(cString);
-            } catch (final FunctorException ex2) {
-                return;
-            }
-        }
-        fail();
+
+        assertThrows(FunctorException.class, () -> PredicateUtils.exceptionPredicate().evaluate(null));
+
+        assertThrows(FunctorException.class, () -> PredicateUtils.exceptionPredicate().evaluate(cString));
     }
 
     // notNullPredicate
@@ -666,10 +659,8 @@ public class PredicateUtilsTest extends AbstractPredicateTest {
         final Predicate<Object> p = EqualPredicate.<Object>equalPredicate("Hello");
         assertFalse(PredicateUtils.transformedPredicate(t, p).evaluate(null));
         assertTrue(PredicateUtils.transformedPredicate(t, p).evaluate(Boolean.TRUE));
-        try {
-            PredicateUtils.transformedPredicate(null, null);
-            fail();
-        } catch (final NullPointerException ex) {}
+
+        assertThrows(NullPointerException.class, () -> PredicateUtils.transformedPredicate(null, null));
     }
 
     // misc tests
@@ -701,6 +692,5 @@ public class PredicateUtilsTest extends AbstractPredicateTest {
     protected Predicate<?> generatePredicate() {
         return truePredicate();  //Just return something to satisfy super class.
     }
+
 }
-
-

--- a/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
@@ -34,6 +34,7 @@ import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.set.AbstractSetTest;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Abstract test class for {@link org.apache.commons.collections4.Bag Bag} methods and contracts.
@@ -59,7 +60,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  * interface (prefix testBag). For Bag specific tests use the {@link #makeObject()} and
  * {@link #makeFullCollection()} methods instead of {@link #resetEmpty()} and resetFull(),
  * otherwise the collection will be wrapped by a {@link CollectionBag} decorator.
- *
  */
 public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
 
@@ -107,7 +107,6 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         bag.addAll(Arrays.asList(getFullElements()));
         return bag;
     }
-
 
     @Override
     public void resetEmpty() {
@@ -379,12 +378,8 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         final Iterator<T> it = bag.iterator();
         it.next();
         bag.remove("A");
-        try {
-            it.next();
-            fail("Should throw ConcurrentModificationException");
-        } catch (final ConcurrentModificationException e) {
-            // expected
-        }
+
+        assertThrows(ConcurrentModificationException.class, () -> it.next());
     }
 
     @SuppressWarnings("unchecked")
@@ -401,12 +396,8 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         it.next();
         it.next();
         it.next();
-        try {
-            it.next();
-            fail("Should throw NoSuchElementException");
-        } catch (final NoSuchElementException ex) {
-            // expected
-        }
+
+        assertThrows(NoSuchElementException.class, () -> it.next());
     }
 
     @SuppressWarnings("unchecked")
@@ -425,12 +416,9 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals(3, bag.size());
         it.remove();
         assertEquals(2, bag.size());
-        try {
-            it.remove();
-            fail("Should throw IllegalStateException");
-        } catch (final IllegalStateException ex) {
-            // expected
-        }
+
+        assertThrows(IllegalStateException.class, () -> it.remove());
+
         assertEquals(2, bag.size());
         it.next();
         it.remove();
@@ -590,7 +578,6 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals(total, bag2.hashCode());
     }
 
-
     /**
      * Bulk test {@link Bag#uniqueSet()}.  This method runs through all of
      * the tests in {@link AbstractSetTest}.
@@ -604,6 +591,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
     }
 
     public class TestBagUniqueSet extends AbstractSetTest<T> {
+
         public TestBagUniqueSet() {
             super("");
         }
@@ -666,8 +654,8 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         public void verify() {
             super.verify();
         }
-    }
 
+    }
 
     /**
      * Compare the current serialized form of the Bag
@@ -696,4 +684,5 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
             assertEquals(bag, bag2);
         }
     }
+
 }

--- a/src/test/java/org/apache/commons/collections4/bag/PredicatedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/PredicatedBagTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Set;
 
 import junit.framework.Test;
@@ -85,12 +87,9 @@ public class PredicatedBagTest<T> extends AbstractBagTest<T> {
     public void testIllegalAdd() {
         final Bag<T> bag = makeTestBag();
         final Integer i = 3;
-        try {
-            bag.add((T) i);
-            fail("Integer should fail string predicate.");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
+
+        assertThrows(IllegalArgumentException.class, () -> bag.add((T) i));
+
         assertFalse("Collection shouldn't contain illegal element", bag.contains(i));
     }
 
@@ -101,18 +100,10 @@ public class PredicatedBagTest<T> extends AbstractBagTest<T> {
         elements.add("two");
         elements.add(3);
         elements.add("four");
-        try {
-            decorateBag((HashBag<T>) elements, stringPredicate());
-            fail("Bag contains an element that should fail the predicate.");
-        } catch (final IllegalArgumentException e) {
-            // expected
-        }
-        try {
-            decorateBag(new HashBag<T>(), null);
-            fail("Expecting NullPointerException for null predicate.");
-        } catch (final NullPointerException e) {
-            // expected
-        }
+
+        assertThrows(IllegalArgumentException.class, () -> decorateBag((HashBag<T>) elements, stringPredicate()));
+
+        assertThrows(NullPointerException.class, () -> decorateBag(new HashBag<T>(), null));
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/bag/PredicatedSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/PredicatedSortedBagTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Comparator;
 
 import junit.framework.Test;
@@ -69,14 +71,10 @@ public class PredicatedSortedBagTest<T> extends AbstractSortedBagTest<T> {
     public void testDecorate() {
         final SortedBag<T> bag = decorateBag(new TreeBag<T>(), stringPredicate());
         ((PredicatedSortedBag<T>) bag).decorated();
-        try {
-            decorateBag(new TreeBag<T>(), null);
-            fail("Expecting NullPointerException for null predicate");
-        } catch (final NullPointerException e) {}
-        try {
-            decorateBag(nullBag, stringPredicate());
-            fail("Expecting NullPointerException for null bag");
-        } catch (final NullPointerException e) {}
+
+        assertThrows(NullPointerException.class, () -> decorateBag(new TreeBag<T>(), null));
+
+        assertThrows(NullPointerException.class, () -> decorateBag(nullBag, stringPredicate()));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/apache/commons/collections4/bag/TreeBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/TreeBagTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import junit.framework.Test;
 
 import org.apache.commons.collections4.Bag;
@@ -25,7 +27,6 @@ import org.apache.commons.collections4.SortedBag;
 /**
  * Extension of {@link AbstractBagTest} for exercising the {@link TreeBag}
  * implementation.
- *
  */
 public class TreeBagTest<T> extends AbstractSortedBagTest<T> {
 
@@ -36,7 +37,6 @@ public class TreeBagTest<T> extends AbstractSortedBagTest<T> {
     public static Test suite() {
         return BulkTest.makeSuite(TreeBagTest.class);
     }
-
 
     @Override
     public SortedBag<T> makeObject() {
@@ -55,33 +55,21 @@ public class TreeBagTest<T> extends AbstractSortedBagTest<T> {
 
     public void testCollections265() {
         final Bag<Object> bag = new TreeBag<>();
-        try {
-            bag.add(new Object());
-            fail("IllegalArgumentException expected");
-        } catch(final IllegalArgumentException iae) {
-            // expected;
-        }
+
+        assertThrows(IllegalArgumentException.class, () -> bag.add(new Object()));
     }
 
     public void testCollections555() {
         final Bag<Object> bag = new TreeBag<>();
-        try {
-            bag.add(null);
-            fail("NullPointerException expected");
-        } catch(final NullPointerException npe) {
-            // expected;
-        }
+
+        assertThrows(NullPointerException.class, () -> bag.add(null));
 
         final Bag<String> bag2 = new TreeBag<>(String::compareTo);
-        try {
-            // jdk bug: adding null to an empty TreeMap works
-            // thus ensure that the bag is not empty before adding null
-            bag2.add("a");
-            bag2.add(null);
-            fail("NullPointerException expected");
-        } catch(final NullPointerException npe) {
-            // expected;
-        }
+        // jdk bug: adding null to an empty TreeMap works
+        // thus ensure that the bag is not empty before adding null
+        bag2.add("a");
+
+        assertThrows(NullPointerException.class, () -> bag2.add(null));
     }
 
     public void testOrdering() {
@@ -104,4 +92,5 @@ public class TreeBagTest<T> extends AbstractSortedBagTest<T> {
 //        bag = makeFullCollection();
 //        writeExternalFormToDisk((java.io.Serializable) bag, "src/test/resources/data/test/TreeBag.fullCollection.version4.obj");
 //    }
+
 }

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractBidiMapTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.bidimap;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -30,7 +32,6 @@ import org.apache.commons.collections4.map.AbstractIterableMapTest;
 
 /**
  * Abstract test class for {@link BidiMap} methods and contracts.
- *
  */
 public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
@@ -208,10 +209,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
 
     public void testBidiClear() {
         if (!isRemoveSupported()) {
-            try {
-                makeFullMap().clear();
-                fail();
-            } catch(final UnsupportedOperationException ex) {}
+            assertThrows(UnsupportedOperationException.class, () -> makeFullMap().clear());
             return;
         }
 
@@ -225,19 +223,14 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
         map.clear();
         assertTrue("Map was not cleared.", map.isEmpty());
         assertTrue("Inverse map was not cleared.", map.inverseBidiMap().isEmpty());
-
     }
 
     public void testBidiRemove() {
         if (!isRemoveSupported()) {
-            try {
-                makeFullMap().remove(getSampleKeys()[0]);
-                fail();
-            } catch(final UnsupportedOperationException ex) {}
-            try {
-                makeFullMap().removeValue(getSampleValues()[0]);
-                fail();
-            } catch(final UnsupportedOperationException ex) {}
+            assertThrows(UnsupportedOperationException.class, () -> makeFullMap().remove(getSampleKeys()[0]));
+
+            assertThrows(UnsupportedOperationException.class, () -> makeFullMap().removeValue(getSampleValues()[0]));
+
             return;
         }
 
@@ -329,8 +322,10 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
     }
 
     public class TestBidiMapEntrySet extends TestMapEntrySet {
+
         public TestBidiMapEntrySet() {
         }
+
         public void testMapEntrySetIteratorEntrySetValueCrossCheck() {
             final K key1 = getSampleKeys()[0];
             final K key2 = getSampleKeys()[1];
@@ -387,6 +382,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
                 it.remove();
             }
         }
+
     }
 
     public BulkTest bulkTestInverseMap() {
@@ -394,6 +390,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
     }
 
     public class TestInverseBidiMap extends AbstractBidiMapTest<V, K> {
+
         final AbstractBidiMapTest<K, V> main;
 
         public TestInverseBidiMap(final AbstractBidiMapTest<K, V> main) {
@@ -414,6 +411,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
         public V[] getSampleKeys() {
             return main.getSampleValues();
         }
+
         @Override
         public K[] getSampleValues() {
             return main.getSampleKeys();
@@ -461,6 +459,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
     }
 
     public class TestBidiMapIterator extends AbstractMapIteratorTest<K, V> {
+
         public TestBidiMapIterator() {
             super("TestBidiMapIterator");
         }
@@ -509,6 +508,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
             super.verify();
             AbstractBidiMapTest.this.verify();
         }
+
     }
 
     public void testBidiMapIteratorSet() {
@@ -522,11 +522,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
         final K key1 = it.next();
 
         if (!isSetValueSupported()) {
-            try {
-                it.setValue(newValue1);
-                fail();
-            } catch (final UnsupportedOperationException ex) {
-            }
+            assertThrows(UnsupportedOperationException.class, () -> it.setValue(newValue1));
             return;
         }
 

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.bidimap;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -30,7 +32,6 @@ import org.apache.commons.collections4.iterators.AbstractMapIteratorTest;
 
 /**
  * Abstract test class for {@link OrderedBidiMap} methods and contracts.
- *
  */
 public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTest<K, V> {
 
@@ -44,10 +45,9 @@ public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTe
     public void testFirstKey() {
         resetEmpty();
         OrderedBidiMap<K, V> bidi = getMap();
-        try {
-            bidi.firstKey();
-            fail();
-        } catch (final NoSuchElementException ex) {}
+
+        OrderedBidiMap<K, V> finalBidi = bidi;
+        assertThrows(NoSuchElementException.class, () -> finalBidi.firstKey());
 
         resetFull();
         bidi = getMap();
@@ -58,10 +58,9 @@ public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTe
     public void testLastKey() {
         resetEmpty();
         OrderedBidiMap<K, V> bidi = getMap();
-        try {
-            bidi.lastKey();
-            fail();
-        } catch (final NoSuchElementException ex) {}
+
+        OrderedBidiMap<K, V> finalBidi = bidi;
+        assertThrows(NoSuchElementException.class, () -> finalBidi.lastKey());
 
         resetFull();
         bidi = getMap();
@@ -96,10 +95,9 @@ public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTe
         assertNull(bidi.nextKey(confirmedLast));
 
         if (!isAllowNullKey()) {
-            try {
-                bidi.nextKey(null);
-                fail();
-            } catch (final NullPointerException ex) {}
+            OrderedBidiMap<K, V> finalBidi = bidi;
+            assertThrows(NullPointerException.class, () -> finalBidi.nextKey(null));
+
         } else {
             assertNull(bidi.nextKey(null));
         }
@@ -131,10 +129,9 @@ public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTe
         assertNull(bidi.previousKey(confirmedLast));
 
         if (!isAllowNullKey()) {
-            try {
-                bidi.previousKey(null);
-                fail();
-            } catch (final NullPointerException ex) {}
+            OrderedBidiMap<K, V> finalBidi = bidi;
+            assertThrows(NullPointerException.class, () -> finalBidi.previousKey(null));
+
         } else {
             assertNull(bidi.previousKey(null));
         }
@@ -153,6 +150,7 @@ public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTe
     }
 
     public class TestBidiOrderedMapIterator extends AbstractMapIteratorTest<K, V> {
+
         public TestBidiOrderedMapIterator() {
             super("TestBidiOrderedMapIterator");
         }
@@ -201,6 +199,7 @@ public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTe
             super.verify();
             AbstractOrderedBidiMapTest.this.verify();
         }
+
     }
 
 }


### PR DESCRIPTION
Again similar to https://github.com/apache/commons-collections/pull/281 and https://github.com/apache/commons-collections/pull/282 another load of JUnit v5 assertThrows for [COLLECTIONS-](https://issues.apache.org/jira/browse/COLLECTIONS-777)

JUnit v5 assertThrows PredicatedBagTest

JUnit v5 assertThrows PredicatedSortedBagTest

JUnit v5 assertThrows TreeBagTest

JUnit v5 assertThrows AbstractBagTest

JUnit v5 assertThrows AbstractBidiMapTest

JUnit v5 assertThrows AbstractOrderedBidiMapTest

JUnit v5 assertThrows PredicateUtilsTest

JUnit v5 assertThrows MultiMapUtilsTest

JUnit v5 assertThrows EnumerationUtilsTest

JUnit v5 assertThrows ArrayStackTest