### PR TITLE
COLLECTIONS-777 change JUnit v3 to JUnitv4 Annotations

### DIFF
--- a/src/test/java/org/apache/commons/collections4/AbstractArrayListTest.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractArrayListTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.ArrayList;
 
 import org.apache.commons.collections4.list.AbstractListTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for ArrayList.
@@ -37,6 +38,7 @@ public abstract class AbstractArrayListTest<E> extends AbstractListTest<E> {
     @Override
     public abstract ArrayList<E> makeObject();
 
+    @Test
     public void testNewArrayList() {
         final ArrayList<E> list = makeObject();
         assertTrue("New list is empty", list.isEmpty());
@@ -45,6 +47,7 @@ public abstract class AbstractArrayListTest<E> extends AbstractListTest<E> {
         assertThrows(IndexOutOfBoundsException.class, () -> list.get(1));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSearch() {
         final ArrayList<E> list = makeObject();

--- a/src/test/java/org/apache/commons/collections4/AbstractLinkedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractLinkedListTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.list.AbstractListTest;
+import org.junit.Test;
 
 /**
  * Tests base {@link java.util.LinkedList} methods and contracts.
@@ -67,6 +68,7 @@ public abstract class AbstractLinkedListTest<T> extends AbstractListTest<T> {
     /**
      *  Tests {@link LinkedList#addFirst(Object)}.
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testLinkedListAddFirst() {
         if (!isAddSupported()) {
@@ -88,6 +90,7 @@ public abstract class AbstractLinkedListTest<T> extends AbstractListTest<T> {
     /**
      *  Tests {@link LinkedList#addLast(Object)}.
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testLinkedListAddLast() {
         if (!isAddSupported()) {
@@ -109,6 +112,7 @@ public abstract class AbstractLinkedListTest<T> extends AbstractListTest<T> {
     /**
      *  Tests {@link LinkedList#getFirst()}.
      */
+    @Test
     public void testLinkedListGetFirst() {
         resetEmpty();
         assertThrows(NoSuchElementException.class, () -> getCollection().getFirst(),
@@ -126,6 +130,7 @@ public abstract class AbstractLinkedListTest<T> extends AbstractListTest<T> {
     /**
      *  Tests {@link LinkedList#getLast()}.
      */
+    @Test
     public void testLinkedListGetLast() {
         resetEmpty();
         assertThrows(NoSuchElementException.class, () -> getCollection().getLast(),
@@ -143,6 +148,7 @@ public abstract class AbstractLinkedListTest<T> extends AbstractListTest<T> {
     /**
      *  Tests {@link LinkedList#removeFirst()}.
      */
+    @Test
     public void testLinkedListRemoveFirst() {
         if (!isRemoveSupported()) {
             return;
@@ -164,6 +170,7 @@ public abstract class AbstractLinkedListTest<T> extends AbstractListTest<T> {
     /**
      *  Tests {@link LinkedList#removeLast()}.
      */
+    @Test
     public void testLinkedListRemoveLast() {
         if (!isRemoveSupported()) {
             return;

--- a/src/test/java/org/apache/commons/collections4/AbstractObjectTest.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractObjectTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4;
 
+import org.junit.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -97,21 +99,25 @@ public abstract class AbstractObjectTest extends BulkTest {
         return true;
     }
 
+    @Test
     public void testObjectEqualsSelf() {
         final Object obj = makeObject();
         assertEquals("A Object should equal itself", obj, obj);
     }
 
+    @Test
     public void testEqualsNull() {
         final Object obj = makeObject();
         assertFalse(obj.equals(null)); // make sure this doesn't throw NPE either
     }
 
+    @Test
     public void testObjectHashCodeEqualsSelfHashCode() {
         final Object obj = makeObject();
         assertEquals("hashCode should be repeatable", obj.hashCode(), obj.hashCode());
     }
 
+    @Test
     public void testObjectHashCodeEqualsContract() {
         final Object obj1 = makeObject();
         if (obj1.equals(obj1)) {
@@ -141,6 +147,7 @@ public abstract class AbstractObjectTest extends BulkTest {
         return dest;
     }
 
+    @Test
     public void testSerializeDeserializeThenCompare() throws Exception {
         final Object obj = makeObject();
         if (obj instanceof Serializable && isTestSerialization()) {
@@ -159,6 +166,7 @@ public abstract class AbstractObjectTest extends BulkTest {
      * @throws IOException
      * @throws ClassNotFoundException
      */
+    @Test
     public void testSimpleSerialization() throws Exception {
         final Object o = makeObject();
         if (o instanceof Serializable && isTestSerialization()) {
@@ -171,6 +179,7 @@ public abstract class AbstractObjectTest extends BulkTest {
      * Tests serialization by comparing against a previously stored version in SCM.
      * If the test object is serializable, confirm that a canonical form exists.
      */
+    @Test
     public void testCanonicalEmptyCollectionExists() {
         if (supportsEmptyCollections() && isTestSerialization() && !skipSerializedCanonicalTests()) {
             final Object object = makeObject();
@@ -187,6 +196,7 @@ public abstract class AbstractObjectTest extends BulkTest {
      * Tests serialization by comparing against a previously stored version in SCM.
      * If the test object is serializable, confirm that a canonical form exists.
      */
+    @Test
     public void testCanonicalFullCollectionExists() {
         if (supportsFullCollections() && isTestSerialization() && !skipSerializedCanonicalTests()) {
             final Object object = makeObject();

--- a/src/test/java/org/apache/commons/collections4/AbstractTreeMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractTreeMapTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.collections4;
 import java.util.TreeMap;
 
 import org.apache.commons.collections4.map.AbstractMapTest;
+import org.junit.Test;
 
 /**
  * Tests TreeMap.
@@ -41,12 +42,14 @@ public abstract class AbstractTreeMapTest<K, V> extends AbstractMapTest<K, V> {
     @Override
     public abstract TreeMap<K, V> makeObject();
 
+    @Test
     public void testNewMap() {
         final TreeMap<K, V> map = makeObject();
         assertTrue("New map is empty", map.isEmpty());
         assertEquals("New map has size zero", 0, map.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSearch() {
         final TreeMap<K, V> map = makeObject();

--- a/src/test/java/org/apache/commons/collections4/ArrayStackTest.java
+++ b/src/test/java/org/apache/commons/collections4/ArrayStackTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.EmptyStackException;
 
-import junit.framework.Test;
+import org.junit.Test;
 
 /**
  * Tests ArrayStack.
@@ -32,7 +32,7 @@ public class ArrayStackTest<E> extends AbstractArrayListTest<E> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(ArrayStackTest.class);
     }
 
@@ -41,6 +41,7 @@ public class ArrayStackTest<E> extends AbstractArrayListTest<E> {
         return new ArrayStack<>();
     }
 
+    @Test
     public void testNewStack() {
         final ArrayStack<E> stack = makeObject();
         assertTrue("New stack is empty", stack.empty());
@@ -51,6 +52,7 @@ public class ArrayStackTest<E> extends AbstractArrayListTest<E> {
         assertThrows(EmptyStackException.class, () -> stack.pop());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPushPeekPop() {
         final ArrayStack<E> stack = makeObject();
@@ -79,6 +81,7 @@ public class ArrayStackTest<E> extends AbstractArrayListTest<E> {
         assertEquals("Stack size is zero", 0, stack.size());
     }
 
+    @Test
     @Override
     @SuppressWarnings("unchecked")
     public void testSearch() {

--- a/src/test/java/org/apache/commons/collections4/BulkTest.java
+++ b/src/test/java/org/apache/commons/collections4/BulkTest.java
@@ -52,11 +52,13 @@ import junit.framework.TestSuite;
  *          this.set = set;
  *      }
  *
+ *      @Test
  *      public void testContains() {
  *          boolean r = set.contains(set.iterator().next()));
  *          assertTrue("Set should contain first element, r);
  *      }
  *
+ *      @Test
  *      public void testClear() {
  *          set.clear();
  *          assertTrue("Set should be empty after clear", set.isEmpty());
@@ -73,6 +75,7 @@ import junit.framework.TestSuite;
  *          return result;
  *      }
  *
+ *      @Test
  *      public void testClear() {
  *          Map map = makeFullMap();
  *          map.clear();

--- a/src/test/java/org/apache/commons/collections4/PredicateUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/PredicateUtilsTest.java
@@ -152,8 +152,8 @@ public class PredicateUtilsTest extends AbstractPredicateTest {
     // allPredicate
     //------------------------------------------------------------------
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testAllPredicate() {
         assertPredicateTrue(AllPredicate.allPredicate(), null);
         assertTrue(AllPredicate.allPredicate(truePredicate(), truePredicate(), truePredicate()).evaluate(null));
@@ -195,8 +195,8 @@ public class PredicateUtilsTest extends AbstractPredicateTest {
         assertThrows(NullPointerException.class, () -> AllPredicate.allPredicate((Predicate<Object>[]) null));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testAllPredicateEx2() {
         assertThrows(NullPointerException.class, () -> AllPredicate.<Object>allPredicate(new Predicate[] { null }));
     }
@@ -243,8 +243,8 @@ public class PredicateUtilsTest extends AbstractPredicateTest {
     // anyPredicate
     //------------------------------------------------------------------
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testAnyPredicate() {
         assertPredicateFalse(PredicateUtils.anyPredicate(), null);
 
@@ -287,8 +287,8 @@ public class PredicateUtilsTest extends AbstractPredicateTest {
         assertThrows(NullPointerException.class, () -> PredicateUtils.anyPredicate((Predicate<Object>[]) null));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testAnyPredicateEx2() {
         assertThrows(NullPointerException.class, () -> PredicateUtils.anyPredicate(new Predicate[] {null}));
     }
@@ -335,8 +335,8 @@ public class PredicateUtilsTest extends AbstractPredicateTest {
     // onePredicate
     //------------------------------------------------------------------
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testOnePredicate() {
         assertPredicateFalse(PredicateUtils.onePredicate((Predicate<Object>[]) new Predicate[] {}), null);
         assertFalse(PredicateUtils.onePredicate(truePredicate(), truePredicate(), truePredicate()).evaluate(null));
@@ -380,8 +380,8 @@ public class PredicateUtilsTest extends AbstractPredicateTest {
         assertThrows(NullPointerException.class, () -> PredicateUtils.onePredicate((Predicate<Object>[]) null));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testOnePredicateEx2() {
         assertThrows(NullPointerException.class, () -> PredicateUtils.onePredicate(new Predicate[] {null}));
     }
@@ -396,8 +396,8 @@ public class PredicateUtilsTest extends AbstractPredicateTest {
         assertThrows(NullPointerException.class, () -> PredicateUtils.onePredicate((Collection<Predicate<Object>>) null));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testOnePredicateEx5() {
         PredicateUtils.onePredicate(Collections.EMPTY_LIST);
     }
@@ -426,8 +426,8 @@ public class PredicateUtilsTest extends AbstractPredicateTest {
     // nonePredicate
     //------------------------------------------------------------------
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testNonePredicate() {
         assertPredicateTrue(PredicateUtils.nonePredicate(), null);
         assertFalse(PredicateUtils.nonePredicate(truePredicate(), truePredicate(), truePredicate()).evaluate(null));
@@ -469,14 +469,14 @@ public class PredicateUtilsTest extends AbstractPredicateTest {
         assertThrows(NullPointerException.class, () -> PredicateUtils.nonePredicate((Predicate<Object>[]) null));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testNonePredicateEx2() {
         assertThrows(NullPointerException.class, () -> PredicateUtils.nonePredicate(new Predicate[] {null}));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testNonePredicateEx3() {
         assertThrows(NullPointerException.class, () -> PredicateUtils.nonePredicate(null, null));
     }

--- a/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
@@ -32,6 +32,7 @@ import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.set.AbstractSetTest;
+import org.junit.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -130,6 +131,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         return (Bag<T>) super.getCollection();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagAdd() {
         if (!isAddSupported()) {
@@ -148,6 +150,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertTrue(bag.contains("B"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagEqualsSelf() {
         final Bag<T> bag = makeObject();
@@ -165,6 +168,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals(bag, bag);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagRemove() {
         if (!isRemoveSupported()) {
@@ -189,6 +193,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals("Should have count of 0", 0, bag.getCount("A"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagRemoveAll() {
         if (!isRemoveSupported()) {
@@ -211,6 +216,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals("Should have count of 2", 2, bag.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagContains() {
         if (!isAddSupported()) {
@@ -235,6 +241,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertTrue("Bag has at least 1 'B'", bag.contains("B"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagContainsAll() {
         if (!isAddSupported()) {
@@ -289,6 +296,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertTrue("Bag containsAll of 1 'A' 1 'B'", bag.containsAll(known1A1B));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagSize() {
         if (!isAddSupported()) {
@@ -314,6 +322,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals("Should have 1 total item", 1, bag.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagRetainAll() {
         if (!isAddSupported()) {
@@ -334,6 +343,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals("Should have 2 total items", 2, bag.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagIterator() {
         if (!isAddSupported()) {
@@ -365,6 +375,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals("Bag should have 1 'A'", 1, bag.getCount("A"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagIteratorFail() {
         if (!isAddSupported()) {
@@ -382,6 +393,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertThrows(ConcurrentModificationException.class, () -> it.next());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagIteratorFailNoMore() {
         if (!isAddSupported()) {
@@ -400,6 +412,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertThrows(NoSuchElementException.class, () -> it.next());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagIteratorFailDoubleRemove() {
         if (!isAddSupported()) {
@@ -425,6 +438,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals(1, bag.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagIteratorRemoveProtectsInvariants() {
         if (!isAddSupported()) {
@@ -451,6 +465,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertFalse(it2.hasNext());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagToArray() {
         if (!isAddSupported()) {
@@ -475,6 +490,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals(1, c);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagToArrayPopulate() {
         if (!isAddSupported()) {
@@ -499,6 +515,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals(1, c);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagEquals() {
         if (!isAddSupported()) {
@@ -523,6 +540,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals(bag, bag2);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagEqualsHashBag() {
         if (!isAddSupported()) {
@@ -547,6 +565,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         assertEquals(bag, bag2);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBagHashCode() {
         if (!isAddSupported()) {
@@ -661,6 +680,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
      * Compare the current serialized form of the Bag
      * against the canonical version in SCM.
      */
+    @Test
     public void testEmptyBagCompatibility() throws IOException, ClassNotFoundException {
         // test to make sure the canonical form has been preserved
         final Bag<T> bag = makeObject();
@@ -675,6 +695,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
      * Compare the current serialized form of the Bag
      * against the canonical version in SCM.
      */
+    @Test
     public void testFullBagCompatibility() throws IOException, ClassNotFoundException {
         // test to make sure the canonical form has been preserved
         final Bag<T> bag = makeFullCollection();

--- a/src/test/java/org/apache/commons/collections4/bag/CollectionBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/CollectionBagTest.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
+import org.junit.Test;
 
 /**
  * Test class for {@link CollectionBag}.
@@ -89,6 +90,7 @@ public class CollectionBagTest<T> extends AbstractCollectionTest<T> {
      * Compares the current serialized form of the Bag
      * against the canonical version in SCM.
      */
+    @Test
     public void testEmptyBagCompatibility() throws IOException, ClassNotFoundException {
         // test to make sure the canonical form has been preserved
         final Bag<T> bag = makeObject();
@@ -103,6 +105,7 @@ public class CollectionBagTest<T> extends AbstractCollectionTest<T> {
      * Compares the current serialized form of the Bag
      * against the canonical version in SCM.
      */
+    @Test
     public void testFullBagCompatibility() throws IOException, ClassNotFoundException {
         // test to make sure the canonical form has been preserved
         final Bag<T> bag = (Bag<T>) makeFullCollection();

--- a/src/test/java/org/apache/commons/collections4/bag/CollectionSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/CollectionSortedBagTest.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.SortedBag;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
+import org.junit.Test;
 
 /**
  * Test class for {@link CollectionSortedBag}.
@@ -127,6 +128,7 @@ public class CollectionSortedBagTest<T> extends AbstractCollectionTest<T> {
      * Compare the current serialized form of the Bag
      * against the canonical version in SCM.
      */
+    @Test
     public void testEmptyBagCompatibility() throws IOException, ClassNotFoundException {
         // test to make sure the canonical form has been preserved
         final Bag<T> bag = makeObject();
@@ -141,6 +143,7 @@ public class CollectionSortedBagTest<T> extends AbstractCollectionTest<T> {
      * Compare the current serialized form of the Bag
      * against the canonical version in SCM.
      */
+    @Test
     public void testFullBagCompatibility() throws IOException, ClassNotFoundException {
         // test to make sure the canonical form has been preserved
         final SortedBag<T> bag = (SortedBag<T>) makeFullCollection();

--- a/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.commons.collections4.bag;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.BulkTest;
 
@@ -32,7 +30,7 @@ public class HashBagTest<T> extends AbstractBagTest<T> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(HashBagTest.class);
     }
 

--- a/src/test/java/org/apache/commons/collections4/bag/PredicatedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/PredicatedBagTest.java
@@ -20,12 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Set;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractBagTest} for exercising the {@link PredicatedBag}
@@ -39,7 +38,7 @@ public class PredicatedBagTest<T> extends AbstractBagTest<T> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(PredicatedBagTest.class);
     }
 
@@ -66,6 +65,7 @@ public class PredicatedBagTest<T> extends AbstractBagTest<T> {
 
     //--------------------------------------------------------------------------
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testlegalAddRemove() {
         final Bag<T> bag = makeTestBag();
@@ -83,6 +83,7 @@ public class PredicatedBagTest<T> extends AbstractBagTest<T> {
         assertFalse("Unique set now does not contain the first element", set.contains(els[0]));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalAdd() {
         final Bag<T> bag = makeTestBag();
@@ -93,6 +94,7 @@ public class PredicatedBagTest<T> extends AbstractBagTest<T> {
         assertFalse("Collection shouldn't contain illegal element", bag.contains(i));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalDecorate() {
         final HashBag<Object> elements = new HashBag<>();

--- a/src/test/java/org/apache/commons/collections4/bag/PredicatedSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/PredicatedSortedBagTest.java
@@ -20,12 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Comparator;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.SortedBag;
 import org.apache.commons.collections4.functors.TruePredicate;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSortedBagTest} for exercising the {@link PredicatedSortedBag}
@@ -41,7 +40,7 @@ public class PredicatedSortedBagTest<T> extends AbstractSortedBagTest<T> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(PredicatedSortedBagTest.class);
     }
 
@@ -68,6 +67,7 @@ public class PredicatedSortedBagTest<T> extends AbstractSortedBagTest<T> {
 
     //--------------------------------------------------------------------------
 
+    @Test
     public void testDecorate() {
         final SortedBag<T> bag = decorateBag(new TreeBag<T>(), stringPredicate());
         ((PredicatedSortedBag<T>) bag).decorated();
@@ -77,6 +77,7 @@ public class PredicatedSortedBagTest<T> extends AbstractSortedBagTest<T> {
         assertThrows(NullPointerException.class, () -> decorateBag(nullBag, stringPredicate()));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSortOrder() {
         final SortedBag<T> bag = decorateBag(new TreeBag<T>(), stringPredicate());

--- a/src/test/java/org/apache/commons/collections4/bag/SynchronizedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/SynchronizedBagTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.commons.collections4.bag;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.BulkTest;
 
@@ -33,7 +31,7 @@ public class SynchronizedBagTest<T> extends AbstractBagTest<T> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(SynchronizedBagTest.class);
     }
 

--- a/src/test/java/org/apache/commons/collections4/bag/TransformedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/TransformedBagTest.java
@@ -16,12 +16,11 @@
  */
 package org.apache.commons.collections4.bag;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractBagTest} for exercising the {@link TransformedBag}
@@ -35,7 +34,7 @@ public class TransformedBagTest<T> extends AbstractBagTest<T> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(TransformedBagTest.class);
     }
 
@@ -47,6 +46,7 @@ public class TransformedBagTest<T> extends AbstractBagTest<T> {
                 (Transformer<T, T>) TransformedCollectionTest.NOOP_TRANSFORMER);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testTransformedBag() {
         //T had better be Object!
@@ -65,6 +65,7 @@ public class TransformedBagTest<T> extends AbstractBagTest<T> {
         assertTrue(bag.remove(Integer.valueOf((String) els[0])));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testTransformedBag_decorateTransform() {
         final Bag<T> originalBag = new HashBag<>();

--- a/src/test/java/org/apache/commons/collections4/bag/TransformedSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/TransformedSortedBagTest.java
@@ -16,12 +16,11 @@
  */
 package org.apache.commons.collections4.bag;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.SortedBag;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSortedBagTest} for exercising the {@link TransformedSortedBag}
@@ -35,7 +34,7 @@ public class TransformedSortedBagTest<T> extends AbstractSortedBagTest<T> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(TransformedSortedBagTest.class);
     }
 
@@ -46,6 +45,7 @@ public class TransformedSortedBagTest<T> extends AbstractSortedBagTest<T> {
         return TransformedSortedBag.transformingSortedBag(new TreeBag<T>(), (Transformer<T, T>) TransformedCollectionTest.NOOP_TRANSFORMER);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testTransformedBag() {
         final SortedBag<T> bag = TransformedSortedBag.transformingSortedBag(new TreeBag<T>(), (Transformer<T, T>) TransformedCollectionTest.STRING_TO_INTEGER_TRANSFORMER);
@@ -61,6 +61,7 @@ public class TransformedSortedBagTest<T> extends AbstractSortedBagTest<T> {
 
     }
 
+    @Test
     public void testTransformedBag_decorateTransform() {
         final TreeBag<T> originalBag = new TreeBag<>();
         final Object[] els = {"1", "3", "5", "7", "2", "4", "6"};

--- a/src/test/java/org/apache/commons/collections4/bag/TreeBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/TreeBagTest.java
@@ -18,11 +18,10 @@ package org.apache.commons.collections4.bag;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.SortedBag;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractBagTest} for exercising the {@link TreeBag}
@@ -34,7 +33,7 @@ public class TreeBagTest<T> extends AbstractSortedBagTest<T> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(TreeBagTest.class);
     }
 
@@ -53,12 +52,14 @@ public class TreeBagTest<T> extends AbstractSortedBagTest<T> {
         return bag;
     }
 
+    @Test
     public void testCollections265() {
         final Bag<Object> bag = new TreeBag<>();
 
         assertThrows(IllegalArgumentException.class, () -> bag.add(new Object()));
     }
 
+    @Test
     public void testCollections555() {
         final Bag<Object> bag = new TreeBag<>();
 
@@ -72,6 +73,7 @@ public class TreeBagTest<T> extends AbstractSortedBagTest<T> {
         assertThrows(NullPointerException.class, () -> bag2.add(null));
     }
 
+    @Test
     public void testOrdering() {
         final Bag<T> bag = setupBag();
         assertEquals("Should get elements in correct order", "A", bag.toArray()[0]);

--- a/src/test/java/org/apache/commons/collections4/bag/UnmodifiableBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/UnmodifiableBagTest.java
@@ -20,12 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -39,7 +38,7 @@ public class UnmodifiableBagTest<E> extends AbstractBagTest<E> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(UnmodifiableBagTest.class);
     }
 
@@ -75,11 +74,13 @@ public class UnmodifiableBagTest<E> extends AbstractBagTest<E> {
         return false;
     }
 
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullCollection() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final Bag<E> queue = makeFullCollection();
         assertSame(queue, UnmodifiableBag.unmodifiableBag(queue));

--- a/src/test/java/org/apache/commons/collections4/bag/UnmodifiableSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/UnmodifiableSortedBagTest.java
@@ -20,12 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.SortedBag;
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -39,7 +38,7 @@ public class UnmodifiableSortedBagTest<E> extends AbstractSortedBagTest<E> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(UnmodifiableSortedBagTest.class);
     }
 
@@ -75,11 +74,13 @@ public class UnmodifiableSortedBagTest<E> extends AbstractSortedBagTest<E> {
         return false;
     }
 
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullCollection() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final SortedBag<E> queue = makeFullCollection();
         assertSame(queue, UnmodifiableSortedBag.unmodifiableSortedBag(queue));

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractBidiMapTest.java
@@ -29,6 +29,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.iterators.AbstractMapIteratorTest;
 import org.apache.commons.collections4.map.AbstractIterableMapTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link BidiMap} methods and contracts.
@@ -76,6 +77,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
     }
 
     // BidiPut
+    @Test
     @SuppressWarnings("unchecked")
     public void testBidiPut() {
         if (!isPutAddSupported() || !isPutChangeSupported()) {
@@ -138,10 +140,12 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
     }
 
     // testGetKey
+    @Test
     public void testBidiGetKey() {
         doTestGetKey(makeFullMap(), getSampleKeys()[0], getSampleValues()[0]);
     }
 
+    @Test
     public void testBidiGetKeyInverse() {
         doTestGetKey(
             makeFullMap().inverseBidiMap(),
@@ -155,6 +159,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
     }
 
     // testInverse
+    @Test
     public void testBidiInverse() {
         final BidiMap<K, V> map = makeFullMap();
         final BidiMap<V, K> inverseMap = map.inverseBidiMap();
@@ -175,6 +180,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
             inverseMap.getKey(getSampleKeys()[0]));
     }
 
+    @Test
     public void testBidiModifyEntrySet() {
         if (!isSetValueSupported()) {
             return;
@@ -207,6 +213,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
             map.getKey(oldValue));
     }
 
+    @Test
     public void testBidiClear() {
         if (!isRemoveSupported()) {
             assertThrows(UnsupportedOperationException.class, () -> makeFullMap().clear());
@@ -225,6 +232,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
         assertTrue("Inverse map was not cleared.", map.inverseBidiMap().isEmpty());
     }
 
+    @Test
     public void testBidiRemove() {
         if (!isRemoveSupported()) {
             assertThrows(UnsupportedOperationException.class, () -> makeFullMap().remove(getSampleKeys()[0]));
@@ -255,6 +263,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
         assertNull("Value was not removed.", map.getKey(value));
     }
 
+    @Test
     public void testBidiKeySetValuesOrder() {
         resetFull();
         final Iterator<K> keys = map.keySet().iterator();
@@ -268,6 +277,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
         assertFalse(values.hasNext());
     }
 
+    @Test
     public void testBidiRemoveByKeySet() {
         if (!isRemoveSupported()) {
             return;
@@ -287,6 +297,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
         assertFalse("Value was not removed from inverse map.", map.inverseBidiMap().containsKey(value));
     }
 
+    @Test
     public void testBidiRemoveByEntrySet() {
         if (!isRemoveSupported()) {
             return;
@@ -326,6 +337,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
         public TestBidiMapEntrySet() {
         }
 
+        @Test
         public void testMapEntrySetIteratorEntrySetValueCrossCheck() {
             final K key1 = getSampleKeys()[0];
             final K key2 = getSampleKeys()[1];
@@ -511,6 +523,7 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
 
     }
 
+    @Test
     public void testBidiMapIteratorSet() {
         final V newValue1 = getOtherValues()[0];
         final V newValue2 = getOtherValues()[1];

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapTest.java
@@ -29,6 +29,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.OrderedBidiMap;
 import org.apache.commons.collections4.iterators.AbstractMapIteratorTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link OrderedBidiMap} methods and contracts.
@@ -42,6 +43,7 @@ public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTe
     public AbstractOrderedBidiMapTest() {
     }
 
+    @Test
     public void testFirstKey() {
         resetEmpty();
         OrderedBidiMap<K, V> bidi = getMap();
@@ -55,6 +57,7 @@ public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTe
         assertEquals(confirmedFirst, bidi.firstKey());
     }
 
+    @Test
     public void testLastKey() {
         resetEmpty();
         OrderedBidiMap<K, V> bidi = getMap();
@@ -71,6 +74,7 @@ public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTe
         assertEquals(confirmedLast, bidi.lastKey());
     }
 
+    @Test
     public void testNextKey() {
         resetEmpty();
         OrderedBidiMap<K, V> bidi = (OrderedBidiMap<K, V>) map;
@@ -103,6 +107,7 @@ public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTe
         }
     }
 
+    @Test
     public void testPreviousKey() {
         resetEmpty();
         OrderedBidiMap<K, V> bidi = getMap();

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractSortedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractSortedBidiMapTest.java
@@ -30,6 +30,7 @@ import java.util.TreeSet;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.SortedBidiMap;
 import org.apache.commons.collections4.map.AbstractSortedMapTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link SortedBidiMap} methods and contracts.
@@ -101,6 +102,7 @@ public abstract class AbstractSortedBidiMapTest<K extends Comparable<K>, V exten
         return new TreeMap<>();
     }
 
+    @Test
     public void testBidiHeadMapContains() {
         // extra test as other tests get complex
         final SortedBidiMap<K, V> sm = makeFullMap();
@@ -123,6 +125,7 @@ public abstract class AbstractSortedBidiMapTest<K extends Comparable<K>, V exten
         assertFalse(head.containsValue(secondValue));
     }
 
+    @Test
     public void testBidiClearByHeadMap() {
         if (!isRemoveSupported()) {
             return;
@@ -169,6 +172,7 @@ public abstract class AbstractSortedBidiMapTest<K extends Comparable<K>, V exten
         assertFalse(sub.containsValue(toKeyValue));
     }
 
+    @Test
     public void testBidiRemoveByHeadMap() {
         if (!isRemoveSupported()) {
             return;
@@ -212,6 +216,7 @@ public abstract class AbstractSortedBidiMapTest<K extends Comparable<K>, V exten
         assertFalse(sub.containsValue(secondValue));
     }
 
+    @Test
     public void testBidiRemoveByHeadMapEntrySet() {
         if (!isRemoveSupported()) {
             return;
@@ -265,6 +270,7 @@ public abstract class AbstractSortedBidiMapTest<K extends Comparable<K>, V exten
         assertFalse(set.contains(secondEntry));
     }
 
+    @Test
     public void testBidiTailMapContains() {
         // extra test as other tests get complex
         final SortedBidiMap<K, V> sm = makeFullMap();
@@ -292,6 +298,7 @@ public abstract class AbstractSortedBidiMapTest<K extends Comparable<K>, V exten
         assertTrue(sub.containsValue(secondValue));
     }
 
+    @Test
     public void testBidiClearByTailMap() {
         if (!isRemoveSupported()) {
             return;
@@ -340,6 +347,7 @@ public abstract class AbstractSortedBidiMapTest<K extends Comparable<K>, V exten
         assertFalse(sub.containsValue(secondValue));
     }
 
+    @Test
     public void testBidiRemoveByTailMap() {
         if (!isRemoveSupported()) {
             return;
@@ -384,6 +392,7 @@ public abstract class AbstractSortedBidiMapTest<K extends Comparable<K>, V exten
         assertFalse(sub.containsValue(secondValue));
     }
 
+    @Test
     public void testBidiRemoveByTailMapEntrySet() {
         if (!isRemoveSupported()) {
             return;
@@ -437,6 +446,7 @@ public abstract class AbstractSortedBidiMapTest<K extends Comparable<K>, V exten
         assertFalse(set.contains(secondEntry));
     }
 
+    @Test
     public void testBidiSubMapContains() {
         // extra test as other tests get complex
         final SortedBidiMap<K, V> sm = makeFullMap();
@@ -471,6 +481,7 @@ public abstract class AbstractSortedBidiMapTest<K extends Comparable<K>, V exten
         assertFalse(sub.containsValue(thirdValue));
     }
 
+    @Test
     public void testBidiClearBySubMap() {
         if (!isRemoveSupported()) {
             return;
@@ -527,6 +538,7 @@ public abstract class AbstractSortedBidiMapTest<K extends Comparable<K>, V exten
         assertFalse(sub.containsValue(toKeyValue));
     }
 
+    @Test
     public void testBidiRemoveBySubMap() {
         if (!isRemoveSupported()) {
             return;
@@ -572,6 +584,7 @@ public abstract class AbstractSortedBidiMapTest<K extends Comparable<K>, V exten
         assertFalse(sub.containsValue(secondValue));
     }
 
+    @Test
     public void testBidiRemoveBySubMapEntrySet() {
         if (!isRemoveSupported()) {
             return;

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualHashBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualHashBidiMapTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.commons.collections4.bidimap;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 
 /**
@@ -26,7 +24,7 @@ import org.apache.commons.collections4.BulkTest;
  */
 public class DualHashBidiMapTest<K, V> extends AbstractBidiMapTest<K, V> {
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(DualHashBidiMapTest.class);
     }
 

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualLinkedHashBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualLinkedHashBidiMapTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.commons.collections4.bidimap;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 
 /**
@@ -26,7 +24,7 @@ import org.apache.commons.collections4.BulkTest;
  */
 public class DualLinkedHashBidiMapTest<K, V> extends AbstractBidiMapTest<K, V> {
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(DualLinkedHashBidiMapTest.class);
     }
 

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap2Test.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap2Test.java
@@ -27,12 +27,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.TreeMap;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.SortedBidiMap;
 import org.apache.commons.collections4.comparators.ComparableComparator;
 import org.apache.commons.collections4.comparators.ReverseComparator;
+import org.junit.Test;
 
 /**
  * JUnit tests.
@@ -41,7 +40,7 @@ import org.apache.commons.collections4.comparators.ReverseComparator;
 @SuppressWarnings("boxing")
 public class DualTreeBidiMap2Test<K extends Comparable<K>, V extends Comparable<V>> extends AbstractSortedBidiMapTest<K, V> {
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(DualTreeBidiMap2Test.class);
     }
 
@@ -61,6 +60,7 @@ public class DualTreeBidiMap2Test<K extends Comparable<K>, V extends Comparable<
         return new TreeMap<>(new ReverseComparator<>(ComparableComparator.<K>comparableComparator()));
     }
 
+    @Test
     public void testComparator() {
         resetEmpty();
         final SortedBidiMap<K, V> bidi = (SortedBidiMap<K, V>) map;
@@ -68,6 +68,7 @@ public class DualTreeBidiMap2Test<K extends Comparable<K>, V extends Comparable<
         assertTrue(bidi.comparator() instanceof ReverseComparator);
     }
 
+    @Test
     public void testComparator2() {
         final DualTreeBidiMap<String, Integer> dtbm = new DualTreeBidiMap<>(
                 String.CASE_INSENSITIVE_ORDER, null);
@@ -78,6 +79,7 @@ public class DualTreeBidiMap2Test<K extends Comparable<K>, V extends Comparable<
 
     }
 
+    @Test
     public void testSerializeDeserializeCheckComparator() throws Exception {
         final SortedBidiMap<?, ?> obj = makeObject();
         if (obj instanceof Serializable && isTestSerialization()) {
@@ -105,6 +107,7 @@ public class DualTreeBidiMap2Test<K extends Comparable<K>, V extends Comparable<
         }
     }
 
+    @Test
     public void testCollections364() throws Exception {
         final DualTreeBidiMap<String, Integer> original = new DualTreeBidiMap<>(
                 String.CASE_INSENSITIVE_ORDER, new IntegerComparator());
@@ -124,6 +127,7 @@ public class DualTreeBidiMap2Test<K extends Comparable<K>, V extends Comparable<
         assertEquals(original.valueComparator().getClass(), deserialized.valueComparator().getClass());
     }
 
+    @Test
     public void testSortOrder() throws Exception {
         final SortedBidiMap<K, V> sm = makeFullMap();
 

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMapTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.commons.collections4.bidimap;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 
 /**
@@ -26,7 +24,7 @@ import org.apache.commons.collections4.BulkTest;
  */
 public class DualTreeBidiMapTest<K extends Comparable<K>, V extends Comparable<V>> extends AbstractSortedBidiMapTest<K, V> {
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(DualTreeBidiMapTest.class);
     }
 

--- a/src/test/java/org/apache/commons/collections4/bidimap/TreeBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/TreeBidiMapTest.java
@@ -18,7 +18,6 @@ package org.apache.commons.collections4.bidimap;
 
 import java.util.TreeMap;
 
-import junit.framework.Test;
 import org.apache.commons.collections4.BidiMap;
 import org.apache.commons.collections4.BulkTest;
 
@@ -28,7 +27,7 @@ import org.apache.commons.collections4.BulkTest;
  */
 public class TreeBidiMapTest<K extends Comparable<K>, V extends Comparable<V>> extends AbstractOrderedBidiMapTest<K, V> {
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(TreeBidiMapTest.class);
     }
 

--- a/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableBidiMapTest.java
@@ -21,18 +21,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.HashMap;
 import java.util.Map;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BidiMap;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
 
 /**
  * JUnit tests.
  */
 public class UnmodifiableBidiMapTest<K, V> extends AbstractBidiMapTest<K, V> {
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(UnmodifiableBidiMapTest.class);
     }
 
@@ -80,11 +79,13 @@ public class UnmodifiableBidiMapTest<K, V> extends AbstractBidiMapTest<K, V> {
         return false;
     }
 
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullMap() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final BidiMap<K, V> map = makeFullMap();
         assertSame(map, UnmodifiableBidiMap.unmodifiableBidiMap(map));

--- a/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableOrderedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableOrderedBidiMapTest.java
@@ -21,18 +21,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Map;
 import java.util.TreeMap;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.OrderedBidiMap;
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
 
 /**
  * JUnit tests.
  */
 public class UnmodifiableOrderedBidiMapTest<K extends Comparable<K>, V extends Comparable<V>> extends AbstractOrderedBidiMapTest<K, V> {
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(UnmodifiableOrderedBidiMapTest.class);
     }
 
@@ -90,11 +89,13 @@ public class UnmodifiableOrderedBidiMapTest<K extends Comparable<K>, V extends C
         return false;
     }
 
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullMap() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final OrderedBidiMap<K, V> map = makeFullMap();
         assertSame(map, UnmodifiableOrderedBidiMap.unmodifiableOrderedBidiMap(map));

--- a/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableSortedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableSortedBidiMapTest.java
@@ -21,18 +21,17 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.SortedBidiMap;
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
 
 /**
  * JUnit tests.
  */
 public class UnmodifiableSortedBidiMapTest<K extends Comparable<K>, V extends Comparable<V>> extends AbstractSortedBidiMapTest<K, V> {
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(UnmodifiableSortedBidiMapTest.class);
     }
 
@@ -94,11 +93,13 @@ public class UnmodifiableSortedBidiMapTest<K extends Comparable<K>, V extends Co
         return false;
     }
 
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullMap() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final SortedBidiMap<K, V> map = makeFullMap();
         assertSame(map, UnmodifiableSortedBidiMap.unmodifiableSortedBidiMap(map));

--- a/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.apache.commons.collections4.AbstractObjectTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link java.util.Collection} methods and contracts.
@@ -489,6 +490,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests {@link Collection#add(Object)}.
      */
+    @Test
     public void testCollectionAdd() {
         if (!isAddSupported()) {
             return;
@@ -521,6 +523,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests {@link Collection#addAll(Collection)}.
      */
+    @Test
     public void testCollectionAddAll() {
         if (!isAddSupported()) {
             return;
@@ -565,6 +568,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
      *  If {@link #isAddSupported()} returns false, tests that add operations
      *  raise <code>UnsupportedOperationException.
      */
+    @Test
     public void testUnsupportedAdd() {
         if (isAddSupported()) {
             return;
@@ -616,6 +620,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Test {@link Collection#clear()}.
      */
+    @Test
     public void testCollectionClear() {
         if (!isRemoveSupported()) {
             return;
@@ -634,6 +639,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests {@link Collection#contains(Object)}.
      */
+    @Test
     public void testCollectionContains() {
         Object[] elements;
 
@@ -671,6 +677,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests {@link Collection#containsAll(Collection)}.
      */
+    @Test
     public void testCollectionContainsAll() {
         resetEmpty();
         Collection<E> col = new HashSet<>();
@@ -714,6 +721,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests {@link Collection#isEmpty()}.
      */
+    @Test
     public void testCollectionIsEmpty() {
         resetEmpty();
         assertTrue("New Collection should be empty.", getCollection().isEmpty());
@@ -729,6 +737,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests the read-only functionality of {@link Collection#iterator()}.
      */
+    @Test
     public void testCollectionIterator() {
         resetEmpty();
         Iterator<E> it1 = getCollection().iterator();
@@ -772,6 +781,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests removals from {@link Collection#iterator()}.
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testCollectionIteratorRemove() {
         if (!isRemoveSupported()) {
@@ -843,6 +853,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests {@link Collection#remove(Object)}.
      */
+    @Test
     public void testCollectionRemove() {
         if (!isRemoveSupported()) {
             return;
@@ -889,6 +900,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests {@link Collection#removeAll(Collection)}.
      */
+    @Test
     public void testCollectionRemoveAll() {
         if (!isRemoveSupported()) {
             return;
@@ -933,6 +945,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
      *  Tests {@link Collection#removeIf(Predicate)}.
      * @since 4.4
      */
+    @Test
     public void testCollectionRemoveIf() {
         if (!isRemoveSupported()) {
             return;
@@ -976,6 +989,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests {@link Collection#retainAll(Collection)}.
      */
+    @Test
     public void testCollectionRetainAll() {
         if (!isRemoveSupported()) {
             return;
@@ -1036,6 +1050,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests {@link Collection#size()}.
      */
+    @Test
     public void testCollectionSize() {
         resetEmpty();
         assertEquals("Size of new Collection is 0.", 0, getCollection().size());
@@ -1047,6 +1062,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests {@link Collection#toArray()}.
      */
+    @Test
     public void testCollectionToArray() {
         resetEmpty();
         assertEquals("Empty Collection should return empty array for toArray",
@@ -1091,6 +1107,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests {@link Collection#toArray(Object[])}.
      */
+    @Test
     public void testCollectionToArray2() {
         resetEmpty();
         Object[] a = { new Object(), null, null };
@@ -1149,6 +1166,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests {@code toString} on a collection.
      */
+    @Test
     public void testCollectionToString() {
         resetEmpty();
         assertNotNull("toString shouldn't return null", getCollection().toString());
@@ -1161,6 +1179,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
      *  If isRemoveSupported() returns false, tests to see that remove
      *  operations raise an UnsupportedOperationException.
      */
+    @Test
     public void testUnsupportedRemove() {
         if (isRemoveSupported()) {
             return;
@@ -1223,6 +1242,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     /**
      *  Tests that the collection's iterator is fail-fast.
      */
+    @Test
     public void testCollectionIteratorFailFast() {
         if (!isFailFastSupported()) {
             return;
@@ -1313,6 +1333,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         }
     }
 
+    @Test
     @Override
     public void testSerializeDeserializeThenCompare() throws Exception {
         Object obj = makeObject();

--- a/src/test/java/org/apache/commons/collections4/collection/CompositeCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/CompositeCollectionTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -146,6 +147,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         two = new HashSet<>();
     }
 
+    @Test
     @SuppressWarnings({ "unchecked", "serial" })
     public void testAddAllMutator() {
         setUpTest();
@@ -182,6 +184,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertTrue(one.contains("foo"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testAddAllToCollection() {
         setUpTest();
@@ -193,6 +196,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertEquals(c.size(), toCollection.size());
     }
 
+    @Test
     @SuppressWarnings({ "unchecked", "serial" })
     public void testAddMutator() {
         setUpTest();
@@ -228,7 +232,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertTrue(one.contains("foo"));
     }
 
-
+    @Test
     @SuppressWarnings("unchecked")
     public void testClear() {
         setUpTest();
@@ -241,6 +245,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertTrue(c.isEmpty());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testContainsAll() {
         setUpTest();
@@ -251,6 +256,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertFalse(c.containsAll(null));
     }
 
+    @Test
     public void testAddNullList() {
         final ArrayList<String> nullList = null;
         final CompositeCollection<String> cc = new CompositeCollection<>();
@@ -258,6 +264,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         Assertions.assertEquals(0, cc.size());
     }
 
+    @Test
     public void testAddNullLists2Args() {
         final ArrayList<String> nullList = null;
         final CompositeCollection<String> cc = new CompositeCollection<>();
@@ -265,6 +272,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         Assertions.assertEquals(0, cc.size());
     }
 
+    @Test
     public void testAddNullListsVarArgs() {
         final ArrayList<String> nullList = null;
         final CompositeCollection<String> cc = new CompositeCollection<>();
@@ -272,6 +280,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         Assertions.assertEquals(0, cc.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIsEmpty() {
         setUpTest();
@@ -283,6 +292,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertFalse(c.isEmpty());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIterator() {
         setUpTest();
@@ -300,6 +310,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertFalse(two.contains(next));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultipleCollectionsSize() {
         setUpTest();
@@ -313,6 +324,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertEquals(set.size() + other.size(), c.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemove() {
         setUpMutatorTest();
@@ -326,6 +338,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertFalse(two.contains("1"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveAll() {
         setUpMutatorTest();
@@ -348,6 +361,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
     /**
      * @since 4.4
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveIf() {
         setUpMutatorTest();
@@ -367,6 +381,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertFalse(two.contains("1"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveComposited() {
         setUpMutatorTest();
@@ -379,6 +394,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertEquals(2, c.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRetainAll() {
         setUpTest();
@@ -398,6 +414,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertTrue(one.contains("1"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSize() {
         setUpTest();
@@ -408,6 +425,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         assertEquals(set.size(), c.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testToCollection() {
         setUpTest();
@@ -425,6 +443,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
      * Override testUnsupportedRemove, since the default impl expects removeAll,
      * retainAll and iterator().remove to throw
      */
+    @Test
     @Override
     public void testUnsupportedRemove() {
         resetFull();

--- a/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.apache.commons.collections4.Transformer;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -104,6 +105,7 @@ public class IndexedCollectionTest extends AbstractCollectionTest<String> {
 
     //------------------------------------------------------------------------
 
+    @Test
     public void testAddedObjectsCanBeRetrievedByKey() throws Exception {
         final Collection<String> coll = makeTestCollection();
         coll.add("12");
@@ -121,6 +123,7 @@ public class IndexedCollectionTest extends AbstractCollectionTest<String> {
         assertEquals("4", indexed.get(4));
     }
 
+    @Test
     public void testEnsureDuplicateObjectsCauseException() throws Exception {
         final Collection<String> coll = makeUniqueTestCollection();
 
@@ -129,6 +132,7 @@ public class IndexedCollectionTest extends AbstractCollectionTest<String> {
         assertThrows(IllegalArgumentException.class, () -> coll.add("1"));
     }
 
+    @Test
     public void testDecoratedCollectionIsIndexedOnCreation() throws Exception {
         final Collection<String> original = makeFullCollection();
         final IndexedCollection<Integer, String> indexed = decorateUniqueCollection(original);
@@ -138,6 +142,7 @@ public class IndexedCollectionTest extends AbstractCollectionTest<String> {
         assertEquals("3", indexed.get(3));
     }
 
+    @Test
     public void testReindexUpdatesIndexWhenDecoratedCollectionIsModifiedSeparately() throws Exception {
         final Collection<String> original = new ArrayList<>();
         final IndexedCollection<Integer, String> indexed = decorateUniqueCollection(original);

--- a/src/test/java/org/apache/commons/collections4/collection/PredicatedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/PredicatedCollectionTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -80,6 +81,7 @@ public class PredicatedCollectionTest<E> extends AbstractCollectionTest<E> {
         return decorateCollection(new ArrayList<E>(), testPredicate);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalAdd() {
         final Collection<E> c = makeTestCollection();
@@ -90,6 +92,7 @@ public class PredicatedCollectionTest<E> extends AbstractCollectionTest<E> {
         assertFalse("Collection shouldn't contain illegal element", c.contains(i));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalAddAll() {
         final Collection<E> c = makeTestCollection();

--- a/src/test/java/org/apache/commons/collections4/collection/TransformedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/TransformedCollectionTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the {@link TransformedCollection}
@@ -86,6 +87,7 @@ public class TransformedCollectionTest extends AbstractCollectionTest<Object> {
         return new Object[] {"9", "88", "678", "87", "98", "78", "99"};
     }
 
+    @Test
     public void testTransformedCollection() {
         final Collection<Object> coll = TransformedCollection.transformingCollection(new ArrayList<>(), STRING_TO_INTEGER_TRANSFORMER);
         assertEquals(0, coll.size());
@@ -100,6 +102,7 @@ public class TransformedCollectionTest extends AbstractCollectionTest<Object> {
         assertTrue(coll.remove(Integer.valueOf((String) elements[0])));
     }
 
+    @Test
     public void testTransformedCollection_decorateTransform() {
         final Collection<Object> originalCollection = new ArrayList<>();
         final Object[] elements = getFullElements();

--- a/src/test/java/org/apache/commons/collections4/collection/UnmodifiableBoundedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/UnmodifiableBoundedCollectionTest.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import org.apache.commons.collections4.BoundedCollection;
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.list.FixedSizeList;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -79,12 +80,13 @@ public class UnmodifiableBoundedCollectionTest<E> extends AbstractCollectionTest
         return "4";
     }
 
-
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullCollection() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final BoundedCollection<E> coll = makeFullCollection();
         assertSame(coll, UnmodifiableBoundedCollection.unmodifiableBoundedCollection(coll));

--- a/src/test/java/org/apache/commons/collections4/collection/UnmodifiableCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/UnmodifiableCollectionTest.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -68,12 +69,13 @@ public class UnmodifiableCollectionTest<E> extends AbstractCollectionTest<E> {
         return false;
     }
 
-
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullCollection() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final Collection<E> coll = makeFullCollection();
         assertSame(coll, UnmodifiableCollection.unmodifiableCollection(coll));

--- a/src/test/java/org/apache/commons/collections4/comparators/AbstractComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/AbstractComparatorTest.java
@@ -175,8 +175,8 @@ public abstract class AbstractComparatorTest<T> extends AbstractObjectTest {
      * Compare the current serialized form of the Comparator
      * against the canonical version in SCM.
      */
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testComparatorCompatibility() throws IOException, ClassNotFoundException {
         if (!skipSerializedCanonicalTests()) {
             Comparator<T> comparator = null;

--- a/src/test/java/org/apache/commons/collections4/comparators/AbstractNullComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/AbstractNullComparatorTest.java
@@ -20,7 +20,6 @@ import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
-import junit.framework.Test;
 import junit.framework.TestSuite;
 
 /**
@@ -33,7 +32,7 @@ public abstract class AbstractNullComparatorTest extends AbstractComparatorTest<
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         final TestSuite suite = new TestSuite(AbstractNullComparatorTest.class.getName());
         suite.addTest(new TestSuite(TestNullComparator1.class));
         suite.addTest(new TestSuite(TestNullComparator2.class));

--- a/src/test/java/org/apache/commons/collections4/comparators/BooleanComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/BooleanComparatorTest.java
@@ -74,7 +74,6 @@ public class BooleanComparatorTest extends AbstractComparatorTest<Boolean> {
     }
 
     @Test
-
     public void testStaticFactoryMethods() {
         allTests(false, BooleanComparator.getFalseFirstComparator());
         allTests(false, BooleanComparator.booleanComparator(false));

--- a/src/test/java/org/apache/commons/collections4/comparators/ReverseComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/ReverseComparatorTest.java
@@ -77,8 +77,8 @@ public class ReverseComparatorTest extends AbstractComparatorTest<Integer> {
      * doesn't adhere to the "soft" Comparator contract, and we've
      * already "canonized" the comparator returned by makeComparator.
      */
-    @Override
     @Test
+    @Override
     public void testSerializeDeserializeThenCompare() throws Exception {
         final Comparator<?> comp = new ReverseComparator<>(new ComparableComparator<String>());
 

--- a/src/test/java/org/apache/commons/collections4/comparators/TransformingComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/TransformingComparatorTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.commons.collections4.ComparatorUtils;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
+import org.junit.Test;
 
 /**
  * Test class for TransformingComparator.
@@ -60,6 +61,7 @@ public class TransformingComparatorTest extends AbstractComparatorTest<Integer> 
         return list;
     }
 
+    @Test
     public void testEquals() {
         final Transformer<String, String> t1 = TransformerUtils.nopTransformer();
         final TransformingComparator<String, String> comp1 = new TransformingComparator<>(t1);

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractIteratorTest.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.AbstractObjectTest;
+import org.junit.Test;
 
 /**
  * Abstract class for testing the Iterator interface.
@@ -97,6 +98,7 @@ public abstract class AbstractIteratorTest<E> extends AbstractObjectTest {
     /**
      * Test the empty iterator.
      */
+    @Test
     public void testEmptyIterator() {
         if (!supportsEmptyIterator()) {
             return;
@@ -121,6 +123,7 @@ public abstract class AbstractIteratorTest<E> extends AbstractObjectTest {
     /**
      * Test normal iteration behavior.
      */
+    @Test
     public void testFullIterator() {
         if (!supportsFullIterator()) {
             return;
@@ -157,6 +160,7 @@ public abstract class AbstractIteratorTest<E> extends AbstractObjectTest {
     /**
      * Test remove behavior.
      */
+    @Test
     public void testRemove() {
         final Iterator<E> it = makeObject();
 

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractListIteratorTest.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
+import org.junit.Test;
+
 /**
  * Abstract class for testing the ListIterator interface.
  * <p>
@@ -88,6 +90,7 @@ public abstract class AbstractListIteratorTest<E> extends AbstractIteratorTest<E
     /**
      * Test that the empty list iterator contract is correct.
      */
+    @Test
     public void testEmptyListIteratorIsIndeedEmpty() {
         if (!supportsEmptyIterator()) {
             return;
@@ -118,6 +121,7 @@ public abstract class AbstractListIteratorTest<E> extends AbstractIteratorTest<E
     /**
      * Test navigation through the iterator.
      */
+    @Test
     public void testWalkForwardAndBack() {
         final ArrayList<E> list = new ArrayList<>();
         final ListIterator<E> it = makeObject();
@@ -156,6 +160,7 @@ public abstract class AbstractListIteratorTest<E> extends AbstractIteratorTest<E
     /**
      * Test add behavior.
      */
+    @Test
     public void testAdd() {
         ListIterator<E> it = makeObject();
 
@@ -193,6 +198,7 @@ public abstract class AbstractListIteratorTest<E> extends AbstractIteratorTest<E
     /**
      * Test set behavior.
      */
+    @Test
     public void testSet() {
         final ListIterator<E> it = makeObject();
 
@@ -220,6 +226,7 @@ public abstract class AbstractListIteratorTest<E> extends AbstractIteratorTest<E
 
     }
 
+    @Test
     public void testRemoveThenSet() {
         final ListIterator<E> it = makeObject();
         if (supportsRemove() && supportsSet()) {
@@ -233,6 +240,7 @@ public abstract class AbstractListIteratorTest<E> extends AbstractIteratorTest<E
         }
     }
 
+    @Test
     public void testAddThenSet() {
         final ListIterator<E> it = makeObject();
         // add then set
@@ -250,6 +258,7 @@ public abstract class AbstractListIteratorTest<E> extends AbstractIteratorTest<E
     /**
      * Test remove after add behavior.
      */
+    @Test
     public void testAddThenRemove() {
         final ListIterator<E> it = makeObject();
 

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractMapIteratorTest.java
@@ -22,6 +22,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 import org.apache.commons.collections4.MapIterator;
+import org.junit.Test;
 
 /**
  * Abstract class for testing the MapIterator interface.
@@ -108,6 +109,7 @@ public abstract class AbstractMapIteratorTest<K, V> extends AbstractIteratorTest
     /**
      * Test that the empty list iterator contract is correct.
      */
+    @Test
     public void testEmptyMapIterator() {
         if (!supportsEmptyIterator()) {
             return;
@@ -154,6 +156,7 @@ public abstract class AbstractMapIteratorTest<K, V> extends AbstractIteratorTest
     /**
      * Test that the full list iterator contract is correct.
      */
+    @Test
     public void testFullMapIterator() {
         if (!supportsFullIterator()) {
             return;
@@ -183,6 +186,7 @@ public abstract class AbstractMapIteratorTest<K, V> extends AbstractIteratorTest
         }
     }
 
+    @Test
     public void testMapIteratorSet() {
         if (!supportsFullIterator()) {
             return;
@@ -229,6 +233,7 @@ public abstract class AbstractMapIteratorTest<K, V> extends AbstractIteratorTest
         verify();
     }
 
+    @Test
     @Override
     public void testRemove() { // override
         final MapIterator<K, V> it = makeObject();
@@ -258,6 +263,7 @@ public abstract class AbstractMapIteratorTest<K, V> extends AbstractIteratorTest
         verify();
     }
 
+    @Test
     public void testMapIteratorSetRemoveSet() {
         if (!supportsSetValue() || !supportsRemove()) {
             return;
@@ -281,6 +287,7 @@ public abstract class AbstractMapIteratorTest<K, V> extends AbstractIteratorTest
         verify();
     }
 
+    @Test
     public void testMapIteratorRemoveGetKey() {
         if (!supportsRemove()) {
             return;
@@ -302,6 +309,7 @@ public abstract class AbstractMapIteratorTest<K, V> extends AbstractIteratorTest
         verify();
     }
 
+    @Test
     public void testMapIteratorRemoveGetValue() {
         if (!supportsRemove()) {
             return;

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractOrderedMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractOrderedMapIteratorTest.java
@@ -27,6 +27,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 import org.apache.commons.collections4.OrderedMapIterator;
+import org.junit.Test;
 
 /**
  * Abstract class for testing the OrderedMapIterator interface.
@@ -58,6 +59,7 @@ public abstract class AbstractOrderedMapIteratorTest<K, V> extends AbstractMapIt
     /**
      * Test that the empty list iterator contract is correct.
      */
+    @Test
     @Override
     public void testEmptyMapIterator() {
         if (!supportsEmptyIterator()) {
@@ -75,6 +77,7 @@ public abstract class AbstractOrderedMapIteratorTest<K, V> extends AbstractMapIt
     /**
      * Test that the full list iterator contract is correct.
      */
+    @Test
     @Override
     public void testFullMapIterator() {
         if (!supportsFullIterator()) {
@@ -130,6 +133,7 @@ public abstract class AbstractOrderedMapIteratorTest<K, V> extends AbstractMapIt
     /**
      * Test that the iterator order matches the keySet order.
      */
+    @Test
     public void testMapIteratorOrder() {
         if (!supportsFullIterator()) {
             return;

--- a/src/test/java/org/apache/commons/collections4/iterators/ArrayIterator2Test.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ArrayIterator2Test.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import org.junit.Test;
+
 /**
  * Tests the ArrayIterator with primitive type arrays.
  */
@@ -60,6 +62,7 @@ public class ArrayIterator2Test<E> extends AbstractIteratorTest<E> {
         return false;
     }
 
+    @Test
     public void testIterator() {
         final Iterator<E> iter = makeObject();
         for (final int element : testArray) {
@@ -78,6 +81,7 @@ public class ArrayIterator2Test<E> extends AbstractIteratorTest<E> {
         }
     }
 
+    @Test
     public void testIndexedArray() {
         Iterator<E> iter = makeArrayIterator(testArray, 2);
         int count = 0;

--- a/src/test/java/org/apache/commons/collections4/iterators/ArrayIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ArrayIteratorTest.java
@@ -19,6 +19,8 @@ package org.apache.commons.collections4.iterators;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import org.junit.Test;
+
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -49,6 +51,7 @@ public class ArrayIteratorTest<E> extends AbstractIteratorTest<E> {
         return false;
     }
 
+    @Test
     public void testIterator() {
         final Iterator<E> iter = makeObject();
         for (final String testValue : testArray) {
@@ -62,10 +65,12 @@ public class ArrayIteratorTest<E> extends AbstractIteratorTest<E> {
         assertThrows(NoSuchElementException.class, iter::next, "NoSuchElementException must be thrown");
     }
 
+    @Test
     public void testNullArray() {
         assertThrows(NullPointerException.class, () -> new ArrayIterator<>(null));
     }
 
+    @Test
     public void testReset() {
         final ArrayIterator<E> it = makeObject();
         it.next();

--- a/src/test/java/org/apache/commons/collections4/iterators/ArrayListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ArrayListIteratorTest.java
@@ -19,6 +19,8 @@ package org.apache.commons.collections4.iterators;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
+import org.junit.Test;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -54,6 +56,7 @@ public class ArrayListIteratorTest<E> extends ArrayIteratorTest<E> {
      * Test the basic ListIterator functionality - going backwards using
      * {@code previous()}.
      */
+    @Test
     public void testListIterator() {
         final ListIterator<E> iter = makeObject();
 
@@ -85,6 +88,7 @@ public class ArrayListIteratorTest<E> extends ArrayIteratorTest<E> {
     /**
      * Tests the {@link java.util.ListIterator#set} operation.
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testListIteratorSet() {
         final String[] testData = { "a", "b", "c" };

--- a/src/test/java/org/apache/commons/collections4/iterators/CollatingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/CollatingIteratorTest.java
@@ -22,6 +22,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.apache.commons.collections4.comparators.ComparableComparator;
+import org.junit.Test;
 
 /**
  * Unit test suite for {@link CollatingIterator}.
@@ -85,6 +86,7 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
 
     //------------------------------------------------------------------- Tests
 
+    @Test
     public void testGetSetComparator() {
         final CollatingIterator<Integer> iter = new CollatingIterator<>();
         assertNull(iter.getComparator());
@@ -94,6 +96,7 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
         assertNull(iter.getComparator());
     }
 
+    @Test
     public void testIterateEven() {
         final CollatingIterator<Integer> iter = new CollatingIterator<>(comparator);
         iter.addIterator(evens.iterator());
@@ -105,6 +108,7 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
         assertFalse(iter.hasNext());
     }
 
+    @Test
     public void testIterateEvenOdd() {
         final CollatingIterator<Integer> iter = new CollatingIterator<>(comparator, evens.iterator(), odds.iterator());
         for (int i = 0; i < 20; i++) {
@@ -115,6 +119,7 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
         assertFalse(iter.hasNext());
     }
 
+    @Test
     public void testIterateOddEven() {
         final CollatingIterator<Integer> iter = new CollatingIterator<>(comparator, odds.iterator(), evens.iterator());
         for (int i = 0; i < 20; i++) {
@@ -125,6 +130,7 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
         assertFalse(iter.hasNext());
     }
 
+    @Test
     public void testIterateEvenEven() {
         final CollatingIterator<Integer> iter = new CollatingIterator<>(comparator);
         iter.addIterator(evens.iterator());
@@ -140,6 +146,7 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
         assertFalse(iter.hasNext());
     }
 
+    @Test
     public void testIterateFibEvenOdd() {
         final CollatingIterator<Integer> iter = new CollatingIterator<>(comparator);
         iter.addIterator(fib.iterator());
@@ -206,6 +213,7 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
         assertFalse(iter.hasNext());
     }
 
+    @Test
     public void testRemoveFromSingle() {
         final CollatingIterator<Integer> iter = new CollatingIterator<>(comparator);
         iter.addIterator(evens.iterator());
@@ -221,6 +229,7 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
         assertEquals(expectedSize, evens.size());
     }
 
+    @Test
     public void testRemoveFromDouble() {
         final CollatingIterator<Integer> iter = new CollatingIterator<>(comparator);
         iter.addIterator(evens.iterator());
@@ -237,6 +246,7 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
         assertEquals(expectedSize, evens.size() + odds.size());
     }
 
+    @Test
     public void testNullComparator() {
         final List<Integer> l1 = Arrays.asList(1, 3, 5);
         final List<Integer> l2 = Arrays.asList(2, 4, 6);

--- a/src/test/java/org/apache/commons/collections4/iterators/FilterIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/FilterIteratorTest.java
@@ -28,6 +28,7 @@ import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.NotNullPredicate;
+import org.junit.Test;
 
 /**
  * Test the filter iterator.
@@ -84,12 +85,14 @@ public class FilterIteratorTest<E> extends AbstractIteratorTest<E> {
         return makePassThroughFilter(list.iterator());
     }
 
+    @Test
     public void testRepeatedHasNext() {
         for (int i = 0; i <= array.length; i++) {
             assertTrue(iterator.hasNext());
         }
     }
 
+    @Test
     @SuppressWarnings("unused")
     public void testRepeatedNext() {
         for (final String element : array) {
@@ -98,6 +101,7 @@ public class FilterIteratorTest<E> extends AbstractIteratorTest<E> {
         verifyNoMoreElements();
     }
 
+    @Test
     public void testReturnValues() {
         verifyElementsInPredicate(new String[0]);
         verifyElementsInPredicate(new String[] { "a" });
@@ -113,6 +117,7 @@ public class FilterIteratorTest<E> extends AbstractIteratorTest<E> {
      * Test that when the iterator is changed, the hasNext method returns the
      * correct response for the new iterator.
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testSetIterator() {
         final Iterator<E> iter1 = Collections.singleton((E) new Object()).iterator();
@@ -132,6 +137,7 @@ public class FilterIteratorTest<E> extends AbstractIteratorTest<E> {
      * Test that when the predicate is changed, the hasNext method returns the
      * correct response for the new predicate.
      */
+    @Test
     public void testSetPredicate() {
         final Iterator<E> iter = Collections.singleton((E) null).iterator();
 

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
@@ -26,6 +26,7 @@ import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.collections4.Predicate;
+import org.junit.Test;
 
 /**
  * Tests the IteratorChain class.
@@ -73,6 +74,7 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         return chain;
     }
 
+    @Test
     public void testIterator() {
         final Iterator<String> iter = makeObject();
         for (final String testValue : testArray) {
@@ -90,6 +92,7 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         }
     }
 
+    @Test
     public void testRemoveFromFilteredIterator() {
 
         final Predicate<Integer> myPredicate = i -> i.compareTo(Integer.valueOf(4)) < 0;
@@ -114,6 +117,7 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         assertEquals(1, list2.size());
     }
 
+    @Test
     @Override
     public void testRemove() {
         final Iterator<String> iter = makeObject();
@@ -136,6 +140,7 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         assertTrue("List is empty", list3.isEmpty());
     }
 
+    @Test
     public void testFirstIteratorIsEmptyBug() {
         final List<String> empty = new ArrayList<>();
         final List<String> notEmpty = new ArrayList<>();
@@ -154,6 +159,7 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         assertFalse("should not have next", chain.hasNext());
     }
 
+    @Test
     public void testEmptyChain() {
         final IteratorChain<Object> chain = new IteratorChain<>();
         assertFalse(chain.hasNext());

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorIterableTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorIterableTest.java
@@ -20,9 +20,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
+import org.junit.Test;
 
 /**
  * Tests for IteratorIterable.
@@ -30,7 +29,7 @@ import org.apache.commons.collections4.BulkTest;
  */
 public class IteratorIterableTest extends BulkTest {
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(IteratorIterableTest.class);
     }
 
@@ -47,6 +46,7 @@ public class IteratorIterableTest extends BulkTest {
         return iter;
     }
 
+    @Test
     @SuppressWarnings("unused")
     public void testIterator() {
         final Iterator<Integer> iter = createIterator();
@@ -61,6 +61,7 @@ public class IteratorIterableTest extends BulkTest {
         }
     }
 
+    @Test
     public void testMultipleUserIterator() {
         final Iterator<Integer> iter = createIterator();
 

--- a/src/test/java/org/apache/commons/collections4/iterators/LazyIteratorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/LazyIteratorChainTest.java
@@ -26,6 +26,7 @@ import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.collections4.Predicate;
+import org.junit.Test;
 
 /**
  * Tests the LazyIteratorChain class.
@@ -87,6 +88,7 @@ public class LazyIteratorChainTest extends AbstractIteratorTest<String> {
         return chain;
     }
 
+    @Test
     public void testIterator() {
         final Iterator<String> iter = makeObject();
         for (final String testValue : testArray) {
@@ -104,6 +106,7 @@ public class LazyIteratorChainTest extends AbstractIteratorTest<String> {
         }
     }
 
+    @Test
     public void testRemoveFromFilteredIterator() {
 
         final Predicate<Integer> myPredicate = i -> i.compareTo(Integer.valueOf(4)) < 0;
@@ -128,6 +131,7 @@ public class LazyIteratorChainTest extends AbstractIteratorTest<String> {
         assertEquals(1, list2.size());
     }
 
+    @Test
     @Override
     public void testRemove() {
         final Iterator<String> iter = makeObject();
@@ -150,6 +154,7 @@ public class LazyIteratorChainTest extends AbstractIteratorTest<String> {
         assertTrue("List is empty", list3.isEmpty());
     }
 
+    @Test
     public void testFirstIteratorIsEmptyBug() {
         final List<String> empty = new ArrayList<>();
         final List<String> notEmpty = new ArrayList<>();
@@ -177,6 +182,7 @@ public class LazyIteratorChainTest extends AbstractIteratorTest<String> {
         assertFalse("should not have next", chain.hasNext());
     }
 
+    @Test
     public void testEmptyChain() {
         final LazyIteratorChain<String> chain = makeEmptyIterator();
         assertFalse(chain.hasNext());

--- a/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapper2Test.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapper2Test.java
@@ -22,6 +22,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.ResettableListIterator;
+import org.junit.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -63,6 +64,7 @@ public class ListIteratorWrapper2Test<E> extends AbstractIteratorTest<E> {
         return new ListIteratorWrapper<>(list1.listIterator());
     }
 
+    @Test
     public void testIterator() {
         final ListIterator<E> iter = makeObject();
         for (final String testValue : testArray) {
@@ -102,6 +104,7 @@ public class ListIteratorWrapper2Test<E> extends AbstractIteratorTest<E> {
 
     }
 
+    @Test
     @Override
     public void testRemove() {
         final ListIterator<E> iter = makeObject();
@@ -171,6 +174,7 @@ public class ListIteratorWrapper2Test<E> extends AbstractIteratorTest<E> {
         //further testing would be fairly meaningless:
     }
 
+    @Test
     public void testReset() {
         final ResettableListIterator<E> iter = makeObject();
         final E first = iter.next();

--- a/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapperTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapperTest.java
@@ -24,6 +24,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.ResettableListIterator;
+import org.junit.Test;
 
 /**
  * Tests the ListIteratorWrapper to insure that it simulates
@@ -64,6 +65,7 @@ public class ListIteratorWrapperTest<E> extends AbstractIteratorTest<E> {
         return new ListIteratorWrapper<>(list1.iterator());
     }
 
+    @Test
     public void testIterator() {
         final ListIterator<E> iter = makeObject();
         for (final String testValue : testArray) {
@@ -103,6 +105,7 @@ public class ListIteratorWrapperTest<E> extends AbstractIteratorTest<E> {
 
     }
 
+    @Test
     @Override
     public void testRemove() {
         final ListIterator<E> iter = makeObject();
@@ -193,6 +196,7 @@ public class ListIteratorWrapperTest<E> extends AbstractIteratorTest<E> {
 
     }
 
+    @Test
     public void testReset() {
         final ResettableListIterator<E> iter = makeObject();
         final E first = iter.next();

--- a/src/test/java/org/apache/commons/collections4/iterators/NodeListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/NodeListIteratorTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Iterator;
 
+import org.junit.Test;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -111,6 +112,7 @@ public class NodeListIteratorTest extends AbstractIteratorTest<Node> {
         return false;
     }
 
+    @Test
     public void testNullConstructor() {
         assertThrows(NullPointerException.class, () -> new NodeListIterator((Node) null));
     }
@@ -118,6 +120,7 @@ public class NodeListIteratorTest extends AbstractIteratorTest<Node> {
     /**
      * tests the convenience Constructor with parameter type org.w3c.Node
      */
+    @Test
     public void testEmptyIteratorWithNodeConstructor(){
         createIteratorWithStandardConstr = false;
         testEmptyIterator();
@@ -126,6 +129,7 @@ public class NodeListIteratorTest extends AbstractIteratorTest<Node> {
     /**
      * tests the convenience Constructor with parameter type org.w3c.Node
      */
+    @Test
     public void testFullIteratorWithNodeConstructor(){
         createIteratorWithStandardConstr = false;
         testFullIterator();

--- a/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayIteratorTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import org.junit.Test;
+
 /**
  * Tests the ObjectArrayIterator.
  */
@@ -66,6 +68,7 @@ public class ObjectArrayIteratorTest<E> extends AbstractIteratorTest<E> {
         return false;
     }
 
+    @Test
     public void testIterator() {
         final Iterator<E> iter = makeObject();
         for (final String testValue : testArray) {
@@ -83,10 +86,12 @@ public class ObjectArrayIteratorTest<E> extends AbstractIteratorTest<E> {
         }
     }
 
+    @Test
     public void testNullArray() {
         assertThrows(NullPointerException.class, () -> makeArrayIterator(null));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testReset() {
         final ObjectArrayIterator<E> it = makeArrayIterator((E[]) testArray);

--- a/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayListIteratorTest.java
@@ -19,6 +19,8 @@ package org.apache.commons.collections4.iterators;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
+import org.junit.Test;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -51,6 +53,7 @@ public class ObjectArrayListIteratorTest<E> extends ObjectArrayIteratorTest<E> {
      * Test the basic ListIterator functionality - going backwards using
      * {@code previous()}.
      */
+    @Test
     public void testListIterator() {
         final ListIterator<E> iter = makeObject();
 
@@ -82,6 +85,7 @@ public class ObjectArrayListIteratorTest<E> extends ObjectArrayIteratorTest<E> {
     /**
      * Tests the {@link java.util.ListIterator#set} operation.
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testListIteratorSet() {
         final String[] testData = { "a", "b", "c" };

--- a/src/test/java/org/apache/commons/collections4/iterators/ObjectGraphIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ObjectGraphIteratorTest.java
@@ -25,6 +25,7 @@ import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.collections4.Transformer;
+import org.junit.Test;
 
 /**
  * Testcase.
@@ -70,6 +71,7 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         return new ObjectGraphIterator<>(iteratorList.iterator());
     }
 
+    @Test
     public void testIteratorConstructor_null1() {
         final Iterator<Object> it = new ObjectGraphIterator<>(null);
 
@@ -80,16 +82,19 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         assertThrows(IllegalStateException.class, () -> it.remove());
     }
 
+    @Test
     public void testIteratorConstructor_null_next() {
         final Iterator<Object> it = new ObjectGraphIterator<>(null);
         assertThrows(NoSuchElementException.class, () -> it.next());
     }
 
+    @Test
     public void testIteratorConstructor_null_remove() {
         final Iterator<Object> it = new ObjectGraphIterator<>(null);
         assertThrows(IllegalStateException.class, () -> it.remove());
     }
 
+    @Test
     public void testIteratorConstructorIteration_Empty() {
         final List<Iterator<Object>> iteratorList = new ArrayList<>();
         final Iterator<Object> it = new ObjectGraphIterator<>(iteratorList.iterator());
@@ -101,6 +106,7 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         assertThrows(IllegalStateException.class, () -> it.remove());
     }
 
+    @Test
     public void testIteratorConstructorIteration_Simple() {
         final List<Iterator<String>> iteratorList = new ArrayList<>();
         iteratorList.add(list1.iterator());
@@ -117,6 +123,7 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         assertThrows(NoSuchElementException.class, () -> it.next());
     }
 
+    @Test
     public void testIteratorConstructorIteration_SimpleNoHasNext() {
         final List<Iterator<String>> iteratorList = new ArrayList<>();
         iteratorList.add(list1.iterator());
@@ -131,6 +138,7 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         assertThrows(NoSuchElementException.class, () -> it.next());
     }
 
+    @Test
     public void testIteratorConstructorIteration_WithEmptyIterators() {
         final List<Iterator<String>> iteratorList = new ArrayList<>();
         iteratorList.add(IteratorUtils.<String>emptyIterator());
@@ -151,6 +159,7 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         assertThrows(NoSuchElementException.class, () -> it.next());
     }
 
+    @Test
     public void testIteratorConstructorRemove() {
         final List<Iterator<String>> iteratorList = new ArrayList<>();
         iteratorList.add(list1.iterator());
@@ -168,6 +177,7 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         assertEquals(0, list3.size());
     }
 
+    @Test
     public void testIteration_IteratorOfIterators() {
         final List<Iterator<String>> iteratorList = new ArrayList<>();
         iteratorList.add(list1.iterator());
@@ -182,6 +192,7 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         assertFalse(it.hasNext());
     }
 
+    @Test
     public void testIteration_IteratorOfIteratorsWithEmptyIterators() {
         final List<Iterator<String>> iteratorList = new ArrayList<>();
         iteratorList.add(IteratorUtils.<String>emptyIterator());
@@ -200,6 +211,7 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         assertFalse(it.hasNext());
     }
 
+    @Test
     public void testIteration_RootNull() {
         final Iterator<Object> it = new ObjectGraphIterator<>(null, null);
 
@@ -210,6 +222,7 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         assertThrows(IllegalStateException.class, () -> it.remove());
     }
 
+    @Test
     public void testIteration_RootNoTransformer() {
         final Forest forest = new Forest();
         final Iterator<Object> it = new ObjectGraphIterator<>(forest, null);
@@ -221,6 +234,7 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         assertThrows(NoSuchElementException.class, () -> it.next());
     }
 
+    @Test
     public void testIteration_Transformed1() {
         final Forest forest = new Forest();
         final Leaf l1 = forest.addTree().addBranch().addLeaf();
@@ -233,6 +247,7 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         assertThrows(NoSuchElementException.class, () -> it.next());
     }
 
+    @Test
     public void testIteration_Transformed2() {
         final Forest forest = new Forest();
         forest.addTree();
@@ -266,6 +281,7 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         assertThrows(NoSuchElementException.class, () -> it.next());
     }
 
+    @Test
     public void testIteration_Transformed3() {
         final Forest forest = new Forest();
         forest.addTree();

--- a/src/test/java/org/apache/commons/collections4/iterators/PeekingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/PeekingIteratorTest.java
@@ -65,7 +65,6 @@ public class PeekingIteratorTest<E> extends AbstractIteratorTest<E> {
         return true;
     }
 
-
     @Test
     public void testEmpty() {
         final Iterator<E> it = makeEmptyIterator();

--- a/src/test/java/org/apache/commons/collections4/iterators/PermutationIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/PermutationIteratorTest.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
+import org.junit.Test;
+
 /**
  * Test class for PermutationIterator.
  *
@@ -68,7 +70,7 @@ public class PermutationIteratorTest extends AbstractIteratorTest<List<Character
         return new PermutationIterator<>(testList);
     }
 
-
+    @Test
     @SuppressWarnings("boxing") // OK in test code
     public void testPermutationResultSize() {
         int factorial = 1;
@@ -90,6 +92,7 @@ public class PermutationIteratorTest extends AbstractIteratorTest<List<Character
     /**
      * test checking that all the permutations are returned
      */
+    @Test
     @SuppressWarnings("boxing") // OK in test code
     public void testPermutationExhaustivity() {
         final List<Character> perm1 = new ArrayList<>();
@@ -140,6 +143,7 @@ public class PermutationIteratorTest extends AbstractIteratorTest<List<Character
     /**
      * test checking that all the permutations are returned only once.
      */
+    @Test
     public void testPermutationUnicity() {
         final List<List<Character>> resultsList = new ArrayList<>();
         final Set<List<Character>> resultsSet = new HashSet<>();
@@ -155,6 +159,7 @@ public class PermutationIteratorTest extends AbstractIteratorTest<List<Character
         assertEquals(6, resultsSet.size());
     }
 
+    @Test
     public void testPermutationException() {
         final List<List<Character>> resultsList = new ArrayList<>();
 
@@ -167,6 +172,7 @@ public class PermutationIteratorTest extends AbstractIteratorTest<List<Character
         assertThrows(NoSuchElementException.class, () -> it.next());
     }
 
+    @Test
     public void testPermutatorHasMore() {
         final PermutationIterator<Character> it = makeObject();
         for (int i = 0; i < 6; i++) {
@@ -176,6 +182,7 @@ public class PermutationIteratorTest extends AbstractIteratorTest<List<Character
         assertFalse(it.hasNext());
     }
 
+    @Test
     public void testEmptyCollection() {
         final PermutationIterator<Character> it = makeEmptyIterator();
         // there is one permutation for an empty set: 0! = 1

--- a/src/test/java/org/apache/commons/collections4/iterators/ReverseListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ReverseListIteratorTest.java
@@ -26,6 +26,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.ResettableListIterator;
+import org.junit.Test;
 
 /**
  * Tests the ReverseListIterator.
@@ -51,6 +52,7 @@ public class ReverseListIteratorTest<E> extends AbstractListIteratorTest<E> {
     }
 
     // overrides
+    @Test
     @Override
     public void testEmptyListIteratorIsIndeedEmpty() {
         final ListIterator<E> it = makeEmptyIterator();
@@ -70,6 +72,7 @@ public class ReverseListIteratorTest<E> extends AbstractListIteratorTest<E> {
         );
     }
 
+    @Test
     @Override
     public void testWalkForwardAndBack() {
         final ArrayList<E> list = new ArrayList<>();
@@ -108,6 +111,7 @@ public class ReverseListIteratorTest<E> extends AbstractListIteratorTest<E> {
                 "NoSuchElementException must be thrown from previous at start of ListIterator");
     }
 
+    @Test
     public void testReverse() {
         final ListIterator<E> it = makeObject();
         assertTrue(it.hasNext());
@@ -140,6 +144,7 @@ public class ReverseListIteratorTest<E> extends AbstractListIteratorTest<E> {
         assertEquals("Four", it.previous());
     }
 
+    @Test
     public void testReset() {
         final ResettableListIterator<E> it = makeObject();
         assertEquals("Four", it.next());

--- a/src/test/java/org/apache/commons/collections4/iterators/SingletonIterator2Test.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/SingletonIterator2Test.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.ResettableIterator;
+import org.junit.Test;
 
 /**
  * Tests the SingletonIterator to ensure that the next() method will actually
@@ -60,6 +61,7 @@ public class SingletonIterator2Test<E> extends AbstractIteratorTest<E> {
         return false;
     }
 
+    @Test
     public void testIterator() {
         final Iterator<E> iter = makeObject();
         assertTrue("Iterator has a first item", iter.hasNext());
@@ -76,6 +78,7 @@ public class SingletonIterator2Test<E> extends AbstractIteratorTest<E> {
         }
     }
 
+    @Test
     public void testReset() {
         final ResettableIterator<E> it = makeObject();
 

--- a/src/test/java/org/apache/commons/collections4/iterators/SingletonIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/SingletonIteratorTest.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.ResettableIterator;
+import org.junit.Test;
 
 /**
  * Tests the SingletonIterator to ensure that the next() method will actually
@@ -63,6 +64,7 @@ public class SingletonIteratorTest<E> extends AbstractIteratorTest<E> {
         return true;
     }
 
+    @Test
     public void testIterator() {
         final Iterator<E> iter = makeObject();
         assertTrue("Iterator has a first item", iter.hasNext());
@@ -79,6 +81,7 @@ public class SingletonIteratorTest<E> extends AbstractIteratorTest<E> {
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSingletonIteratorRemove() {
         final ResettableIterator<E> iter = new SingletonIterator<>((E) "xyzzy");
@@ -89,6 +92,7 @@ public class SingletonIteratorTest<E> extends AbstractIteratorTest<E> {
         assertFalse(iter.hasNext());
     }
 
+    @Test
     public void testReset() {
         final ResettableIterator<E> it = makeObject();
 

--- a/src/test/java/org/apache/commons/collections4/iterators/SingletonListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/SingletonListIteratorTest.java
@@ -20,6 +20,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.ResettableListIterator;
+import org.junit.Test;
 
 /**
  * Tests the SingletonListIterator.
@@ -67,6 +68,7 @@ public class SingletonListIteratorTest<E> extends AbstractListIteratorTest<E> {
         return true;
     }
 
+    @Test
     public void testIterator() {
         final ListIterator<E> iter = makeObject();
         assertTrue( "Iterator should have next item", iter.hasNext() );
@@ -111,6 +113,7 @@ public class SingletonListIteratorTest<E> extends AbstractListIteratorTest<E> {
         }
     }
 
+    @Test
     public void testReset() {
         final ResettableListIterator<E> it = makeObject();
 

--- a/src/test/java/org/apache/commons/collections4/iterators/UniqueFilterIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UniqueFilterIteratorTest.java
@@ -21,6 +21,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import org.junit.Test;
+
 /**
  * Tests the UniqueFilterIterator class.
  *
@@ -65,6 +67,7 @@ public class UniqueFilterIteratorTest<E> extends AbstractIteratorTest<E> {
         return new UniqueFilterIterator<>(i);
     }
 
+    @Test
     public void testIterator() {
         final Iterator<E> iter = makeObject();
         for (final String testValue : testArray) {

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableIteratorTest.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
 
 /**
  * Tests the UnmodifiableIterator.
@@ -63,10 +64,12 @@ public class UnmodifiableIteratorTest<E> extends AbstractIteratorTest<E> {
         return false;
     }
 
+    @Test
     public void testIterator() {
         assertTrue(makeEmptyIterator() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         Iterator<E> it = makeObject();
         assertSame(it, UnmodifiableIterator.unmodifiableIterator(it));

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableListIteratorTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.ListIterator;
 
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -73,10 +74,12 @@ public class UnmodifiableListIteratorTest<E> extends AbstractListIteratorTest<E>
         return false;
     }
 
+    @Test
     public void testListIterator() {
         assertTrue(makeEmptyIterator() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         ListIterator<E> it = makeObject();
         assertSame(it, UnmodifiableListIterator.unmodifiableListIterator(it));

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableMapIteratorTest.java
@@ -25,6 +25,7 @@ import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.bidimap.DualHashBidiMap;
+import org.junit.Test;
 
 /**
  * Tests the UnmodifiableMapIterator.
@@ -75,10 +76,12 @@ public class UnmodifiableMapIteratorTest<K, V> extends AbstractMapIteratorTest<K
         return false;
     }
 
+    @Test
     public void testMapIterator() {
         assertTrue(makeEmptyIterator() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         MapIterator<K, V> it = makeObject();
         assertSame(it, UnmodifiableMapIterator.unmodifiableMapIterator(it));

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableOrderedMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableOrderedMapIteratorTest.java
@@ -26,6 +26,7 @@ import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.OrderedMapIterator;
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.map.ListOrderedMap;
+import org.junit.Test;
 
 /**
  * Tests the UnmodifiableOrderedMapIterator.
@@ -77,10 +78,12 @@ public class UnmodifiableOrderedMapIteratorTest<K, V> extends AbstractOrderedMap
         return false;
     }
 
+    @Test
     public void testOrderedMapIterator() {
         assertTrue(makeEmptyIterator() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         OrderedMapIterator<K, V> it = makeObject();
         assertSame(it, UnmodifiableOrderedMapIterator.unmodifiableOrderedMapIterator(it));

--- a/src/test/java/org/apache/commons/collections4/iterators/ZippingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ZippingIteratorTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.collections4.iterators;
 import java.util.ArrayList;
 
 import org.apache.commons.collections4.IteratorUtils;
+import org.junit.Test;
 
 /**
  * Unit test suite for {@link ZippingIterator}.
@@ -77,6 +78,7 @@ public class ZippingIteratorTest extends AbstractIteratorTest<Integer> {
 
     //------------------------------------------------------------------- Tests
 
+    @Test
     public void testIterateEven() {
         @SuppressWarnings("unchecked")
         final ZippingIterator<Integer> iter = new ZippingIterator<>(evens.iterator());
@@ -87,6 +89,7 @@ public class ZippingIteratorTest extends AbstractIteratorTest<Integer> {
         assertFalse(iter.hasNext());
     }
 
+    @Test
     public void testIterateEvenOdd() {
         final ZippingIterator<Integer> iter = new ZippingIterator<>(evens.iterator(), odds.iterator());
         for (int i = 0; i < 20; i++) {
@@ -96,6 +99,7 @@ public class ZippingIteratorTest extends AbstractIteratorTest<Integer> {
         assertFalse(iter.hasNext());
     }
 
+    @Test
     public void testIterateOddEven() {
         final ZippingIterator<Integer> iter = new ZippingIterator<>(odds.iterator(), evens.iterator());
         for (int i = 0, j = 0; i < 20; i++) {
@@ -111,6 +115,7 @@ public class ZippingIteratorTest extends AbstractIteratorTest<Integer> {
         assertFalse(iter.hasNext());
     }
 
+    @Test
     public void testIterateEvenEven() {
         final ZippingIterator<Integer> iter = new ZippingIterator<>(evens.iterator(), evens.iterator());
         for (final Integer even : evens) {
@@ -122,6 +127,7 @@ public class ZippingIteratorTest extends AbstractIteratorTest<Integer> {
         assertFalse(iter.hasNext());
     }
 
+    @Test
     public void testIterateFibEvenOdd() {
         final ZippingIterator<Integer> iter = new ZippingIterator<>(fib.iterator(), evens.iterator(), odds.iterator());
 
@@ -157,6 +163,7 @@ public class ZippingIteratorTest extends AbstractIteratorTest<Integer> {
         assertFalse(iter.hasNext());
     }
 
+    @Test
     public void testRemoveFromSingle() {
         @SuppressWarnings("unchecked")
         final ZippingIterator<Integer> iter = new ZippingIterator<>(evens.iterator());
@@ -172,6 +179,7 @@ public class ZippingIteratorTest extends AbstractIteratorTest<Integer> {
         assertEquals(expectedSize, evens.size());
     }
 
+    @Test
     public void testRemoveFromDouble() {
         final ZippingIterator<Integer> iter = new ZippingIterator<>(evens.iterator(), odds.iterator());
         int expectedSize = evens.size() + odds.size();

--- a/src/test/java/org/apache/commons/collections4/keyvalue/AbstractMapEntryTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/AbstractMapEntryTest.java
@@ -74,8 +74,8 @@ public abstract class AbstractMapEntryTest<K, V> {
         return entry;
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testAccessorsAndMutators() {
         Map.Entry<K, V> entry = makeMapEntry((K) key, (V) value);
 
@@ -99,8 +99,8 @@ public abstract class AbstractMapEntryTest<K, V> {
      *
      */
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testSelfReferenceHandling() {
         // test that #setValue does not permit
         //  the MapEntry to contain itself (and thus cause infinite recursion
@@ -120,8 +120,8 @@ public abstract class AbstractMapEntryTest<K, V> {
      */
     public abstract void testConstructors();
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testEqualsAndHashCode() {
         // 1. test with object data
         Map.Entry<K, V> e1 = makeMapEntry((K) key, (V) value);
@@ -142,8 +142,8 @@ public abstract class AbstractMapEntryTest<K, V> {
         assertEquals(e1.hashCode(), e2.hashCode());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testToString() {
         Map.Entry<K, V> entry = makeMapEntry((K) key, (V) value);
         assertEquals(entry.toString(), entry.getKey() + "=" + entry.getValue());

--- a/src/test/java/org/apache/commons/collections4/keyvalue/DefaultKeyValueTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/DefaultKeyValueTest.java
@@ -56,8 +56,8 @@ public class DefaultKeyValueTest<K, V> {
         return new DefaultKeyValue<>(key, value);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testAccessorsAndMutators() {
         final DefaultKeyValue<K, V> kv = makeDefaultKeyValue();
 
@@ -75,8 +75,8 @@ public class DefaultKeyValueTest<K, V> {
         assertNull(kv.getValue());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testSelfReferenceHandling() {
         // test that #setKey and #setValue do not permit
         //  the KVP to contain itself (and thus cause infinite recursion
@@ -92,8 +92,8 @@ public class DefaultKeyValueTest<K, V> {
     /**
      * Subclasses should override this method to test their own constructors.
      */
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testConstructors() {
         // 1. test default constructor
         DefaultKeyValue<K, V> kv = new DefaultKeyValue<>();
@@ -126,8 +126,8 @@ public class DefaultKeyValueTest<K, V> {
         assertSame(value, kv.getValue());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testEqualsAndHashCode() {
         // 1. test with object data
         DefaultKeyValue<K, V> kv = makeDefaultKeyValue((K) key, (V) value);
@@ -146,8 +146,8 @@ public class DefaultKeyValueTest<K, V> {
         assertEquals(kv.hashCode(), kv2.hashCode());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testToString() {
         DefaultKeyValue<K, V> kv = makeDefaultKeyValue((K) key, (V) value);
         assertEquals(kv.toString(), kv.getKey() + "=" + kv.getValue());
@@ -157,8 +157,8 @@ public class DefaultKeyValueTest<K, V> {
         assertEquals(kv.toString(), kv.getKey() + "=" + kv.getValue());
     }
 
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testToMapEntry() {
         final DefaultKeyValue<K, V> kv = makeDefaultKeyValue((K) key, (V) value);
 

--- a/src/test/java/org/apache/commons/collections4/keyvalue/DefaultMapEntryTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/DefaultMapEntryTest.java
@@ -22,7 +22,6 @@ import org.apache.commons.collections4.KeyValue;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test the DefaultMapEntry class.
@@ -55,9 +54,9 @@ public class DefaultMapEntryTest<K, V> extends AbstractMapEntryTest<K, V> {
      * Subclasses should override this method.
      *
      */
+    @Test
     @Override
     @SuppressWarnings("unchecked")
-    @Test
     public void testConstructors() {
         // 1. test key-value constructor
         final Map.Entry<K, V> entry = new DefaultMapEntry<>((K) key, (V) value);
@@ -79,12 +78,13 @@ public class DefaultMapEntryTest<K, V> extends AbstractMapEntryTest<K, V> {
         assertSame(value, entry2.getValue());
     }
 
+    @Test
     @Override
     @SuppressWarnings("unchecked")
     public void testSelfReferenceHandling() {
         final Map.Entry<K, V> entry = makeMapEntry();
 
-        assertThrows(Exception.class, () -> entry.setValue((V) entry));
+        entry.setValue((V) entry);
         assertSame(entry, entry.getValue());
     }
 

--- a/src/test/java/org/apache/commons/collections4/keyvalue/TiedMapEntryTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/TiedMapEntryTest.java
@@ -43,8 +43,8 @@ public class TiedMapEntryTest<K, V> extends AbstractMapEntryTest<K, V> {
     /**
      * Tests the constructors.
      */
-    @Override
     @Test
+    @Override
     public void testConstructors() {
         // ignore
     }
@@ -52,8 +52,8 @@ public class TiedMapEntryTest<K, V> extends AbstractMapEntryTest<K, V> {
     /**
      * Tests the constructors.
      */
-    @SuppressWarnings("unchecked")
     @Test
+    @SuppressWarnings("unchecked")
     public void testSetValue() {
         final Map<K, V> map = new HashMap<>();
         map.put((K) "A", (V) "a");

--- a/src/test/java/org/apache/commons/collections4/keyvalue/UnmodifiableMapEntryTest.java
+++ b/src/test/java/org/apache/commons/collections4/keyvalue/UnmodifiableMapEntryTest.java
@@ -57,9 +57,9 @@ public class UnmodifiableMapEntryTest<K, V> extends AbstractMapEntryTest<K, V> {
      * Subclasses should override this method.
      *
      */
+    @Test
     @Override
     @SuppressWarnings("unchecked")
-    @Test
     public void testConstructors() {
         // 1. test key-value constructor
         Map.Entry<K, V> entry = new UnmodifiableMapEntry<>((K) key, (V) value);
@@ -80,6 +80,7 @@ public class UnmodifiableMapEntryTest<K, V> extends AbstractMapEntryTest<K, V> {
         assertTrue(entry instanceof Unmodifiable);
     }
 
+    @Test
     @Override
     @SuppressWarnings("unchecked")
     public void testAccessorsAndMutators() {
@@ -94,8 +95,8 @@ public class UnmodifiableMapEntryTest<K, V> extends AbstractMapEntryTest<K, V> {
         assertSame(null, entry.getValue());
     }
 
-    @Override
     @Test
+    @Override
     public void testSelfReferenceHandling() {
         // block
     }

--- a/src/test/java/org/apache/commons/collections4/list/AbstractLinkedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/AbstractLinkedListTest.java
@@ -18,6 +18,8 @@ package org.apache.commons.collections4.list;
 
 import java.util.Arrays;
 
+import org.junit.Test;
+
 /**
  * Test case for {@link AbstractLinkedList}.
  *
@@ -28,6 +30,7 @@ public abstract class AbstractLinkedListTest<E> extends AbstractListTest<E> {
         super(testName);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveFirst() {
         resetEmpty();
@@ -52,6 +55,7 @@ public abstract class AbstractLinkedListTest<E> extends AbstractListTest<E> {
         checkNodes();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveLast() {
         resetEmpty();
@@ -73,6 +77,7 @@ public abstract class AbstractLinkedListTest<E> extends AbstractListTest<E> {
         assertEquals("value4", list.removeFirst());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testAddNodeAfter() {
         resetEmpty();
@@ -106,6 +111,7 @@ public abstract class AbstractLinkedListTest<E> extends AbstractListTest<E> {
         assertEquals("value5", list.getLast());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveNode() {
         resetEmpty();
@@ -132,6 +138,7 @@ public abstract class AbstractLinkedListTest<E> extends AbstractListTest<E> {
         checkNodes();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testGetNode() {
         resetEmpty();

--- a/src/test/java/org/apache/commons/collections4/list/AbstractListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/AbstractListTest.java
@@ -34,6 +34,7 @@ import java.util.NoSuchElementException;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.iterators.AbstractListIteratorTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link java.util.List} methods and contracts.
@@ -171,6 +172,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      *  Tests bounds checking for {@link List#add(int, Object)} on an
      *  empty list.
      */
+    @Test
     public void testListAddByIndexBoundsChecking() {
         if (!isAddSupported()) {
             return;
@@ -216,6 +218,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      *  Tests bounds checking for {@link List#add(int, Object)} on a
      *  full list.
      */
+    @Test
     public void testListAddByIndexBoundsChecking2() {
         if (!isAddSupported()) {
             return;
@@ -260,6 +263,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests {@link List#add(int,Object)}.
      */
+    @Test
     public void testListAddByIndex() {
         if (!isAddSupported()) {
             return;
@@ -279,6 +283,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests {@link List#equals(Object)}.
      */
+    @Test
     public void testListEquals() {
         resetEmpty();
         List<E> list = getCollection();
@@ -349,6 +354,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests {@link List#hashCode()}.
      */
+    @Test
     public void testListHashCode() {
         resetEmpty();
         int hash1 = getCollection().hashCode();
@@ -366,6 +372,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests {@link List#get(int)}.
      */
+    @Test
     public void testListGetByIndex() {
         resetFull();
         final List<E> list = getCollection();
@@ -380,6 +387,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      *  Tests bounds checking for {@link List#get(int)} on an
      *  empty list.
      */
+    @Test
     public void testListGetByIndexBoundsChecking() {
         final List<E> list = makeObject();
 
@@ -423,6 +431,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      *  Tests bounds checking for {@link List#get(int)} on a
      *  full list.
      */
+    @Test
     public void testListGetByIndexBoundsChecking2() {
         final List<E> list = makeFullCollection();
 
@@ -458,6 +467,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests {@link List#indexOf}.
      */
+    @Test
     public void testListIndexOf() {
         resetFull();
         final List<E> list1 = getCollection();
@@ -480,6 +490,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests {@link List#lastIndexOf}.
      */
+    @Test
     public void testListLastIndexOf() {
         resetFull();
         final List<E> list1 = getCollection();
@@ -505,6 +516,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      *  Tests bounds checking for {@link List#set(int,Object)} on an
      *  empty list.
      */
+    @Test
     public void testListSetByIndexBoundsChecking() {
         if (!isSetSupported()) {
             return;
@@ -554,6 +566,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      *  Tests bounds checking for {@link List#set(int,Object)} on a
      *  full list.
      */
+    @Test
     public void testListSetByIndexBoundsChecking2() {
         if (!isSetSupported()) {
             return;
@@ -597,6 +610,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Test {@link List#set(int,Object)}.
      */
+    @Test
     public void testListSetByIndex() {
         if (!isSetSupported()) {
             return;
@@ -619,6 +633,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      *  If {@link #isSetSupported()} returns false, tests that set operation
      *  raises <Code>UnsupportedOperationException.
      */
+    @Test
     public void testUnsupportedSet() {
         if (isSetSupported()) {
             return;
@@ -640,6 +655,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      *  Tests bounds checking for {@link List#remove(int)} on an
      *  empty list.
      */
+    @Test
     public void testListRemoveByIndexBoundsChecking() {
         if (!isRemoveSupported()) {
             return;
@@ -687,6 +703,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      *  Tests bounds checking for {@link List#remove(int)} on a
      *  full list.
      */
+    @Test
     public void testListRemoveByIndexBoundsChecking2() {
         if (!isRemoveSupported()) {
             return;
@@ -729,6 +746,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests {@link List#remove(int)}.
      */
+    @Test
     public void testListRemoveByIndex() {
         if (!isRemoveSupported()) {
             return;
@@ -747,6 +765,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests the read-only bits of {@link List#listIterator()}.
      */
+    @Test
     public void testListListIterator() {
         resetFull();
         forwardTest(getCollection().listIterator(), 0);
@@ -756,6 +775,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests the read-only bits of {@link List#listIterator(int)}.
      */
+    @Test
     public void testListListIteratorByIndex() {
         resetFull();
         try {
@@ -779,6 +799,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      * Tests remove on list iterator is correct.
      */
+    @Test
     public void testListListIteratorPreviousRemoveNext() {
         if (!isRemoveSupported()) {
             return;
@@ -811,6 +832,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      * Tests remove on list iterator is correct.
      */
+    @Test
     public void testListListIteratorPreviousRemovePrevious() {
         if (!isRemoveSupported()) {
             return;
@@ -843,6 +865,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      * Tests remove on list iterator is correct.
      */
+    @Test
     public void testListListIteratorNextRemoveNext() {
         if (!isRemoveSupported()) {
             return;
@@ -872,6 +895,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     /**
      * Tests remove on list iterator is correct.
      */
+    @Test
     public void testListListIteratorNextRemovePrevious() {
         if (!isRemoveSupported()) {
             return;
@@ -972,6 +996,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      *  Tests the {@link ListIterator#add(Object)} method of the list
      *  iterator.
      */
+    @Test
     public void testListIteratorAdd() {
         if (!isAddSupported()) {
             return;
@@ -1007,6 +1032,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      *  Tests the {@link ListIterator#set(Object)} method of the list
      *  iterator.
      */
+    @Test
     public void testListIteratorSet() {
         if (!isSetSupported()) {
             return;
@@ -1026,6 +1052,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testEmptyListSerialization() throws IOException, ClassNotFoundException {
         final List<E> list = makeObject();
@@ -1040,6 +1067,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         assertEquals("Both lists are empty", 0, list2.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testFullListSerialization() throws IOException, ClassNotFoundException {
         final List<E> list = makeFullCollection();
@@ -1059,6 +1087,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      * Compare the current serialized form of the List
      * against the canonical version in SCM.
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testEmptyListCompatibility() throws IOException, ClassNotFoundException {
         /*
@@ -1083,6 +1112,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      * Compare the current serialized form of the List
      * against the canonical version in SCM.
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testFullListCompatibility() throws IOException, ClassNotFoundException {
         /*
@@ -1201,6 +1231,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      * Tests that a sublist raises a {@link java.util.ConcurrentModificationException ConcurrentModificationException}
      * if elements are added to the original list.
      */
+    @Test
     public void testListSubListFailFastOnAdd() {
         if (!isFailFastSupported()) {
             return;
@@ -1235,6 +1266,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
      * Tests that a sublist raises a {@link java.util.ConcurrentModificationException ConcurrentModificationException}
      * if elements are removed from the original list.
      */
+    @Test
     public void testListSubListFailFastOnRemove() {
         if (!isFailFastSupported()) {
             return;

--- a/src/test/java/org/apache/commons/collections4/list/CursorableLinkedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/CursorableLinkedListTest.java
@@ -28,9 +28,8 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
+import org.junit.Test;
 
 /**
  * Test class.
@@ -41,7 +40,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(CursorableLinkedListTest.class);
     }
 
@@ -57,6 +56,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         return new CursorableLinkedList<>();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testAdd() {
         assertEquals("[]", list.toString());
@@ -88,6 +88,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("[-2, -1, 0, A, B, C, 1, 2, 3, 4, 5, A, B, C]", list.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testClear() {
         assertEquals(0, list.size());
@@ -124,6 +125,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertTrue(list.isEmpty());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testContains() {
         assertFalse(list.contains("A"));
@@ -139,6 +141,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertFalse(list.contains("A"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testContainsAll() {
         assertTrue(list.containsAll(list));
@@ -160,6 +163,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertTrue(list.containsAll(list));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCursorNavigation() {
         list.add((E) "1");
@@ -215,6 +219,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         it.close();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCursorSet() {
         list.add((E) "1");
@@ -240,6 +245,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         it.close();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCursorRemove() {
         list.add((E) "1");
@@ -281,6 +287,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         it.close();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCursorAdd() {
         final CursorableLinkedList.Cursor<E> it = list.cursor();
@@ -300,6 +307,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         it.close();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCursorConcurrentModification() {
         // this test verifies that cursors remain valid when the list
@@ -360,6 +368,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         c2.close(); // not necessary
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCursorNextIndexMid() {
         list.add((E) "1");
@@ -381,6 +390,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("3", c1.next());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCursorNextIndexFirst() {
         list.add((E) "1");
@@ -398,6 +408,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("3", c1.next());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCursorNextIndexAddBefore() {
         list.add((E) "1");
@@ -414,6 +425,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("2", c1.next());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCursorNextIndexAddNext() {
         list.add((E) "1");
@@ -431,6 +443,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("1", c1.next());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCursorNextIndexAddAfter() {
         list.add((E) "1");
@@ -448,6 +461,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("0", c1.next());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextNextPreviousRemoveIndex1ByList() {
         list.add((E) "A");
@@ -474,6 +488,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextRemoveIndex1ByList() {
         list.add((E) "A");
@@ -498,6 +513,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextNextRemoveIndex1ByList() {
         list.add((E) "A");
@@ -523,6 +539,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextNextNextRemoveIndex1ByList() {
         list.add((E) "A");
@@ -549,6 +566,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextNextPreviousRemoveByIterator() {
         list.add((E) "A");
@@ -573,6 +591,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextNextRemoveByIterator() {
         list.add((E) "A");
@@ -596,6 +615,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextNextPreviousAddIndex1ByList() {
         list.add((E) "A");
@@ -621,6 +641,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextAddIndex1ByList() {
         list.add((E) "A");
@@ -644,6 +665,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextNextAddIndex1ByList() {
         list.add((E) "A");
@@ -667,6 +689,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextNextPreviousAddByIterator() {
         list.add((E) "A");
@@ -690,6 +713,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextNextAddByIterator() {
         list.add((E) "A");
@@ -713,6 +737,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextNextRemoveByListSetByIterator() {
         list.add((E) "A");
@@ -734,6 +759,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.set((E) "Z"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextNextPreviousSetByIterator() {
         list.add((E) "A");
@@ -759,6 +785,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_CursorNextNextSetByIterator() {
         list.add((E) "A");
@@ -783,6 +810,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertThrows(IllegalStateException.class, () -> c1.remove());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testEqualsAndHashCode() {
         assertEquals(list, list);
@@ -847,6 +875,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertFalse(list2.equals(list));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testGet() {
         assertThrows(IndexOutOfBoundsException.class, () -> list.get(0),
@@ -865,6 +894,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         );
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIndexOf() {
         assertEquals(-1, list.indexOf("A"));
@@ -886,6 +916,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals(2, list.lastIndexOf("B"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIsEmpty() {
         assertTrue(list.isEmpty());
@@ -899,6 +930,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertTrue(list.isEmpty());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIterator() {
         list.add((E) "1");
@@ -943,6 +975,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertFalse(it.hasNext());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testListIteratorNavigation() {
         list.add((E) "1");
@@ -1027,6 +1060,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals(0, it.nextIndex());
     }
 
+    @Test
     @Override
     @SuppressWarnings("unchecked")
     public void testListIteratorSet() {
@@ -1052,6 +1086,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("[A, B, 3, D, E]", list.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testListIteratorRemove() {
         list.add((E) "1");
@@ -1094,6 +1129,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("[]", list.toString());
     }
 
+    @Test
     @Override
     @SuppressWarnings("unchecked")
     public void testListIteratorAdd() {
@@ -1113,6 +1149,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("[1, 2, 3, 4, 5]", list.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveAll() {
         list.add((E) "1");
@@ -1133,6 +1170,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertFalse(list.removeAll(set));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveByIndex() {
         list.add((E) "1");
@@ -1153,6 +1191,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("[]", list.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemove() {
         list.add((E) "1");
@@ -1190,6 +1229,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("[]", list.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRetainAll() {
         list.add((E) "1");
@@ -1215,6 +1255,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertFalse(list.retainAll(set));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSet() {
         list.add((E) "1");
@@ -1235,6 +1276,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("[A, B, C, D, E]", list.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSubList() {
         list.add((E) "A");
@@ -1252,6 +1294,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("[]", list.subList(5, 5).toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSubListAddEnd() {
         list.add((E) "A");
@@ -1269,6 +1312,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("[F, G]", sublist.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSubListAddBegin() {
         list.add((E) "A");
@@ -1286,6 +1330,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("[a, b]", sublist.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSubListAddMiddle() {
         list.add((E) "A");
@@ -1303,6 +1348,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("[B, C, a, b]", sublist.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSubListRemove() {
         list.add((E) "A");
@@ -1325,6 +1371,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals("[A, E]", list.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testToArray() {
         list.add((E) "1");
@@ -1369,6 +1416,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals(5, elts4b.length);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSerialization() throws Exception {
         list.add((E) "A");
@@ -1392,6 +1440,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals(list, list2);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSerializationWithOpenCursor() throws Exception {
         list.add((E) "A");
@@ -1414,6 +1463,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
         assertEquals(list, list2);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testLongSerialization() throws Exception {
         // recursive serialization will cause a stack

--- a/src/test/java/org/apache/commons/collections4/list/FixedSizeListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/FixedSizeListTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractListTest} for exercising the {@link FixedSizeList}
@@ -69,6 +70,7 @@ public class FixedSizeListTest<E> extends AbstractListTest<E> {
 //        writeExternalFormToDisk((java.io.Serializable) getCollection(), "src/test/resources/data/test/FixedSizeList.fullCollection.version4.obj");
 //    }
 
+    @Test
     public void testListAllowsMutationOfUnderlyingCollection() {
 
         final List<String> decoratedList = new ArrayList<>();
@@ -93,13 +95,14 @@ public class FixedSizeListTest<E> extends AbstractListTest<E> {
         return FixedSizeList.fixedSizeList(decoratedList);
     }
 
+    @Test
     public void testAdd() {
         final FixedSizeList<String> fixedSizeList = initFixedSizeList();
 
         assertThrows(UnsupportedOperationException.class, () -> fixedSizeList.add(2, "New Value"));
     }
 
-
+    @Test
     public void testAddAll() {
         final FixedSizeList<String> fixedSizeList = initFixedSizeList();
 
@@ -110,12 +113,14 @@ public class FixedSizeListTest<E> extends AbstractListTest<E> {
         assertThrows(UnsupportedOperationException.class, () -> fixedSizeList.addAll(2, addList));
     }
 
+    @Test
     public void testRemove() {
         final FixedSizeList<String> fixedSizeList = initFixedSizeList();
 
         assertThrows(UnsupportedOperationException.class, () -> fixedSizeList.remove(1));
     }
 
+    @Test
     public void testSubList() {
         final FixedSizeList<String> fixedSizeList = initFixedSizeList();
 
@@ -124,12 +129,14 @@ public class FixedSizeListTest<E> extends AbstractListTest<E> {
         Assertions.assertEquals(0, subFixedSizeList.size());
     }
 
+    @Test
     public void testIsFull() {
         final FixedSizeList<String> fixedSizeList = initFixedSizeList();
 
         Assertions.assertTrue(fixedSizeList.isFull());
     }
 
+    @Test
     public void testMaxSize() {
         final FixedSizeList<String> fixedSizeList = initFixedSizeList();
 

--- a/src/test/java/org/apache/commons/collections4/list/GrowthListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/GrowthListTest.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.junit.jupiter.api.function.Executable;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractListTest} for exercising the {@link GrowthList}.
@@ -50,6 +51,7 @@ public class GrowthListTest<E> extends AbstractListTest<E> {
         return GrowthList.growthList(list);
     }
 
+    @Test
     public void testGrowthList() {
         final Integer zero = Integer.valueOf(0);
         final Integer one = Integer.valueOf(1);
@@ -64,6 +66,7 @@ public class GrowthListTest<E> extends AbstractListTest<E> {
         assertEquals(3, grower.size());
     }
 
+    @Test
     public void testGrowthAdd() {
         final Integer one = Integer.valueOf(1);
         final GrowthList<Integer> grower = new GrowthList<>();
@@ -74,6 +77,7 @@ public class GrowthListTest<E> extends AbstractListTest<E> {
         assertEquals(one, grower.get(1));
     }
 
+    @Test
     public void testGrowthAddAll() {
         final Integer one = Integer.valueOf(1);
         final Integer two = Integer.valueOf(2);
@@ -89,6 +93,7 @@ public class GrowthListTest<E> extends AbstractListTest<E> {
         assertEquals(two, grower.get(2));
     }
 
+    @Test
     public void testGrowthSet1() {
         final Integer one = Integer.valueOf(1);
         final GrowthList<Integer> grower = new GrowthList<>();
@@ -99,6 +104,7 @@ public class GrowthListTest<E> extends AbstractListTest<E> {
         assertEquals(one, grower.get(1));
     }
 
+    @Test
     public void testGrowthSet2() {
         final Integer one = Integer.valueOf(1);
         final GrowthList<Integer> grower = new GrowthList<>();
@@ -111,6 +117,7 @@ public class GrowthListTest<E> extends AbstractListTest<E> {
     /**
      * Override.
      */
+    @Test
     @Override
     public void testListAddByIndexBoundsChecking() {
         final E element = getOtherElements()[0];
@@ -125,6 +132,7 @@ public class GrowthListTest<E> extends AbstractListTest<E> {
     /**
      * Override.
      */
+    @Test
     @Override
     public void testListAddByIndexBoundsChecking2() {
         final E element = getOtherElements()[0];
@@ -136,6 +144,7 @@ public class GrowthListTest<E> extends AbstractListTest<E> {
     /**
      * Override.
      */
+    @Test
     @Override
     public void testListSetByIndexBoundsChecking() {
         final List<E> list = makeObject();
@@ -147,6 +156,7 @@ public class GrowthListTest<E> extends AbstractListTest<E> {
     /**
      * Override.
      */
+    @Test
     @Override
     public void testListSetByIndexBoundsChecking2() {
         final List<E> list = makeFullCollection();

--- a/src/test/java/org/apache/commons/collections4/list/LazyListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/LazyListTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.collections4.list;
 import org.apache.commons.collections4.AbstractObjectTest;
 import org.apache.commons.collections4.Factory;
 import org.apache.commons.collections4.Transformer;
+import org.junit.Test;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -37,26 +38,31 @@ public class LazyListTest extends AbstractObjectTest {
         return new LazyList<>(new ArrayList<>(), dateFactory);
     }
 
+    @Test
     @Override
     public void testSimpleSerialization() {
         // Factory and Transformer are not serializable
     }
 
+    @Test
     @Override
     public void testSerializeDeserializeThenCompare() {
         // Factory and Transformer are not serializable
     }
 
+    @Test
     @Override
     public void testCanonicalEmptyCollectionExists() {
         // Factory and Transformer are not serializable
     }
 
+    @Test
     @Override
     public void testCanonicalFullCollectionExists() {
         // Factory and Transformer are not serializable
     }
 
+    @Test
     public void testElementCreationWithFactory() {
         final Factory<LocalDateTime> dateFactory = LocalDateTime::now;
         final List<LocalDateTime> list = new LazyList<>(new ArrayList<>(), dateFactory);
@@ -68,6 +74,7 @@ public class LazyListTest extends AbstractObjectTest {
         assertFalse(list.isEmpty());
     }
 
+    @Test
     public void testElementCreationWithTransformer() {
         final Factory<LocalDateTime> dateFactory = LocalDateTime::now;
         final List<LocalDateTime> list = new LazyList<>(new ArrayList<>(), dateFactory);
@@ -79,6 +86,7 @@ public class LazyListTest extends AbstractObjectTest {
         assertFalse(list.isEmpty());
     }
 
+    @Test
     public void testCreateNullGapsWithFactory() {
         final Factory<LocalDateTime> dateFactory = LocalDateTime::now;
         final List<LocalDateTime> list = new LazyList<>(new ArrayList<>(), dateFactory);
@@ -88,6 +96,7 @@ public class LazyListTest extends AbstractObjectTest {
         assertNotNull(fourthElement);
     }
 
+    @Test
     public void testCreateNullGapsWithTransformer() {
         final List<Integer> hours = Arrays.asList(7, 5, 8, 2);
         final Transformer<Integer, LocalDateTime> dateFactory = input -> LocalDateTime.now().withHour(hours.get(input));
@@ -98,6 +107,7 @@ public class LazyListTest extends AbstractObjectTest {
         assertNotNull(fourthElement);
     }
 
+    @Test
     public void testGetWithNull() {
         final List<Integer> hours = Arrays.asList(7, 5, 8, 2);
         final Transformer<Integer, LocalDateTime> transformer = input -> LocalDateTime.now().withHour(hours.get(input));
@@ -111,6 +121,7 @@ public class LazyListTest extends AbstractObjectTest {
         assertNotNull(fourthElement);
     }
 
+    @Test
     public void testSubListWitheFactory() {
         final Factory<LocalDateTime> dateFactory = LocalDateTime::now;
         final List<LocalDateTime> list = new LazyList<>(new ArrayList<>(), dateFactory);
@@ -120,6 +131,7 @@ public class LazyListTest extends AbstractObjectTest {
         testSubList(list);
     }
 
+    @Test
     public void testSubListWithTransformer() {
         final List<Integer> hours = Arrays.asList(7, 5, 8, 2);
         final Transformer<Integer, LocalDateTime> transformer = input -> LocalDateTime.now().withHour(hours.get(input));

--- a/src/test/java/org/apache/commons/collections4/list/NodeCachingLinkedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/NodeCachingLinkedListTest.java
@@ -19,9 +19,8 @@ package org.apache.commons.collections4.list;
 import java.util.Arrays;
 import java.util.LinkedList;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
+import org.junit.Test;
 
 /**
  * Test class for NodeCachingLinkedList, a performance optimised LinkedList.
@@ -33,7 +32,7 @@ public class NodeCachingLinkedListTest<E> extends AbstractLinkedListTest<E> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(NodeCachingLinkedListTest.class);
     }
 
@@ -47,6 +46,7 @@ public class NodeCachingLinkedListTest<E> extends AbstractLinkedListTest<E> {
         return "4";
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testShrinkCache() {
         if (!isRemoveSupported() || !isAddSupported()) {

--- a/src/test/java/org/apache/commons/collections4/list/PredicatedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/PredicatedListTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractListTest} for exercising the
@@ -64,6 +65,7 @@ public class PredicatedListTest<E> extends AbstractListTest<E> {
         return decorateList(new ArrayList<E>(), testPredicate);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalAdd() {
         final List<E> list = makeTestList();
@@ -75,6 +77,7 @@ public class PredicatedListTest<E> extends AbstractListTest<E> {
         assertFalse("Collection shouldn't contain illegal element", list.contains(i));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalAddAll() {
         final List<E> list = makeTestList();
@@ -93,6 +96,7 @@ public class PredicatedListTest<E> extends AbstractListTest<E> {
         assertFalse("List shouldn't contain illegal element", list.contains("four"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalSet() {
         final List<E> list = makeTestList();
@@ -100,6 +104,7 @@ public class PredicatedListTest<E> extends AbstractListTest<E> {
                 "Integer should fail string predicate.");
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testLegalAddAll() {
         final List<E> list = makeTestList();
@@ -115,6 +120,7 @@ public class PredicatedListTest<E> extends AbstractListTest<E> {
         assertTrue("List should contain legal element", list.contains("three"));
     }
 
+    @Test
     public void testSubList() {
         final List<E> list = makeTestList();
         list.add((E) "zero");

--- a/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4.list;
 
 import org.apache.commons.collections4.set.UnmodifiableSet;
+import org.junit.Test;
 
 import java.util.*;
 
@@ -81,6 +82,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         return new SetUniqueList<>(new ArrayList<E>(), new HashSet<E>());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testAdd() {
         final SetUniqueList<E> lset = new SetUniqueList<>(new ArrayList<E>(), new HashSet<E>());
@@ -96,6 +98,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertEquals("Unique element was not added.", 2, lset.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testAddAll() {
         final SetUniqueList<E> lset = new SetUniqueList<>(new ArrayList<E>(), new HashSet<E>());
@@ -106,6 +109,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertEquals("Duplicate element was added.", 1, lset.size());
     }
 
+    @Test
     @Override
     public void testCollectionAddAll() {
         // override for set behavior
@@ -135,6 +139,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
                 size + elements.length, getCollection().size());
     }
 
+    @Test
     @Override
     public void testCollectionIteratorRemove() {
         try {
@@ -144,6 +149,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
             extraVerify = true;
         }
     }
+    @Test
     public void testCollections304() {
         final List<String> list = new LinkedList<>();
         final SetUniqueList<String> decoratedList = SetUniqueList.setUniqueList(list);
@@ -167,6 +173,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertEquals(4, decoratedList.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCollections307() {
         List<E> list = new ArrayList<>();
@@ -208,6 +215,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertFalse(subUniqueList.contains("World")); // fails
     }
 
+    @Test
     public void testCollections701() {
         final SetUniqueList<Object> uniqueList = new SetUniqueList<>(new ArrayList<>(), new HashSet<>());
         final Integer obj1 = Integer.valueOf(1);
@@ -233,6 +241,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertEquals(4, decoratedList.size());
     }
 
+    @Test
     public void testFactory() {
         final Integer[] array = { Integer.valueOf(1), Integer.valueOf(2), Integer.valueOf(1) };
         final ArrayList<Integer> list = new ArrayList<>(Arrays.asList(array));
@@ -245,6 +254,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertEquals(Integer.valueOf(2), list.get(1));
     }
 
+    @Test
     public void testIntCollectionAddAll() {
         // make a SetUniqueList with one element
         final List<Integer> list = new SetUniqueList<>(new ArrayList<Integer>(), new HashSet<Integer>());
@@ -270,6 +280,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertEquals("Third new element should be at index 0", thirdNewElement, list.get(0));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testListIterator() {
         final SetUniqueList<E> lset = new SetUniqueList<>(new ArrayList<E>(), new HashSet<E>());
@@ -292,6 +303,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertEquals("Duplicate element was added", 2, lset.size());
     }
 
+    @Test
     @Override
     public void testListIteratorAdd() {
         // override to cope with Set behavior
@@ -321,6 +333,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         }
     }
 
+    @Test
     @Override
     public void testListIteratorSet() {
         // override to block
@@ -331,6 +344,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertThrows(UnsupportedOperationException.class, () -> it.set(null));
     }
 
+    @Test
     @Override
     @SuppressWarnings("unchecked")
     public void testListSetByIndex() {
@@ -345,6 +359,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertEquals(Long.valueOf(1000), getCollection().get(1));  // set into 2, but shifted down to 1
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRetainAll() {
         final List<E> list = new ArrayList<>(10);
@@ -367,6 +382,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertTrue(uniqueList.contains(Integer.valueOf(8)));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRetainAllWithInitialList() {
         // initialized with empty list
@@ -393,6 +409,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertTrue(uniqueList.contains(Integer.valueOf(8)));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSet() {
         final SetUniqueList<E> lset = new SetUniqueList<>(new ArrayList<E>(), new HashSet<E>());
@@ -432,6 +449,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertSame(obj1, lset.get(0));
     }
 
+    @Test
     public void testSetCollections444() {
         final SetUniqueList<Integer> lset = new SetUniqueList<>(new ArrayList<Integer>(), new HashSet<Integer>());
 
@@ -450,6 +468,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertTrue(lset.contains(obj2));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSetDownwardsInList() {
         /*
@@ -478,6 +497,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertTrue(s.contains(b));
         assertFalse(s.contains(a));
     }
+    @Test
     @SuppressWarnings("unchecked")
     public void testSetInBiggerList() {
         /*
@@ -514,6 +534,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertTrue(s.contains(c));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSetUpwardsInList() {
         /*
@@ -550,6 +571,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertTrue(s.contains(c));
     }
 
+    @Test
     public void testSubListIsUnmodifiable() {
         resetFull();
         final List<E> subList = getCollection().subList(1, 3);
@@ -557,6 +579,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertThrows(UnsupportedOperationException.class, () -> subList.remove(0));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testUniqueListDoubleInsert() {
         final List<E> l = SetUniqueList.setUniqueList(new LinkedList<E>());
@@ -572,6 +595,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertEquals(1, l.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testUniqueListReInsert() {
         final List<E> l = SetUniqueList.setUniqueList(new LinkedList<E>());
@@ -607,6 +631,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCreateSetBasedOnList() {
         final List<String> list = new ArrayList<>();

--- a/src/test/java/org/apache/commons/collections4/list/TransformedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/TransformedListTest.java
@@ -23,6 +23,7 @@ import java.util.ListIterator;
 
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractListTest} for exercising the {@link TransformedList}
@@ -59,6 +60,7 @@ public class TransformedListTest<E> extends AbstractListTest<E> {
         return TransformedList.transformingList(list, (Transformer<E, E>) TransformedCollectionTest.NOOP_TRANSFORMER);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testTransformedList() {
         final List<E> list = TransformedList.transformingList(new ArrayList<E>(), (Transformer<E, E>) TransformedCollectionTest.STRING_TO_INTEGER_TRANSFORMER);
@@ -107,6 +109,7 @@ public class TransformedListTest<E> extends AbstractListTest<E> {
         assertEquals(Integer.valueOf(2), list.get(2));
     }
 
+    @Test
     public void testTransformedList_decorateTransform() {
         final List<Object> originalList = new ArrayList<>();
         final Object[] els = {"1", "3", "5", "7", "2", "4", "6"};
@@ -124,6 +127,7 @@ public class TransformedListTest<E> extends AbstractListTest<E> {
         assertTrue(list.remove(Integer.valueOf((String) els[0])));
     }
 
+    @Test
     public void testSubList() {
         final List<E> list = makeObject();
         List<E> subList = list.subList(0, 0);

--- a/src/test/java/org/apache/commons/collections4/list/TreeListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/TreeListTest.java
@@ -20,9 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
+import org.junit.Test;
 
 /**
  * JUnit tests
@@ -48,7 +47,7 @@ public class TreeListTest<E> extends AbstractListTest<E> {
 //        benchmark(new NodeCachingLinkedList());
 //    }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(TreeListTest.class);
     }
 
@@ -108,6 +107,7 @@ public class TreeListTest<E> extends AbstractListTest<E> {
         return new TreeList<>();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testAddMultiple() {
         final List<E> l = makeObject();
@@ -125,6 +125,7 @@ public class TreeListTest<E> extends AbstractListTest<E> {
         assertEquals("harald", l.get(5));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemove() {
         final List<E> l = makeObject();
@@ -164,6 +165,7 @@ public class TreeListTest<E> extends AbstractListTest<E> {
         assertEquals("harald", l.get(i++));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInsertBefore() {
         final List<E> l = makeObject();
@@ -173,6 +175,7 @@ public class TreeListTest<E> extends AbstractListTest<E> {
         assertEquals("erna", l.get(1));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIndexOf() {
         final List<E> l = makeObject();
@@ -214,6 +217,7 @@ public class TreeListTest<E> extends AbstractListTest<E> {
 //        l.add("A6");
 //    }
 
+    @Test
     public void testBug35258() {
         final Object objectToRemove = Integer.valueOf(3);
 
@@ -244,6 +248,7 @@ public class TreeListTest<E> extends AbstractListTest<E> {
         assertFalse(li.hasNext());
     }
 
+    @Test
     public void testBugCollections447() {
         final List<String> treeList = new TreeList<>();
         treeList.add("A");
@@ -264,6 +269,7 @@ public class TreeListTest<E> extends AbstractListTest<E> {
         assertEquals("A", li.previous());
     }
 
+    @Test
     @SuppressWarnings("boxing") // OK in test code
     public void testIterationOrder() {
         // COLLECTIONS-433:
@@ -290,6 +296,7 @@ public class TreeListTest<E> extends AbstractListTest<E> {
         }
     }
 
+    @Test
     @SuppressWarnings("boxing") // OK in test code
     public void testIterationOrderAfterAddAll() {
         // COLLECTIONS-433:

--- a/src/test/java/org/apache/commons/collections4/list/UnmodifiableListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/UnmodifiableListTest.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+import org.junit.Test;
+
 /**
  * Extension of {@link AbstractListTest} for exercising the
  * {@link UnmodifiableList} implementation.
@@ -75,12 +77,14 @@ public class UnmodifiableListTest<E> extends AbstractListTest<E> {
     /**
      * Verify that base list and sublists are not modifiable
      */
+    @Test
     public void testUnmodifiable() {
         setupList();
         verifyUnmodifiable(list);
         verifyUnmodifiable(list.subList(0, 2));
     }
 
+    @Test
     public void testDecorateFactory() {
         final List<E> list = makeObject();
         assertSame(list, UnmodifiableList.unmodifiableList(list));
@@ -117,6 +121,7 @@ public class UnmodifiableListTest<E> extends AbstractListTest<E> {
     /**
      * Verify that iterator is not modifiable
      */
+    @Test
     public void testUnmodifiableIterator() {
         setupList();
         final Iterator<E> iterator = list.iterator();

--- a/src/test/java/org/apache/commons/collections4/map/AbstractIterableMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractIterableMapTest.java
@@ -24,6 +24,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.iterators.AbstractMapIteratorTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link IterableMap} methods and contracts.
@@ -54,6 +55,7 @@ public abstract class AbstractIterableMapTest<K, V> extends AbstractMapTest<K, V
         return (IterableMap<K, V>) super.makeFullMap();
     }
 
+    @Test
     public void testFailFastEntrySet() {
         if (!isRemoveSupported()) {
             return;
@@ -80,6 +82,7 @@ public abstract class AbstractIterableMapTest<K, V> extends AbstractMapTest<K, V
         } catch (final ConcurrentModificationException ex) {}
     }
 
+    @Test
     public void testFailFastKeySet() {
         if (!isRemoveSupported()) {
             return;
@@ -106,6 +109,7 @@ public abstract class AbstractIterableMapTest<K, V> extends AbstractMapTest<K, V
         } catch (final ConcurrentModificationException ex) {}
     }
 
+    @Test
     public void testFailFastValues() {
         if (!isRemoveSupported()) {
             return;

--- a/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
@@ -35,6 +35,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.keyvalue.DefaultMapEntry;
 import org.apache.commons.collections4.set.AbstractSetTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link java.util.Map} methods and contracts.
@@ -479,6 +480,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * value if useNullValue() is true and may only have duplicate values if
      * isAllowDuplicateValues() returns true.
      */
+    @Test
     public void testSampleMappings() {
         final Object[] keys = getSampleKeys();
         final Object[] values = getSampleValues();
@@ -530,6 +532,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * Test to ensure that makeEmptyMap and makeFull returns a new non-null
      * map with each invocation.
      */
+    @Test
     public void testMakeMap() {
         final Map<K, V> em = makeObject();
         assertNotNull("failure in test: makeEmptyMap must return a non-null map.", em);
@@ -553,6 +556,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Tests Map.isEmpty()
      */
+    @Test
     public void testMapIsEmpty() {
         resetEmpty();
         assertTrue("Map.isEmpty() should return true with an empty map", getMap().isEmpty());
@@ -566,6 +570,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Tests Map.size()
      */
+    @Test
     public void testMapSize() {
         resetEmpty();
         assertEquals("Map.size() should be 0 with an empty map",
@@ -586,6 +591,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * elements, this method checks to ensure clear throws an
      * UnsupportedOperationException.
      */
+    @Test
     public void testMapClear() {
         if (!isRemoveSupported()) {
             try {
@@ -612,6 +618,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * sample keys on a map created using an empty map and returns true for
      * all sample keys returned on a full map.
      */
+    @Test
     public void testMapContainsKey() {
         final Object[] keys = getSampleKeys();
 
@@ -634,6 +641,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * sample values on an empty map and returns true for all sample values on
      * a full map.
      */
+    @Test
     public void testMapContainsValue() {
         final Object[] values = getSampleValues();
 
@@ -655,6 +663,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Tests Map.equals(Object)
      */
+    @Test
     public void testMapEquals() {
         resetEmpty();
         assertEquals("Empty maps unequal.", getMap(), confirmed);
@@ -681,6 +690,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Tests Map.get(Object)
      */
+    @Test
     public void testMapGet() {
         resetEmpty();
 
@@ -702,6 +712,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Tests Map.hashCode()
      */
+    @Test
     public void testMapHashCode() {
         resetEmpty();
         assertEquals("Empty maps have different hashCodes.", getMap().hashCode(), confirmed.hashCode());
@@ -719,6 +730,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * default implementation just verifies that the toString() method does
      * not return null.
      */
+    @Test
     public void testMapToString() {
         resetEmpty();
         assertNotNull("Empty map toString() should not return null", getMap().toString());
@@ -733,6 +745,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * Compare the current serialized form of the Map
      * against the canonical version in SCM.
      */
+    @Test
     public void testEmptyMapCompatibility() throws Exception {
         /*
          * Create canonical objects with this code
@@ -755,6 +768,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * Compare the current serialized form of the Map
      * against the canonical version in SCM.
      */
+    @Test
     public void testFullMapCompatibility() throws Exception {
         /*
          * Create canonical objects with this code
@@ -776,6 +790,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Tests Map.put(Object, Object)
      */
+    @Test
     public void testMapPut() {
         resetEmpty();
         final K[] keys = getSampleKeys();
@@ -859,6 +874,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Tests Map.put(null, value)
      */
+    @Test
     public void testMapPutNullKey() {
         resetFull();
         final V[] values = getSampleValues();
@@ -878,6 +894,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Tests Map.put(null, value)
      */
+    @Test
     public void testMapPutNullValue() {
         resetFull();
         final K[] keys = getSampleKeys();
@@ -897,6 +914,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Tests Map.putAll(map)
      */
+    @Test
     public void testMapPutAll() {
         if (!isPutAddSupported()) {
             if (!isPutChangeSupported()) {
@@ -958,6 +976,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Tests Map.remove(Object)
      */
+    @Test
     public void testMapRemove() {
         if (!isRemoveSupported()) {
             try {
@@ -1006,6 +1025,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * Tests that the {@link Map#values} collection is backed by
      * the underlying map for clear().
      */
+    @Test
     public void testValuesClearChangesMap() {
         if (!isRemoveSupported()) {
             return;
@@ -1034,6 +1054,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * Tests that the {@link Map#keySet} collection is backed by
      * the underlying map for clear().
      */
+    @Test
     public void testKeySetClearChangesMap() {
         if (!isRemoveSupported()) {
             return;
@@ -1062,6 +1083,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * Tests that the {@link Map#entrySet()} collection is backed by
      * the underlying map for clear().
      */
+    @Test
     public void testEntrySetClearChangesMap() {
         if (!isRemoveSupported()) {
             return;
@@ -1086,6 +1108,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         assertTrue(entrySet.isEmpty());
     }
 
+    @Test
     public void testEntrySetContains1() {
         resetFull();
         final Set<Map.Entry<K, V>> entrySet = getMap().entrySet();
@@ -1093,6 +1116,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         assertTrue(entrySet.contains(entry));
     }
 
+    @Test
     public void testEntrySetContains2() {
         resetFull();
         final Set<Map.Entry<K, V>> entrySet = getMap().entrySet();
@@ -1101,6 +1125,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         assertTrue(entrySet.contains(test));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testEntrySetContains3() {
         resetFull();
@@ -1112,6 +1137,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         assertFalse(entrySet.contains(test));
     }
 
+    @Test
     public void testEntrySetRemove1() {
         if (!isRemoveSupported()) {
             return;
@@ -1127,6 +1153,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         assertEquals(size - 1, getMap().size());
     }
 
+    @Test
     public void testEntrySetRemove2() {
         if (!isRemoveSupported()) {
             return;
@@ -1143,6 +1170,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         assertEquals(size - 1, getMap().size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testEntrySetRemove3() {
         if (!isRemoveSupported()) {
@@ -1177,6 +1205,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * 9573</a>.
      * </p>
      */
+    @Test
     public void testValuesRemoveChangesMap() {
         resetFull();
         final V[] sampleValues = getSampleValues();
@@ -1202,6 +1231,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Tests values.removeAll.
      */
+    @Test
     public void testValuesRemoveAll() {
         resetFull();
         final Collection<V> values = getMap().values();
@@ -1228,6 +1258,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Test values.retainAll.
      */
+    @Test
     public void testValuesRetainAll() {
         resetFull();
         final Collection<V> values = getMap().values();
@@ -1254,6 +1285,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Verifies that values.iterator.remove changes the underlying map.
      */
+    @Test
     @SuppressWarnings("boxing") // OK in test code
     public void testValuesIteratorRemoveChangesMap() {
         resetFull();
@@ -1287,6 +1319,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * the underlying map by removing from the keySet set
      * and testing if the key was removed from the map.
      */
+    @Test
     public void testKeySetRemoveChangesMap() {
         resetFull();
         final K[] sampleKeys = getSampleKeys();
@@ -1305,6 +1338,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Test keySet.removeAll.
      */
+    @Test
     public void testKeySetRemoveAll() {
         resetFull();
         final Set<K> keys = getMap().keySet();
@@ -1329,6 +1363,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Test keySet.retainAll.
      */
+    @Test
     public void testKeySetRetainAll() {
         resetFull();
         final Set<K> keys = getMap().keySet();
@@ -1353,6 +1388,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Verify that keySet.iterator.remove changes the underlying map.
      */
+    @Test
     public void testKeySetIteratorRemoveChangesMap() {
         resetFull();
         for (final Iterator<K> iter = getMap().keySet().iterator(); iter.hasNext();) {
@@ -1371,6 +1407,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * the underlying map by removing from the entrySet set
      * and testing if the entry was removed from the map.
      */
+    @Test
     public void testEntrySetRemoveChangesMap() {
         resetFull();
         final K[] sampleKeys = getSampleKeys();
@@ -1390,6 +1427,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Test entrySet.removeAll.
      */
+    @Test
     public void testEntrySetRemoveAll() {
         resetFull();
         final K[] sampleKeys = getSampleKeys();
@@ -1425,6 +1463,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Test entrySet.retainAll.
      */
+    @Test
     public void testEntrySetRetainAll() {
         resetFull();
         final K[] sampleKeys = getSampleKeys();
@@ -1460,6 +1499,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     /**
      * Verify that entrySet.iterator.remove changes the underlying map.
      */
+    @Test
     public void testEntrySetIteratorRemoveChangesMap() {
         resetFull();
         for (final Iterator<Map.Entry<K, V>> iter = getMap().entrySet().iterator(); iter.hasNext();) {
@@ -1586,6 +1626,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
             TestMapEntrySet.this.setConfirmed(AbstractMapTest.this.getConfirmed().entrySet());
         }
 
+        @Test
         public void testMapEntrySetIteratorEntry() {
             resetFull();
             final Iterator<Map.Entry<K, V>> it = getCollection().iterator();
@@ -1602,6 +1643,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
             assertEquals(getCollection().size(), count);
         }
 
+        @Test
         public void testMapEntrySetIteratorEntrySetValue() {
             final K key1 = getSampleKeys()[0];
             final K key2 = getSampleKeys().length == 1 ? getSampleKeys()[0] : getSampleKeys()[1];
@@ -1672,6 +1714,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
             return entry;
         }
 
+        @Test
         public void testMapEntrySetRemoveNonMapEntry() {
             if (!isRemoveSupported()) {
                 return;

--- a/src/test/java/org/apache/commons/collections4/map/AbstractOrderedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractOrderedMapTest.java
@@ -30,6 +30,7 @@ import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.OrderedMapIterator;
 import org.apache.commons.collections4.comparators.NullComparator;
 import org.apache.commons.collections4.iterators.AbstractOrderedMapIteratorTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link OrderedMap} methods and contracts.
@@ -82,6 +83,7 @@ public abstract class AbstractOrderedMapTest<K, V> extends AbstractIterableMapTe
         return (K[]) list.toArray();
     }
 
+    @Test
     public void testFirstKey() {
         resetEmpty();
         OrderedMap<K, V> ordered = getMap();
@@ -96,6 +98,7 @@ public abstract class AbstractOrderedMapTest<K, V> extends AbstractIterableMapTe
         assertEquals(confirmedFirst, ordered.firstKey());
     }
 
+    @Test
     public void testLastKey() {
         resetEmpty();
         OrderedMap<K, V> ordered = getMap();
@@ -113,6 +116,7 @@ public abstract class AbstractOrderedMapTest<K, V> extends AbstractIterableMapTe
         assertEquals(confirmedLast, ordered.lastKey());
     }
 
+    @Test
     public void testNextKey() {
         resetEmpty();
         OrderedMap<K, V> ordered = getMap();
@@ -146,6 +150,7 @@ public abstract class AbstractOrderedMapTest<K, V> extends AbstractIterableMapTe
         }
     }
 
+    @Test
     public void testPreviousKey() {
         resetEmpty();
         OrderedMap<K, V> ordered = getMap();

--- a/src/test/java/org/apache/commons/collections4/map/AbstractSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractSortedMapTest.java
@@ -25,6 +25,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.commons.collections4.BulkTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link java.util.SortedMap} methods and contracts.
@@ -61,6 +62,7 @@ public abstract class AbstractSortedMapTest<K, V> extends AbstractMapTest<K, V> 
         return new TreeMap<>();
     }
 
+    @Test
     public void testComparator() {
 //        SortedMap<K, V> sm = makeFullMap();
         // no tests I can think of
@@ -80,11 +82,13 @@ public abstract class AbstractSortedMapTest<K, V> extends AbstractMapTest<K, V> 
         return (SortedMap<K, V>) super.makeFullMap();
     }
 
+    @Test
     public void testFirstKey() {
         final SortedMap<K, V> sm = makeFullMap();
         assertSame(sm.keySet().iterator().next(), sm.firstKey());
     }
 
+    @Test
     public void testLastKey() {
         final SortedMap<K, V> sm = makeFullMap();
         K obj = null;
@@ -230,6 +234,8 @@ public abstract class AbstractSortedMapTest<K, V> extends AbstractMapTest<K, V> 
         public SortedMap<K, V> makeFullMap() {
             return ((SortedMap<K, V>) main.makeFullMap()).headMap(toKey);
         }
+
+        @Test
         public void testHeadMapOutOfRange() {
             if (!isPutAddSupported()) {
                 return;
@@ -285,6 +291,8 @@ public abstract class AbstractSortedMapTest<K, V> extends AbstractMapTest<K, V> 
         public SortedMap<K, V> makeFullMap() {
             return ((SortedMap<K, V>) main.makeFullMap()).tailMap(fromKey);
         }
+
+        @Test
         public void testTailMapOutOfRange() {
             if (!isPutAddSupported()) {
                 return;
@@ -347,6 +355,8 @@ public abstract class AbstractSortedMapTest<K, V> extends AbstractMapTest<K, V> 
         public SortedMap<K, V> makeFullMap() {
             return ((SortedMap<K, V>) main.makeFullMap()).subMap(fromKey, toKey);
         }
+
+        @Test
         public void testSubMapOutOfRange() {
             if (!isPutAddSupported()) {
                 return;

--- a/src/test/java/org/apache/commons/collections4/map/CaseInsensitiveMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/CaseInsensitiveMapTest.java
@@ -21,9 +21,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
+import org.junit.Test;
 
 /**
  * Tests for the {@link CaseInsensitiveMap} implementation.
@@ -31,7 +30,7 @@ import org.apache.commons.collections4.BulkTest;
  */
 public class CaseInsensitiveMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(CaseInsensitiveMapTest.class);
     }
 
@@ -49,6 +48,7 @@ public class CaseInsensitiveMapTest<K, V> extends AbstractIterableMapTest<K, V> 
         return new CaseInsensitiveMap<>();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testCaseInsensitive() {
         final Map<K, V> map = makeObject();
@@ -60,6 +60,7 @@ public class CaseInsensitiveMapTest<K, V> extends AbstractIterableMapTest<K, V> 
         assertEquals("Three", map.get("Two"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testClone() {
         final CaseInsensitiveMap<K, V> map = new CaseInsensitiveMap<>(10);
@@ -72,12 +73,14 @@ public class CaseInsensitiveMapTest<K, V> extends AbstractIterableMapTest<K, V> 
     /**
      * Test for <a href="https://issues.apache.org/jira/browse/COLLECTIONS-323">COLLECTIONS-323</a>.
      */
+    @Test
     public void testInitialCapacityZero() {
         final CaseInsensitiveMap<String, String> map = new CaseInsensitiveMap<>(0);
         assertEquals(1, map.data.length);
     }
 
     // COLLECTIONS-294
+    @Test
     public void testLocaleIndependence() {
         final Locale orig = Locale.getDefault();
 
@@ -112,6 +115,7 @@ public class CaseInsensitiveMapTest<K, V> extends AbstractIterableMapTest<K, V> 
 //        writeExternalFormToDisk((java.io.Serializable) map, "src/test/resources/data/test/CaseInsensitiveMap.fullCollection.version4.obj");
 //    }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testNullHandling() {
         final Map<K, V> map = makeObject();
@@ -128,6 +132,7 @@ public class CaseInsensitiveMapTest<K, V> extends AbstractIterableMapTest<K, V> 
         assertEquals(3, keys.size());
     }
 
+    @Test
     public void testPutAll() {
         final Map<Object, String> map = new HashMap<>();
         map.put("One", "One");

--- a/src/test/java/org/apache/commons/collections4/map/CompositeMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/CompositeMapTest.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Collection;
 
+import org.junit.Test;
+
 /**
  * Extension of {@link AbstractMapTest} for exercising the
  * {@link CompositeMap} implementation.
@@ -67,12 +69,14 @@ public class CompositeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         return map;
     }
 
+    @Test
     public void testGet() {
         final CompositeMap<K, V> map = new CompositeMap<>(buildOne(), buildTwo());
         assertEquals("one", map.get("1"));
         assertEquals("four", map.get("4"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testAddComposited() {
         final CompositeMap<K, V> map = new CompositeMap<>(buildOne(), buildTwo());
@@ -85,6 +89,7 @@ public class CompositeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertThrows(IllegalArgumentException.class, () -> map.addComposited(three));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveComposited() {
         final CompositeMap<K, V> map = new CompositeMap<>(buildOne(), buildTwo());
@@ -102,6 +107,7 @@ public class CompositeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveFromUnderlying() {
         final CompositeMap<K, V> map = new CompositeMap<>(buildOne(), buildTwo());
@@ -116,6 +122,7 @@ public class CompositeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertFalse(map.containsKey("5"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveFromComposited() {
         final CompositeMap<K, V> map = new CompositeMap<>(buildOne(), buildTwo());
@@ -130,6 +137,7 @@ public class CompositeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertFalse(three.containsKey("5"));
     }
 
+    @Test
     public void testResolveCollision() {
         final CompositeMap<K, V> map = new CompositeMap<>(buildOne(), buildTwo(),
             new CompositeMap.MapMutator<K, V>() {
@@ -159,6 +167,7 @@ public class CompositeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertTrue(pass);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPut() {
         final CompositeMap<K, V> map = new CompositeMap<>(buildOne(), buildTwo(),
@@ -189,6 +198,7 @@ public class CompositeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertTrue(pass);
     }
 
+    @Test
     public void testPutAll() {
         final CompositeMap<K, V> map = new CompositeMap<>(buildOne(), buildTwo(),
             new CompositeMap.MapMutator<K, V>() {

--- a/src/test/java/org/apache/commons/collections4/map/DefaultedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/DefaultedMapTest.java
@@ -28,6 +28,7 @@ import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
 import org.apache.commons.collections4.functors.ConstantFactory;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractMapTest} for exercising the
@@ -49,6 +50,7 @@ public class DefaultedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         return DefaultedMap.defaultedMap(new HashMap<K, V>(), nullFactory);
     }
 
+    @Test
     @Override
     @SuppressWarnings("unchecked")
     public void testMapGet() {
@@ -66,6 +68,7 @@ public class DefaultedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals("NULL", map.get("NotInMap"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMapGet2() {
         final HashMap<K, V> base = new HashMap<>();
@@ -85,6 +88,7 @@ public class DefaultedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals("NULL", map.get("NotInMap"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMapGet3() {
         final HashMap<K, V> base = new HashMap<>();
@@ -104,6 +108,7 @@ public class DefaultedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals("NULL", map.get("NotInMap"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMapGet4() {
         final HashMap<K, V> base = new HashMap<>();
@@ -130,6 +135,7 @@ public class DefaultedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals("NULL_OBJECT", map.get(Integer.valueOf(0)));
     }
 
+    @Test
     public void testFactoryMethods() {
         final HashMap<K, V> base = new HashMap<>();
         assertAll(

--- a/src/test/java/org/apache/commons/collections4/map/FixedSizeSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/FixedSizeSortedMapTest.java
@@ -19,8 +19,6 @@ package org.apache.commons.collections4.map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 
 /**
@@ -35,7 +33,7 @@ public class FixedSizeSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(FixedSizeSortedMapTest.class);
     }
 

--- a/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
@@ -29,8 +29,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.iterators.AbstractMapIteratorTest;
-
-import junit.framework.Test;
+import org.junit.Test;
 
 /**
  * JUnit tests.
@@ -49,7 +48,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(Flat3MapTest.class);
     }
 
@@ -58,6 +57,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         return new Flat3Map<>();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testEquals1() {
         final Flat3Map<K, V> map1 = makeObject();
@@ -69,6 +69,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertFalse(map1.equals(map2));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testEquals2() {
         final Flat3Map<K, V> map1 = makeObject();
@@ -80,6 +81,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertFalse(map1.equals(map2));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testClone2() {
         final Flat3Map<K, V> map = makeObject();
@@ -111,6 +113,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertSame(TWENTY, cloned.get(TWO));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testClone4() {
         final Flat3Map<K, V> map = makeObject();
@@ -147,6 +150,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertSame(TWO, cloned.get(TWENTY));
     }
 
+    @Test
     public void testSerialisation0() throws Exception {
         final Flat3Map<K, V> map = makeObject();
         final ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -162,6 +166,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(0, ser.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSerialisation2() throws Exception {
         final Flat3Map<K, V> map = makeObject();
@@ -185,6 +190,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(TWENTY, ser.get(TWO));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSerialisation4() throws Exception {
         final Flat3Map<K, V> map = makeObject();
@@ -214,6 +220,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(TWO, ser.get(TWENTY));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testEntryIteratorSetValue1() throws Exception {
         final Flat3Map<K, V> map = makeObject();
@@ -233,6 +240,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(THIRTY, map.get(THREE));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testEntryIteratorSetValue2() throws Exception {
         final Flat3Map<K, V> map = makeObject();
@@ -253,6 +261,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(THIRTY, map.get(THREE));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testEntryIteratorSetValue3() throws Exception {
         final Flat3Map<K, V> map = makeObject();
@@ -274,6 +283,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals("NewValue", map.get(THREE));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMapIteratorSetValue1() throws Exception {
         final Flat3Map<K, V> map = makeObject();
@@ -293,6 +303,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(THIRTY, map.get(THREE));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMapIteratorSetValue2() throws Exception {
         final Flat3Map<K, V> map = makeObject();
@@ -313,6 +324,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(THIRTY, map.get(THREE));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMapIteratorSetValue3() throws Exception {
         final Flat3Map<K, V> map = makeObject();
@@ -334,6 +346,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals("NewValue", map.get(THREE));
     }
 
+    @Test
     public void testEntrySet() {
         // Sanity check
         putAndRemove(new LinkedHashMap<>());
@@ -429,6 +442,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
 //            "src/test/resources/data/test/Flat3Map.fullCollection.version4.obj");
 //    }
 
+    @Test
     public void testCollections261() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         m.put( Integer.valueOf(1), Integer.valueOf(1) );
@@ -444,6 +458,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals( Integer.valueOf(0), m.remove( Integer.valueOf(0) ) );
     }
 
+    @Test
     public void testToString() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         final String string0 = m.toString();
@@ -465,6 +480,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertNotSame(string2, string3);
     }
 
+    @Test
     public void testRemove1() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 
@@ -494,6 +510,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertSame(TWO, obj);
     }
 
+    @Test
     public void testRemove2() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         Object obj;
@@ -513,6 +530,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertSame(THREE, obj);
     }
 
+    @Test
     public void testRemove3() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         Object obj;
@@ -532,6 +550,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertSame(THREE, obj);
     }
 
+    @Test
     public void testRemove4() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         Object obj;
@@ -551,6 +570,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertNull(obj);
     }
 
+    @Test
     public void testRemove5() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         Object obj;
@@ -564,6 +584,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertNull(obj);
     }
 
+    @Test
     public void testRemove6() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         Object obj;
@@ -580,6 +601,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertNull(obj);
     }
 
+    @Test
     public void testRemove7() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         Object obj;
@@ -596,6 +618,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertSame(TWO, obj);
     }
 
+    @Test
     public void testRemove8() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         Object obj;
@@ -615,6 +638,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertNull(obj);
     }
 
+    @Test
     public void testRemove9() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         final Object obj;
@@ -625,6 +649,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertNull(obj);
     }
 
+    @Test
     public void testRemove10() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         final Object obj;
@@ -636,6 +661,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertNull(obj);
     }
 
+    @Test
     public void testRemove11() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         final Object obj;
@@ -648,6 +674,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertNull(obj);
     }
 
+    @Test
     public void testRemove12() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         final Object obj;
@@ -660,6 +687,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertNull(obj);
     }
 
+    @Test
     public void testRemove13() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         final Object obj;
@@ -671,6 +699,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertNull(obj);
     }
 
+    @Test
     public void testNewInstance1() {
         final Map<Integer, Integer> orig = new HashMap<>();
         orig.put(ONE, ONE);
@@ -682,6 +711,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(2, m.size());
     }
 
+    @Test
     public void testGet1() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         final Object obj;
@@ -691,6 +721,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertSame(ONE, obj);
     }
 
+    @Test
     public void testGet2() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         final Object obj;
@@ -701,6 +732,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertSame(TWO, obj);
     }
 
+    @Test
     public void testGet3() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
         final Object obj;
@@ -712,6 +744,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertSame(THREE, obj);
     }
 
+    @Test
     public void testContainsKey1() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 
@@ -722,6 +755,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertTrue(contains);
     }
 
+    @Test
     public void testContainsKey2() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 
@@ -731,6 +765,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertTrue(contains);
     }
 
+    @Test
     public void testContainsKey3() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 
@@ -739,6 +774,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertTrue(contains);
     }
 
+    @Test
     public void testContainsValue1() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 
@@ -749,6 +785,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertTrue(contains);
     }
 
+    @Test
     public void testContainsValue2() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 
@@ -758,6 +795,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertTrue(contains);
     }
 
+    @Test
     public void testContainsValue3() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 
@@ -766,6 +804,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertTrue(contains);
     }
 
+    @Test
     public void testPut1() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 
@@ -777,6 +816,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(ONE, m.get(null));
     }
 
+    @Test
     public void testPut2() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 
@@ -787,6 +827,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(ONE, m.get(null));
     }
 
+    @Test
     public void testPut3() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 
@@ -796,6 +837,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertNull(m.get(ONE));
     }
 
+    @Test
     public void testPut4() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 
@@ -807,6 +849,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(ONE, m.get(THREE));
     }
 
+    @Test
     public void testPut5() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 
@@ -817,6 +860,7 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(ONE, m.get(TWO));
     }
 
+    @Test
     public void testPut6() {
         final Flat3Map<Integer, Integer> m = new Flat3Map<>();
 

--- a/src/test/java/org/apache/commons/collections4/map/HashedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/HashedMapTest.java
@@ -16,9 +16,8 @@
  */
 package org.apache.commons.collections4.map;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
+import org.junit.Test;
 
 /**
  * JUnit tests.
@@ -30,7 +29,7 @@ public class HashedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(HashedMapTest.class);
     }
 
@@ -44,6 +43,7 @@ public class HashedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         return "4";
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testClone() {
         final HashedMap<K, V> map = new HashedMap<>(10);
@@ -53,6 +53,7 @@ public class HashedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertSame(map.get("1"), cloned.get("1"));
     }
 
+    @Test
     public void testInternalState() {
         final HashedMap<Integer, Integer> map = new HashedMap<>(42, 0.75f);
         assertEquals(0.75f, map.loadFactor, 0.1f);
@@ -83,6 +84,7 @@ public class HashedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
     /**
      * Test for <a href="https://issues.apache.org/jira/browse/COLLECTIONS-323">COLLECTIONS-323</a>.
      */
+    @Test
     public void testInitialCapacityZero() {
         final HashedMap<String, String> map = new HashedMap<>(0);
         assertEquals(1, map.data.length);

--- a/src/test/java/org/apache/commons/collections4/map/LRUMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LRUMapTest.java
@@ -25,12 +25,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.ResettableIterator;
+import org.junit.Test;
 
 /**
  * JUnit tests.
@@ -41,7 +40,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(LRUMapTest.class);
     }
 
@@ -71,6 +70,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         return (LRUMap<K, V>) super.getMap();
     }
 
+    @Test
     public void testCtors() {
         assertAll(
                 () -> assertThrows(IllegalArgumentException.class, () -> new LRUMap<K, V>(0),
@@ -88,6 +88,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         );
     }
 
+    @Test
     public void testLRU() {
         if (!isPutAddSupported() || !isPutChangeSupported()) {
             return;
@@ -152,6 +153,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertSame(values[3], vit.next());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testReset() {
         resetEmpty();
@@ -168,6 +170,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertSame(list.get(0), it.next());
     }
 
+    @Test
     public void testAccessOrder() {
         if (!isPutAddSupported() || !isPutChangeSupported()) {
             return;
@@ -242,6 +245,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertSame(values[3], vit.next());
     }
 
+    @Test
     public void testAccessOrder2() {
         if (!isPutAddSupported() || !isPutChangeSupported()) {
             return;
@@ -291,6 +295,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertSame(values[0], vit.next());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testClone() {
         final LRUMap<K, V> map = new LRUMap<>(10);
@@ -300,6 +305,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertSame(map.get("1"), cloned.get("1"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveLRU() {
         final MockLRUMapSubclass<K, String> map = new MockLRUMapSubclass<>(2);
@@ -343,6 +349,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
 
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveLRUBlocksRemove() {
         final MockLRUMapSubclassBlocksRemove<K, V> map = new MockLRUMapSubclassBlocksRemove<>(2, false);
@@ -359,6 +366,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertTrue(map.containsKey("C"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveLRUBlocksRemoveScan() {
         final MockLRUMapSubclassBlocksRemove<K, V> map = new MockLRUMapSubclassBlocksRemove<>(2, true);
@@ -393,6 +401,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
 
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveLRUFirstBlocksRemove() {
         final MockLRUMapSubclassFirstBlocksRemove<K, V> map = new MockLRUMapSubclassFirstBlocksRemove<>(2);
@@ -452,6 +461,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
 
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_Buckets() {
         if (!isPutAddSupported() || !isPutChangeSupported()) {
@@ -542,6 +552,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertEquals(three, map.data[hashIndex].next.next.key);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testInternalState_getEntry_int() {
         if (!isPutAddSupported() || !isPutChangeSupported()) {
@@ -565,6 +576,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         );
     }
 
+    @Test
     public void testSynchronizedRemoveFromMapIterator() throws InterruptedException {
 
         final LRUMap<Object, Thread> map = new LRUMap<>(10000);
@@ -648,6 +660,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
                 + counter[0] + " did succeed", counter[0] >= threads.length);
     }
 
+    @Test
     public void testSynchronizedRemoveFromEntrySet() throws InterruptedException {
 
         final Map<Object, Thread> map = new LRUMap<>(10000);
@@ -726,6 +739,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
                 + counter[0] + " did succeed", counter[0] >= threads.length);
     }
 
+    @Test
     public void testSynchronizedRemoveFromKeySet() throws InterruptedException {
 
         final Map<Object, Thread> map = new LRUMap<>(10000);
@@ -809,6 +823,7 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
                 + counter[0] + " did succeed", counter[0] >= threads.length);
     }
 
+    @Test
     public void testSynchronizedRemoveFromValues() throws InterruptedException {
 
         final Map<Object, Thread> map = new LRUMap<>(10000);

--- a/src/test/java/org/apache/commons/collections4/map/LazyMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LazyMapTest.java
@@ -46,6 +46,7 @@ public class LazyMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         return lazyMap(new HashMap<K, V>(), FactoryUtils.<V>nullFactory());
     }
 
+    @Test
     @Override
     public void testMapGet() {
         //TODO eliminate need for this via superclass - see svn history.

--- a/src/test/java/org/apache/commons/collections4/map/LazySortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LazySortedMapTest.java
@@ -69,6 +69,7 @@ public class LazySortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
     }
 
     // from LazyMapTest
+    @Test
     @Override
     public void testMapGet() {
         //TODO eliminate need for this via superclass - see svn history.
@@ -89,6 +90,7 @@ public class LazySortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
 
     }
 
+    @Test
     public void testSortOrder() {
         final SortedMap<String, Number> map = lazySortedMap(new TreeMap<String, Number>(), oneFactory);
         map.put("A",  5);
@@ -107,6 +109,7 @@ public class LazySortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
         assertNull("natural order, so comparator should be null", c);
     }
 
+    @Test
     public void testReverseSortOrder() {
         final SortedMap<String, Number> map = lazySortedMap(new ConcurrentSkipListMap<String, Number>(reverseStringComparator), oneFactory);
         map.put("A",  5);
@@ -125,6 +128,7 @@ public class LazySortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
         assertSame("natural order, so comparator should be null", c, reverseStringComparator);
     }
 
+    @Test
     public void testTransformerDecorate() {
         final Transformer<Object, Integer> transformer = TransformerUtils.asTransformer(oneFactory);
         SortedMap<Integer, Number> map = lazySortedMap(new TreeMap<Integer, Number>(), transformer);

--- a/src/test/java/org/apache/commons/collections4/map/LinkedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LinkedMapTest.java
@@ -21,13 +21,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.ResettableIterator;
 import org.apache.commons.collections4.list.AbstractListTest;
+import org.junit.Test;
 
 /**
  * JUnit tests.
@@ -39,7 +38,7 @@ public class LinkedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(LinkedMapTest.class);
     }
 
@@ -61,6 +60,7 @@ public class LinkedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         return "4";
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testReset() {
         resetEmpty();
@@ -77,6 +77,7 @@ public class LinkedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertSame(list.get(0), it.next());
     }
 
+    @Test
     public void testInsertionOrder() {
         if (!isPutAddSupported() || !isPutChangeSupported()) {
             return;
@@ -124,6 +125,7 @@ public class LinkedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertSame(values[2], valueIter.next());
     }
 
+    @Test
     public void testGetByIndex() {
         resetEmpty();
         LinkedMap<K, V> lm = getMap();
@@ -149,6 +151,7 @@ public class LinkedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     public void testGetValueByIndex() {
         resetEmpty();
         LinkedMap<K, V> lm = getMap();
@@ -175,6 +178,7 @@ public class LinkedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     public void testIndexOf() {
         resetEmpty();
         LinkedMap<K, V> lm = getMap();
@@ -191,6 +195,7 @@ public class LinkedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     public void testRemoveByIndex() {
         resetEmpty();
         LinkedMap<K, V> lm = getMap();
@@ -269,6 +274,7 @@ public class LinkedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testClone() {
         final LinkedMap<K, V> map = new LinkedMap<>(10);
@@ -296,6 +302,7 @@ public class LinkedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
     /**
      * Test for <a href="https://issues.apache.org/jira/browse/COLLECTIONS-323">COLLECTIONS-323</a>.
      */
+    @Test
     public void testInitialCapacityZero() {
         final LinkedMap<String, String> map = new LinkedMap<>(0);
         assertEquals(1, map.data.length);

--- a/src/test/java/org/apache/commons/collections4/map/ListOrderedMap2Test.java
+++ b/src/test/java/org/apache/commons/collections4/map/ListOrderedMap2Test.java
@@ -19,11 +19,10 @@ package org.apache.commons.collections4.map;
 import java.util.ArrayList;
 import java.util.List;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.list.AbstractListTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractOrderedMapTest} for exercising the {@link ListOrderedMap}
@@ -37,7 +36,7 @@ public class ListOrderedMap2Test<K, V> extends AbstractOrderedMapTest<K, V> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(ListOrderedMap2Test.class);
     }
 
@@ -54,6 +53,7 @@ public class ListOrderedMap2Test<K, V> extends AbstractOrderedMapTest<K, V> {
         return (ListOrderedMap<K, V>) super.makeFullMap();
     }
 
+    @Test
     public void testGetByIndex() {
         resetEmpty();
         ListOrderedMap<K, V> lom = getMap();
@@ -79,6 +79,7 @@ public class ListOrderedMap2Test<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     public void testGetValueByIndex() {
         resetEmpty();
         ListOrderedMap<K, V> lom = getMap();
@@ -105,6 +106,7 @@ public class ListOrderedMap2Test<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     public void testIndexOf() {
         resetEmpty();
         ListOrderedMap<K, V> lom = getMap();
@@ -121,6 +123,7 @@ public class ListOrderedMap2Test<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     public void testRemoveByIndex() {
         resetEmpty();
         ListOrderedMap<K, V> lom = getMap();

--- a/src/test/java/org/apache/commons/collections4/map/ListOrderedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ListOrderedMapTest.java
@@ -25,11 +25,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.list.AbstractListTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractOrderedMapTest} for exercising the {@link ListOrderedMap}
@@ -43,7 +42,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(ListOrderedMapTest.class);
     }
 
@@ -60,6 +59,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         return (ListOrderedMap<K, V>) super.makeFullMap();
     }
 
+    @Test
     public void testGetByIndex() {
         resetEmpty();
         ListOrderedMap<K, V> lom = getMap();
@@ -85,6 +85,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     public void testGetValueByIndex() {
         resetEmpty();
         ListOrderedMap<K, V> lom = getMap();
@@ -111,6 +112,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     public void testIndexOf() {
         resetEmpty();
         ListOrderedMap<K, V> lom = getMap();
@@ -127,6 +129,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSetValueByIndex() {
         resetEmpty();
@@ -155,6 +158,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     public void testRemoveByIndex() {
         resetEmpty();
         ListOrderedMap<K, V> lom = getMap();
@@ -187,6 +191,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPut_intObjectObject() {
         resetEmpty();
@@ -303,6 +308,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertEquals("One", lom.getValue(2));
     }
 
+    @Test
     public void testPutAllWithIndex() {
         resetEmpty();
         @SuppressWarnings("unchecked")
@@ -330,6 +336,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertEquals("testInsert2v", lom.getValue(4));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPutAllWithIndexBug441() {
         // see COLLECTIONS-441
@@ -354,6 +361,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     public void testValueList_getByIndex() {
         resetFull();
         final ListOrderedMap<K, V> lom = getMap();
@@ -363,6 +371,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testValueList_setByIndex() {
         resetFull();
@@ -376,6 +385,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     public void testValueList_removeByIndex() {
         resetFull();
         final ListOrderedMap<K, V> lom = getMap();
@@ -385,6 +395,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         }
     }
 
+    @Test
     public void testCOLLECTIONS_474_nullValues () {
         final Object key1 = new Object();
         final Object key2 = new Object();
@@ -399,6 +410,7 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         listMap.putAll(2, hmap);
     }
 
+    @Test
     public void testCOLLECTIONS_474_nonNullValues () {
         final Object key1 = new Object();
         final Object key2 = new Object();

--- a/src/test/java/org/apache/commons/collections4/map/MultiKeyMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/MultiKeyMapTest.java
@@ -20,11 +20,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Map;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.keyvalue.MultiKey;
+import org.junit.Test;
 
 /**
  * JUnit tests.
@@ -44,7 +43,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(MultiKeyMapTest.class);
     }
 
@@ -114,6 +113,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         return false;
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testNullHandling() {
         resetFull();
@@ -132,6 +132,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         assertThrows(NullPointerException.class, () -> map.put(null, (V) new Object()));
     }
 
+    @Test
     public void testMultiKeyGet() {
         resetFull();
         final MultiKeyMap<K, V> multimap = getMap();
@@ -185,6 +186,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         }
     }
 
+    @Test
     public void testMultiKeyContainsKey() {
         resetFull();
         final MultiKeyMap<K, V> multimap = getMap();
@@ -234,6 +236,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         }
     }
 
+    @Test
     public void testMultiKeyPut() {
         final MultiKey<K>[] keys = getMultiKeyKeys();
         final V[] values = getSampleValues();
@@ -295,6 +298,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         }
     }
 
+    @Test
     public void testMultiKeyPutWithNullKey() {
         final MultiKeyMap<String, String> map = new MultiKeyMap<>();
         map.put("a", null, "value1");
@@ -311,6 +315,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         assertEquals("value6", map.get(null, "a"));
     }
 
+    @Test
     public void testMultiKeyRemove() {
         final MultiKey<K>[] keys = getMultiKeyKeys();
         final V[] values = getSampleValues();
@@ -362,6 +367,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         }
     }
 
+    @Test
     public void testMultiKeyRemoveAll1() {
         resetFull();
         final MultiKeyMap<K, V> multimap = getMap();
@@ -375,6 +381,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         }
     }
 
+    @Test
     public void testMultiKeyRemoveAll2() {
         resetFull();
         final MultiKeyMap<K, V> multimap = getMap();
@@ -388,6 +395,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         }
     }
 
+    @Test
     public void testMultiKeyRemoveAll3() {
         resetFull();
         final MultiKeyMap<K, V> multimap = getMap();
@@ -401,6 +409,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         }
     }
 
+    @Test
     public void testMultiKeyRemoveAll4() {
         resetFull();
         final MultiKeyMap<K, V> multimap = getMap();
@@ -414,6 +423,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testClone() {
         final MultiKeyMap<K, V> map = new MultiKeyMap<>();
@@ -423,6 +433,7 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
         assertSame(map.get(new MultiKey<>((K) I1, (K) I2)), cloned.get(new MultiKey<>((K) I1, (K) I2)));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testLRUMultiKeyMap() {
         final MultiKeyMap<K, V> map = MultiKeyMap.multiKeyMap(new LRUMap<MultiKey<? extends K>, V>(2));

--- a/src/test/java/org/apache/commons/collections4/map/MultiValueMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/MultiValueMapTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import org.apache.commons.collections4.AbstractObjectTest;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.collections4.MultiMap;
+import org.junit.Test;
 
 /**
  * TestMultiValueMap.
@@ -48,17 +49,20 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         super(testName);
     }
 
+    @Test
     public void testNoMappingReturnsNull() {
         final MultiValueMap<K, V> map = createTestMap();
         assertNull(map.get("whatever"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testValueCollectionType() {
         final MultiValueMap<K, V> map = createTestMap(LinkedList.class);
         assertTrue(map.get("one") instanceof LinkedList);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultipleValues() {
         final MultiValueMap<K, V> map = createTestMap(HashSet.class);
@@ -68,6 +72,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertEquals(expected, map.get("one"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testContainsValue() {
         final MultiValueMap<K, V> map = createTestMap(HashSet.class);
@@ -80,6 +85,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertFalse(map.containsValue("quatro"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testKeyContainsValue() {
         final MultiValueMap<K, V> map = createTestMap(HashSet.class);
@@ -92,6 +98,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertFalse(map.containsValue("four", "quatro"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testValues() {
         final MultiValueMap<K, V> map = createTestMap(HashSet.class);
@@ -124,6 +131,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         return map;
     }
 
+    @Test
     public void testKeyedIterator() {
         final MultiValueMap<K, V> map = createTestMap();
         final ArrayList<Object> actual = new ArrayList<>(IteratorUtils.toList(map.iterator("one")));
@@ -131,6 +139,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertEquals(expected, actual);
     }
 
+    @Test
     public void testRemoveAllViaIterator() {
         final MultiValueMap<K, V> map = createTestMap();
         for (final Iterator<?> i = map.values().iterator(); i.hasNext();) {
@@ -141,6 +150,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertTrue(map.isEmpty());
     }
 
+    @Test
     public void testRemoveAllViaKeyedIterator() {
         final MultiValueMap<K, V> map = createTestMap();
         for (final Iterator<?> i = map.iterator("one"); i.hasNext();) {
@@ -151,6 +161,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertEquals(4, map.totalSize());
     }
 
+    @Test
     public void testIterator() {
         final MultiValueMap<K, V> map = createTestMap();
         @SuppressWarnings("unchecked")
@@ -165,6 +176,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertTrue(values.isEmpty());
     }
 
+    @Test
     public void testRemoveAllViaEntryIterator() {
         final MultiValueMap<K, V> map = createTestMap();
         for (final Iterator<?> i = map.iterator(); i.hasNext();) {
@@ -175,10 +187,12 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertEquals(0, map.totalSize());
     }
 
+    @Test
     public void testTotalSizeA() {
         assertEquals(6, createTestMap().totalSize());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMapEquals() {
         final MultiValueMap<K, V> one = new MultiValueMap<>();
@@ -190,6 +204,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertEquals(two, one);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testGetCollection() {
         final MultiValueMap<K, V> map = new MultiValueMap<>();
@@ -197,6 +212,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertSame(map.get("A"), map.getCollection("A"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testTotalSize() {
         final MultiValueMap<K, V> map = new MultiValueMap<>();
@@ -215,6 +231,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertEquals(2, map.totalSize());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSize() {
         final MultiValueMap<K, V> map = new MultiValueMap<>();
@@ -233,6 +250,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertEquals(1, map.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSize_Key() {
         final MultiValueMap<K, V> map = new MultiValueMap<>();
@@ -258,6 +276,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertEquals(2, map.size("B"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIterator_Key() {
         final MultiValueMap<K, V> map = new MultiValueMap<>();
@@ -269,6 +288,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertFalse(it.hasNext());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testContainsValue_Key() {
         final MultiValueMap<K, V> map = new MultiValueMap<>();
@@ -279,6 +299,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertFalse(map.containsValue("A", "AB"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPutWithList() {
         @SuppressWarnings("rawtypes")
@@ -290,6 +311,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertEquals(2, test.totalSize());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPutWithSet() {
         @SuppressWarnings("rawtypes")
@@ -302,6 +324,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertEquals(2, test.totalSize());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPutAll_Map1() {
         final MultiMap<K, V> original = new MultiValueMap<>();
@@ -323,6 +346,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertTrue(test.containsValue("object2"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPutAll_Map2() {
         final Map<K, V> original = new HashMap<>();
@@ -345,6 +369,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertTrue(test.containsValue("object2"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPutAll_KeyCollection() {
         final MultiValueMap<K, V> map = new MultiValueMap<>();
@@ -377,6 +402,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertTrue(map.containsValue("A", "M"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemove_KeyItem() {
         final MultiValueMap<K, V> map = new MultiValueMap<>();
@@ -391,6 +417,7 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         assertEquals(new MultiValueMap<K, V>(), map);
     }
 
+    @Test
     public void testUnsafeDeSerialization() throws Exception {
         final MultiValueMap map1 = MultiValueMap.multiValueMap(new HashMap(), ArrayList.class);
         byte[] bytes = serialize(map1);
@@ -447,12 +474,14 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
         return new MultiValueMap();
     }
 
+    @Test
     public void testEmptyMapCompatibility() throws Exception {
         final Map<?, ?> map = makeEmptyMap();
         final Map<?, ?> map2 = (Map<?, ?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(map));
         assertEquals("Map is empty", 0, map2.size());
     }
 
+    @Test
     public void testFullMapCompatibility() throws Exception {
         final Map<?, ?> map = (Map<?, ?>) makeObject();
         final Map<?, ?> map2 = (Map<?, ?>) readExternalFormFromDisk(getCanonicalFullCollectionName(map));

--- a/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
@@ -23,10 +23,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.map.PassiveExpiringMap.ExpirationPolicy;
+import org.junit.Test;
 
 /**
  * JUnit tests.
@@ -55,7 +54,7 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
         }
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(PassiveExpiringMapTest.class);
     }
 
@@ -104,6 +103,7 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
         return m;
     }
 
+    @Test
     public void testConstructors() {
         assertAll(
                 () -> assertThrows(NullPointerException.class, () -> {
@@ -124,6 +124,7 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
         );
     }
 
+    @Test
     public void testContainsKey() {
         final Map<Integer, String> m = makeTestMap();
         assertFalse(m.containsKey(Integer.valueOf(1)));
@@ -134,6 +135,7 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
         assertTrue(m.containsKey(Integer.valueOf(6)));
     }
 
+    @Test
     public void testContainsValue() {
         final Map<Integer, String> m = makeTestMap();
         assertFalse(m.containsValue("one"));
@@ -144,6 +146,7 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
         assertTrue(m.containsValue("six"));
     }
 
+    @Test
     public void testDecoratedMap() {
         // entries shouldn't expire
         final Map<Integer, String> m = makeDecoratedTestMap();
@@ -173,11 +176,13 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
         assertEquals("two", m.get(Integer.valueOf(2)));
     }
 
+    @Test
     public void testEntrySet() {
         final Map<Integer, String> m = makeTestMap();
         assertEquals(3, m.entrySet().size());
     }
 
+    @Test
     public void testExpiration() {
         validateExpiration(new PassiveExpiringMap<String, String>(500), 500);
         validateExpiration(new PassiveExpiringMap<String, String>(1000), 1000);
@@ -187,6 +192,7 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
                 new PassiveExpiringMap.ConstantTimeToLiveExpirationPolicy<String, String>(1, TimeUnit.SECONDS)), 1000);
     }
 
+    @Test
     public void testGet() {
         final Map<Integer, String> m = makeTestMap();
         assertNull(m.get(Integer.valueOf(1)));
@@ -197,6 +203,7 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
         assertEquals("six", m.get(Integer.valueOf(6)));
     }
 
+    @Test
     public void testIsEmpty() {
         Map<Integer, String> m = makeTestMap();
         assertFalse(m.isEmpty());
@@ -209,11 +216,13 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
         assertTrue(m.isEmpty());
     }
 
+    @Test
     public void testKeySet() {
         final Map<Integer, String> m = makeTestMap();
         assertEquals(3, m.size());
     }
 
+    @Test
     public void testPut() {
         final Map<Integer, String> m = makeTestMap();
         assertNull(m.put(Integer.valueOf(1), "ONE"));
@@ -224,16 +233,19 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
         assertEquals("six", m.put(Integer.valueOf(6), "SIX"));
     }
 
+    @Test
     public void testSize() {
         final Map<Integer, String> m = makeTestMap();
         assertEquals(3, m.size());
     }
 
+    @Test
     public void testValues() {
         final Map<Integer, String> m = makeTestMap();
         assertEquals(3, m.size());
     }
 
+    @Test
     public void testZeroTimeToLive() {
         // item should not be available
         final PassiveExpiringMap<String, String> m = new PassiveExpiringMap<>(0L);

--- a/src/test/java/org/apache/commons/collections4/map/PredicatedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PredicatedMapTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractMapTest} for exercising the
@@ -54,6 +55,7 @@ public class PredicatedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         return decorateMap(new HashMap<K, V>(), testPredicate, testPredicate);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testEntrySet() {
         Map<K, V> map = makeTestMap();
@@ -64,6 +66,7 @@ public class PredicatedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         map = decorateMap(map, null, null);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPut() {
         final Map<K, V> map = makeTestMap();

--- a/src/test/java/org/apache/commons/collections4/map/PredicatedSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PredicatedSortedMapTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
+import org.junit.Test;
 
 /**
  * Extension of {@link PredicatedMapTest} for exercising the
@@ -82,6 +83,7 @@ public class PredicatedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
     }
 
     // from TestPredicatedMap
+    @Test
     @SuppressWarnings("unchecked")
     public void testEntrySet() {
         SortedMap<K, V> map = makeTestMap();
@@ -92,6 +94,7 @@ public class PredicatedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
         map = decorateMap(map, null, null);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPut() {
         final Map<K, V> map = makeTestMap();
@@ -142,6 +145,7 @@ public class PredicatedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
 
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSortOrder() {
         final SortedMap<K, V> map = makeTestMap();
@@ -173,6 +177,7 @@ public class PredicatedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
         assertNull("natural order, so comparator should be null", c);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testReverseSortOrder() {
         final SortedMap<K, V> map = makeTestMapWithComparator();

--- a/src/test/java/org/apache/commons/collections4/map/ReferenceIdentityMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ReferenceIdentityMapTest.java
@@ -20,11 +20,10 @@ import java.lang.ref.WeakReference;
 import java.util.Iterator;
 import java.util.Map;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength;
+import org.junit.Test;
 
 /**
  * Tests for ReferenceIdentityMap.
@@ -48,7 +47,7 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
         }
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(ReferenceIdentityMapTest.class);
     }
 
@@ -114,6 +113,7 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
 /*
     // Tests often fail because gc is uncontrollable
 
+    @Test
     public void testPurge() {
         ReferenceIdentityMap map = new ReferenceIdentityMap(ReferenceIdentityMap.WEAK, ReferenceIdentityMap.WEAK);
         Object[] hard = new Object[10];
@@ -139,7 +139,7 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
         assertTrue("map should be empty after purge of weak keys and values", map.isEmpty());
     }
 
-
+    @Test
     public void testGetAfterGC() {
         ReferenceIdentityMap map = new ReferenceIdentityMap(ReferenceIdentityMap.WEAK, ReferenceIdentityMap.WEAK);
         for (int i = 0; i < 10; i++) {
@@ -154,7 +154,7 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
         }
     }
 
-
+    @Test
     public void testEntrySetIteratorAfterGC() {
         ReferenceIdentityMap map = new ReferenceIdentityMap(ReferenceIdentityMap.WEAK, ReferenceIdentityMap.WEAK);
         Object[] hard = new Object[10];
@@ -176,6 +176,7 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
 
     }
 
+    @Test
     public void testMapIteratorAfterGC() {
         ReferenceIdentityMap map = new ReferenceIdentityMap(ReferenceIdentityMap.WEAK, ReferenceIdentityMap.WEAK);
         Object[] hard = new Object[10];
@@ -198,6 +199,7 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
 
     }
 
+    @Test
     public void testMapIteratorAfterGC2() {
         ReferenceIdentityMap map = new ReferenceIdentityMap(ReferenceIdentityMap.WEAK, ReferenceIdentityMap.WEAK);
         Object[] hard = new Object[10];
@@ -226,6 +228,7 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
         return new ReferenceIdentityMap<>(ReferenceStrength.WEAK, ReferenceStrength.WEAK);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testBasics() {
         final IterableMap<K, V> map = new ReferenceIdentityMap<>(ReferenceStrength.HARD, ReferenceStrength.HARD);
@@ -259,6 +262,7 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
         assertTrue(map.containsValue(I2B));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testHashEntry() {
         final IterableMap<K, V> map = new ReferenceIdentityMap<>(ReferenceStrength.HARD, ReferenceStrength.HARD);
@@ -276,6 +280,7 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
         assertFalse(entry1.equals(entry3));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testNullHandling() {
         resetFull();
@@ -301,6 +306,7 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
     }
 
     /** Tests whether purge values setting works */
+    @Test
     public void testPurgeValues() throws Exception {
         // many thanks to Juozas Baliuka for suggesting this method
         final Map<K, V> testMap = buildRefMap();

--- a/src/test/java/org/apache/commons/collections4/map/ReferenceMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ReferenceMapTest.java
@@ -32,8 +32,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.map.AbstractHashedMap.HashEntry;
 import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceEntry;
 import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength;
-
-import junit.framework.Test;
+import org.junit.Test;
 
 /**
  * Tests for ReferenceMap.
@@ -45,7 +44,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(ReferenceMapTest.class);
     }
 
@@ -80,6 +79,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 //            "src/test/resources/data/test/ReferenceMap.fullCollection.version4.obj");
 //    }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testNullHandling() {
         resetFull();
@@ -107,6 +107,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 /*
     // Tests often fail because gc is uncontrollable
 
+    @Test
     public void testPurge() {
         ReferenceMap map = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.WEAK);
         Object[] hard = new Object[10];
@@ -132,7 +133,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertTrue("map should be empty after purge of weak keys and values", map.isEmpty());
     }
 
-
+    @Test
     public void testGetAfterGC() {
         ReferenceMap map = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.WEAK);
         for (int i = 0; i < 10; i++) {
@@ -147,7 +148,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         }
     }
 
-
+    @Test
     public void testEntrySetIteratorAfterGC() {
         ReferenceMap map = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.WEAK);
         Object[] hard = new Object[10];
@@ -169,6 +170,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
     }
 
+    @Test
     public void testMapIteratorAfterGC() {
         ReferenceMap map = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.WEAK);
         Object[] hard = new Object[10];
@@ -191,6 +193,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
     }
 
+    @Test
     public void testMapIteratorAfterGC2() {
         ReferenceMap map = new ReferenceMap(ReferenceMap.WEAK, ReferenceMap.WEAK);
         Object[] hard = new Object[10];
@@ -235,6 +238,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
     }
 
     /** Tests whether purge values setting works */
+    @Test
     public void testPurgeValues() throws Exception {
         // many thanks to Juozas Baliuka for suggesting this method
         final Map<K, V> testMap = buildRefMap();
@@ -258,6 +262,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         }
     }
 
+    @Test
     public void testCustomPurge() {
         final List<Integer> expiredValues = new ArrayList<>();
         @SuppressWarnings("unchecked")
@@ -297,6 +302,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
      *
      * See <a href="https://issues.apache.org/jira/browse/COLLECTIONS-599">COLLECTIONS-599: HashEntry array object naming data initialized with double the size during deserialization</a>
      */
+    @Test
     public void testDataSizeAfterSerialization() throws IOException, ClassNotFoundException {
 
         final ReferenceMap<String, String> serializeMap = new ReferenceMap<>(ReferenceStrength.WEAK, ReferenceStrength.WEAK, true);

--- a/src/test/java/org/apache/commons/collections4/map/SingletonMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/SingletonMapTest.java
@@ -18,11 +18,11 @@ package org.apache.commons.collections4.map;
 
 import java.util.HashMap;
 
-import junit.framework.Test;
 import org.apache.commons.collections4.BoundedMap;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.KeyValue;
 import org.apache.commons.collections4.OrderedMap;
+import org.junit.Test;
 
 /**
  * JUnit tests.
@@ -38,7 +38,7 @@ public class SingletonMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(SingletonMapTest.class);
     }
 
@@ -93,6 +93,7 @@ public class SingletonMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         return (V[]) new Object[] { TEN };
     }
 
+    @Test
     public void testClone() {
         final SingletonMap<K, V> map = makeFullMap();
         assertEquals(1, map.size());
@@ -102,6 +103,7 @@ public class SingletonMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertTrue(cloned.containsValue(TWO));
     }
 
+    @Test
     public void testKeyValue() {
         final SingletonMap<K, V> map = makeFullMap();
         assertEquals(1, map.size());
@@ -110,6 +112,7 @@ public class SingletonMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertTrue(map instanceof KeyValue);
     }
 
+    @Test
     public void testBoundedMap() {
         final SingletonMap<K, V> map = makeFullMap();
         assertEquals(1, map.size());

--- a/src/test/java/org/apache/commons/collections4/map/StaticBucketMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/StaticBucketMapTest.java
@@ -16,9 +16,8 @@
  */
 package org.apache.commons.collections4.map;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
+import org.junit.Test;
 
 /**
  * Unit tests.
@@ -31,7 +30,7 @@ public class StaticBucketMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         super(name);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(StaticBucketMapTest.class);
     }
 
@@ -60,6 +59,7 @@ public class StaticBucketMapTest<K, V> extends AbstractIterableMapTest<K, V> {
     }
 
     // Bugzilla 37567
+    @Test
     @SuppressWarnings("unchecked")
     public void test_get_nullMatchesIncorrectly() {
         final StaticBucketMap<K, V> map = new StaticBucketMap<>(17);
@@ -72,6 +72,7 @@ public class StaticBucketMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void test_containsKey_nullMatchesIncorrectly() {
         final StaticBucketMap<K, V> map = new StaticBucketMap<>(17);
@@ -84,6 +85,7 @@ public class StaticBucketMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void test_containsValue_nullMatchesIncorrectly() {
         final StaticBucketMap<K, V> map = new StaticBucketMap<>(17);

--- a/src/test/java/org/apache/commons/collections4/map/TransformedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/TransformedMapTest.java
@@ -24,6 +24,7 @@ import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractMapTest} for exercising the {@link TransformedMap}
@@ -44,6 +45,7 @@ public class TransformedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
     public void testTransformedMap() {
         final Object[] els = { "1", "3", "5", "7", "2", "4", "6" };
 
@@ -92,6 +94,7 @@ public class TransformedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(Integer.valueOf(88), map.get(entry.getKey()));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testFactory_Decorate() {
         final Map<K, V> base = new HashMap<>();
@@ -112,6 +115,7 @@ public class TransformedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         assertEquals(Integer.valueOf(4), trans.get("D"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testFactory_decorateTransform() {
         final Map<K, V> base = new HashMap<>();

--- a/src/test/java/org/apache/commons/collections4/map/TransformedSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/TransformedSortedMapTest.java
@@ -21,12 +21,11 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSortedMapTest} for exercising the {@link TransformedSortedMap}
@@ -40,7 +39,7 @@ public class TransformedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> 
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(TransformedSortedMapTest.class);
     }
 
@@ -63,6 +62,7 @@ public class TransformedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> 
         return false;
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testTransformedMap() {
         final Object[] els = { "1", "3", "5", "7", "2", "4", "6" };
@@ -120,6 +120,7 @@ public class TransformedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> 
         assertEquals(Integer.valueOf(88), map.get(entry.getKey()));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testFactory_Decorate() {
         final SortedMap<K, V> base = new TreeMap<>();
@@ -140,6 +141,7 @@ public class TransformedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> 
         assertEquals(Integer.valueOf(4), trans.get("D"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testFactory_decorateTransform() {
         final SortedMap<K, V> base = new TreeMap<>();

--- a/src/test/java/org/apache/commons/collections4/map/UnmodifiableMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/UnmodifiableMapTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractMapTest} for exercising the
@@ -65,11 +66,13 @@ public class UnmodifiableMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         return (IterableMap<K, V>) UnmodifiableMap.unmodifiableMap(m);
     }
 
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullMap() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final Map<K, V> map = makeFullMap();
         assertSame(map, UnmodifiableMap.unmodifiableMap(map));

--- a/src/test/java/org/apache/commons/collections4/map/UnmodifiableOrderedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/UnmodifiableOrderedMapTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 
 import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractOrderedMapTest} for exercising the
@@ -64,11 +65,13 @@ public class UnmodifiableOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, 
         return UnmodifiableOrderedMap.unmodifiableOrderedMap(m);
     }
 
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullMap() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final OrderedMap<K, V> map = makeFullMap();
         assertSame(map, UnmodifiableOrderedMap.unmodifiableOrderedMap(map));

--- a/src/test/java/org/apache/commons/collections4/map/UnmodifiableSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/UnmodifiableSortedMapTest.java
@@ -22,6 +22,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSortedMapTest} for exercising the
@@ -64,11 +65,13 @@ public class UnmodifiableSortedMapTest<K, V> extends AbstractSortedMapTest<K, V>
         return UnmodifiableSortedMap.unmodifiableSortedMap(m);
     }
 
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullMap() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final SortedMap<K, V> map = makeFullMap();
         assertSame(map, UnmodifiableSortedMap.unmodifiableSortedMap(map));
@@ -76,6 +79,7 @@ public class UnmodifiableSortedMapTest<K, V> extends AbstractSortedMapTest<K, V>
         assertThrows(NullPointerException.class, () -> UnmodifiableSortedMap.unmodifiableSortedMap(null));
     }
 
+    @Test
     public void testHeadMap() {
         final SortedMap<K, V> map = makeFullMap();
         final SortedMap<K, V> m = new TreeMap<>();
@@ -88,6 +92,7 @@ public class UnmodifiableSortedMapTest<K, V> extends AbstractSortedMapTest<K, V>
         assertSame(16, map.headMap((K) "we'll").size());
     }
 
+    @Test
     public void testTailMap() {
         final SortedMap<K, V> map = makeFullMap();
 
@@ -100,6 +105,7 @@ public class UnmodifiableSortedMapTest<K, V> extends AbstractSortedMapTest<K, V>
         assertSame(18, map.tailMap((K) "again").size());
     }
 
+    @Test
     public void testSubMap() {
         final SortedMap<K, V> map = makeFullMap();
 

--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -40,6 +40,7 @@ import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.map.AbstractMapTest;
 import org.apache.commons.collections4.multiset.AbstractMultiSetTest;
 import org.apache.commons.collections4.set.AbstractSetTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link MultiValuedMap} contract and methods.
@@ -208,12 +209,14 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testNoMappingReturnsEmptyCol() {
         final MultiValuedMap<K, V> map = makeFullMap();
         assertTrue(map.get((K) "whatever").isEmpty());
     }
 
+    @Test
     public void testMultipleValues() {
         final MultiValuedMap<K, V> map = makeFullMap();
         @SuppressWarnings("unchecked")
@@ -222,6 +225,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertTrue(col.contains("un"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testGet() {
         final MultiValuedMap<K, V> map = makeFullMap();
@@ -233,6 +237,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertTrue(map.get((K) "three").contains("trois"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testAddMappingThroughGet(){
         if (!isAddSupported()) {
@@ -256,6 +261,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertTrue(col2.contains("uno"));
     }
 
+    @Test
     public void testRemoveMappingThroughGet() {
         if (!isRemoveSupported()) {
             return;
@@ -279,6 +285,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertEquals(0, col.size());
     }
 
+    @Test
     public void testRemoveMappingThroughGetIterator() {
         if (!isRemoveSupported()) {
             return;
@@ -302,6 +309,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertEquals(0, coll.size());
     }
 
+    @Test
     public void testContainsValue() {
         final MultiValuedMap<K, V> map = makeFullMap();
         assertTrue(map.containsValue("uno"));
@@ -313,6 +321,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertFalse(map.containsValue("quatro"));
     }
 
+    @Test
     public void testKeyContainsValue() {
         final MultiValuedMap<K, V> map = makeFullMap();
         assertTrue(map.containsMapping("one", "uno"));
@@ -324,6 +333,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertFalse(map.containsMapping("four", "quatro"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testValues() {
         final MultiValuedMap<K, V> map = makeFullMap();
@@ -346,6 +356,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
 //        assertEquals(expected, actual);
 //    }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveAllViaValuesIterator() {
         if (!isRemoveSupported()) {
@@ -360,6 +371,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertTrue(map.isEmpty());
     }
 
+    @Test
     public void testRemoveViaValuesRemove() {
         if (!isRemoveSupported()) {
             return;
@@ -397,6 +409,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
 //        assertEquals(4, map.size());
 //    }
 
+    @Test
     public void testEntriesCollectionIterator() {
         final MultiValuedMap<K, V> map = makeFullMap();
         final Collection<V> values = new ArrayList<>(map.values());
@@ -414,6 +427,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveAllViaEntriesIterator() {
         if (!isRemoveSupported()) {
@@ -428,11 +442,13 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertEquals(0, map.size());
     }
 
+    @Test
     public void testSize() {
         assertEquals(6, makeFullMap().size());
     }
 
     // -----------------------------------------------------------------------
+    @Test
     @SuppressWarnings("unchecked")
     public void testMapEquals() {
         if (!isAddSupported()) {
@@ -447,6 +463,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertEquals(two, one);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSizeWithPutRemove() {
         if (!isRemoveSupported() || !isAddSupported()) {
@@ -468,11 +485,13 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertEquals(2, map.size());
     }
 
+    @Test
     public void testKeySetSize() {
         final MultiValuedMap<K, V> map = makeFullMap();
         assertEquals(3, map.keySet().size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSize_Key() {
         final MultiValuedMap<K, V> map = makeFullMap();
@@ -528,6 +547,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
 //        assertEquals(false, it.hasNext());
 //    }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testContainsValue_Key() {
         final MultiValuedMap<K, V> map = makeFullMap();
@@ -541,6 +561,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertFalse(map.containsMapping("A", "AB"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPutAll_Map1() {
         if (!isAddSupported()) {
@@ -573,6 +594,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertTrue(test.containsValue("object2"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPutAll_Map2() {
         if (!isAddSupported()) {
@@ -606,6 +628,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertTrue(test.containsValue("object2"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testPutAll_KeyIterable() {
         if (!isAddSupported()) {
@@ -647,6 +670,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertTrue(map.containsMapping("A", "M"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemove_KeyItem() {
         if (!isRemoveSupported() || !isAddSupported()) {
@@ -664,6 +688,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         //assertEquals(new MultiValuedHashMap<K, V>(), map);
     }
 
+    @Test
     public void testToString(){
         if (!isAddSupported()) {
             return;
@@ -697,6 +722,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertEquals("{}", map.toString());
     }
 
+    @Test
     public void testKeysMultiSet() {
         final MultiValuedMap<K, V> map = makeFullMap();
         final MultiSet<K> keyMultiSet = map.keys();
@@ -707,6 +733,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertEquals(6, keyMultiSet.size());
     }
 
+    @Test
     public void testKeysBagIterator() {
         final MultiValuedMap<K, V> map = makeFullMap();
         final Collection<K> col = new ArrayList<>();
@@ -721,6 +748,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertEquals(6, bag.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testKeysBagContainsAll() {
         final MultiValuedMap<K, V> map = makeFullMap();
@@ -729,6 +757,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertTrue(keyMultiSet.containsAll(col));
     }
 
+    @Test
     public void testAsMapGet() {
         resetEmpty();
         Map<K, Collection<V>> mapCol = getMap().asMap();
@@ -743,6 +772,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertTrue(col.contains("uno"));
     }
 
+    @Test
     public void testAsMapRemove() {
         if (!isRemoveSupported()) {
             return;
@@ -754,6 +784,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertEquals(4, getMap().size());
     }
 
+    @Test
     public void testMapIterator() {
         resetEmpty();
         MapIterator<K, V> mapIt  = getMap().mapIterator();
@@ -768,6 +799,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         }
     }
 
+    @Test
     public void testMapIteratorRemove() {
         if (!isRemoveSupported()) {
             return;
@@ -781,6 +813,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertTrue(getMap().isEmpty());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMapIteratorUnsupportedSet() {
         resetFull();
@@ -793,6 +826,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         }
     }
 
+    @Test
     public void testMultiValuedMapIterator() {
         final MultiValuedMap<K, V> map = makeFullMap();
         final MapIterator<K, V> it = map.mapIterator();
@@ -848,6 +882,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
     // extend the AbstractTestMap
     // -----------------------------------------------------------------------
 
+    @Test
     public void testEmptyMapCompatibility() throws Exception {
         final MultiValuedMap<?, ?> map = makeObject();
         final MultiValuedMap<?, ?> map2 =
@@ -856,6 +891,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
     public void testFullMapCompatibility() throws Exception {
         final MultiValuedMap map = makeFullMap();
         final MultiValuedMap map2 =

--- a/src/test/java/org/apache/commons/collections4/multimap/ArrayListValuedHashMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/ArrayListValuedHashMapTest.java
@@ -23,11 +23,10 @@ import java.util.HashMap;
 import java.util.Arrays;
 import java.util.ArrayList;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.ListValuedMap;
 import org.apache.commons.collections4.MultiValuedMap;
+import org.junit.Test;
 
 /**
  * Test ArrayListValuedHashMap
@@ -40,7 +39,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(ArrayListValuedHashMapTest.class);
     }
 
@@ -51,6 +50,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
     }
 
     // -----------------------------------------------------------------------
+    @Test
     @SuppressWarnings("unchecked")
     public void testListValuedMapAdd() {
         final ListValuedMap<K, V> listMap = makeObject();
@@ -61,6 +61,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
         assertTrue(listMap.containsKey("A"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testListValuedMapAddViaListIterator() {
         final ListValuedMap<K, V> listMap = makeObject();
@@ -75,6 +76,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
         assertFalse(listIt.hasNext());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testListValuedMapRemove() {
         final ListValuedMap<K, V> listMap = makeObject();
@@ -92,6 +94,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
         assertFalse(listMap.containsKey("A"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testListValuedMapRemoveViaListIterator() {
         final ListValuedMap<K, V> listMap = makeObject();
@@ -113,6 +116,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
     public void testEqualsHashCodeContract() {
         final MultiValuedMap map1 = makeObject();
         final MultiValuedMap map2 = makeObject();
@@ -130,6 +134,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
     public void testListValuedMapEqualsHashCodeContract() {
         final ListValuedMap map1 = makeObject();
         final ListValuedMap map2 = makeObject();
@@ -149,6 +154,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
         assertNotSame(map1.hashCode(), map2.hashCode());
     }
 
+    @Test
     public void testArrayListValuedHashMap() {
         final ListValuedMap<K, V> listMap;
         final ListValuedMap<K, V> listMap1;
@@ -167,6 +173,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
         assertEquals("{}", listMap1.toString());
     }
 
+    @Test
     public void testTrimToSize(){
         final ArrayListValuedHashMap<K, V> listMap = new ArrayListValuedHashMap<>(4);
 
@@ -182,6 +189,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
         assertEquals(1, listMap.get((K) "B").size());
     }
 
+    @Test
     public void testWrappedListAdd() {
         final ListValuedMap<K, V> listMap = makeObject();
         final List<V> listA = listMap.get((K) "A");
@@ -193,6 +201,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
         assertEquals("{A=[W, Q, F]}", listMap.toString());
     }
 
+    @Test
     public void testWrappedListAddAll() {
         final ListValuedMap<K, V> listMap = makeObject();
         final List<V> listA = listMap.get((K) "A");
@@ -224,6 +233,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
         assertEquals("Q", list3.get(2));
     }
 
+    @Test
     public void testValuesListIteratorMethods(){
         final ListValuedMap<K, V> listMap = makeObject();
         final List<V> listA = listMap.get((K) "A");

--- a/src/test/java/org/apache/commons/collections4/multimap/HashSetValuedHashMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/HashSetValuedHashMapTest.java
@@ -21,11 +21,10 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.SetValuedMap;
+import org.junit.Test;
 
 /**
  * Test HashSetValuedHashMap
@@ -38,7 +37,7 @@ public class HashSetValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest<K
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(HashSetValuedHashMapTest.class);
     }
 
@@ -59,6 +58,7 @@ public class HashSetValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest<K
     }
 
     // -----------------------------------------------------------------------
+    @Test
     @SuppressWarnings("unchecked")
     public void testSetValuedMapAdd() {
         final SetValuedMap<K, V> setMap = makeObject();
@@ -72,6 +72,7 @@ public class HashSetValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest<K
         assertTrue(setMap.containsKey("A"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSetValuedMapRemove() {
         final SetValuedMap<K, V> setMap = makeObject();
@@ -92,6 +93,7 @@ public class HashSetValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest<K
         assertFalse(setMap.containsKey("A"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testSetValuedMapRemoveViaIterator() {
         final SetValuedMap<K, V> setMap = makeObject();
@@ -112,6 +114,7 @@ public class HashSetValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest<K
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Test
     public void testSetValuedMapEqualsHashCodeContract() {
         final SetValuedMap map1 = makeObject();
         final SetValuedMap map2 = makeObject();
@@ -132,6 +135,7 @@ public class HashSetValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest<K
         assertNotSame(map1.hashCode(), map2.hashCode());
     }
 
+    @Test
     public void testHashSetValueHashMap() {
         final SetValuedMap<K, V> setMap = new HashSetValuedHashMap<>(4);
         assertEquals(0, setMap.get((K) "whatever").size());
@@ -143,6 +147,7 @@ public class HashSetValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest<K
         assertEquals(3, setMap.get((K) "A").size());
     }
 
+    @Test
     public void testHashSetValueHashMap_1() {
         final MultiValuedMap<K, V> map = new ArrayListValuedHashMap<>();
         final SetValuedMap<K, V> map1;
@@ -165,6 +170,7 @@ public class HashSetValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest<K
         assertEquals("{}", map3.toString());
     }
 
+    @Test
     public void testHashSetValuedHashMap_2(){
         final Map<K, V> map = new HashMap<>();
         final SetValuedMap<K, V> map1;

--- a/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
@@ -18,13 +18,12 @@ package org.apache.commons.collections4.multimap;
 
 import java.util.Collection;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
+import org.junit.Test;
 
 /**
  * Tests for TransformedMultiValuedMap
@@ -37,7 +36,7 @@ public class TransformedMultiValuedMapTest<K, V> extends AbstractMultiValuedMapT
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(TransformedMultiValuedMapTest.class);
     }
 
@@ -49,6 +48,7 @@ public class TransformedMultiValuedMapTest<K, V> extends AbstractMultiValuedMapT
     }
 
     // -----------------------------------------------------------------------
+    @Test
     @SuppressWarnings("unchecked")
     public void testKeyTransformedMap() {
         final Object[] els = { "1", "3", "5", "7", "2", "4", "6" };
@@ -73,6 +73,7 @@ public class TransformedMultiValuedMapTest<K, V> extends AbstractMultiValuedMapT
         assertTrue(map.remove(Integer.valueOf((String) els[0])).contains(els[0]));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testValueTransformedMap() {
         final Object[] els = { "1", "3", "5", "7", "2", "4", "6" };
@@ -93,6 +94,7 @@ public class TransformedMultiValuedMapTest<K, V> extends AbstractMultiValuedMapT
     }
 
     // -----------------------------------------------------------------------
+    @Test
     @SuppressWarnings("unchecked")
     public void testFactory_Decorate() {
         final MultiValuedMap<K, V> base = new ArrayListValuedHashMap<>();
@@ -113,6 +115,7 @@ public class TransformedMultiValuedMapTest<K, V> extends AbstractMultiValuedMapT
         assertTrue(trans.get((K) "D").contains(Integer.valueOf(4)));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testFactory_decorateTransform() {
         final MultiValuedMap<K, V> base = new ArrayListValuedHashMap<>();

--- a/src/test/java/org/apache/commons/collections4/multimap/UnmodifiableMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/UnmodifiableMultiValuedMapTest.java
@@ -24,13 +24,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.MultiSet;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
 
 /**
  * Tests for UnmodifiableMultiValuedMap
@@ -43,7 +42,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(UnmodifiableMultiValuedMapTest.class);
     }
 
@@ -82,16 +81,19 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
     }
 
     // -----------------------------------------------------------------------
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullMap() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final MultiValuedMap<K, V> map = makeFullMap();
         assertSame(map, UnmodifiableMultiValuedMap.unmodifiableMultiValuedMap(map));
     }
 
+    @Test
     public void testDecoratorFactoryNullMap() {
         try {
             UnmodifiableMultiValuedMap.unmodifiableMultiValuedMap(null);
@@ -101,6 +103,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testAddException() {
         final MultiValuedMap<K, V> map = makeObject();
@@ -111,6 +114,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         }
     }
 
+    @Test
     public void testRemoveException() {
         final MultiValuedMap<K, V> map = makeFullMap();
         try {
@@ -123,6 +127,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         this.assertMapContainsAllValues(map);
     }
 
+    @Test
     public void testRemoveMappingException() {
         final MultiValuedMap<K, V> map = makeFullMap();
         try {
@@ -135,6 +140,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         this.assertMapContainsAllValues(map);
     }
 
+    @Test
     public void testClearException() {
         final MultiValuedMap<K, V> map = makeFullMap();
         try {
@@ -147,6 +153,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         this.assertMapContainsAllValues(map);
     }
 
+    @Test
     public void testPutAllException() {
         final MultiValuedMap<K, V> map = makeObject();
         final MultiValuedMap<K, V> original = new ArrayListValuedHashMap<>();
@@ -183,6 +190,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         assertEquals("{}", map.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testUnmodifiableEntries() {
         resetFull();
@@ -208,6 +216,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testUnmodifiableMapIterator() {
         resetFull();
@@ -225,6 +234,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testUnmodifiableKeySet() {
         resetFull();
@@ -255,6 +265,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testUnmodifiableValues() {
         resetFull();
@@ -285,6 +296,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testUnmodifiableAsMap() {
         resetFull();
@@ -314,6 +326,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testUnmodifiableKeys() {
         resetFull();

--- a/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
@@ -32,6 +32,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiSet;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.set.AbstractSetTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link org.apache.commons.collections4.MultiSet MultiSet}
@@ -126,6 +127,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         return (MultiSet<T>) super.getCollection();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetAdd() {
         if (!isAddSupported()) {
@@ -144,6 +146,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertTrue(multiset.contains("B"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetEqualsSelf() {
         final MultiSet<T> multiset = makeObject();
@@ -161,6 +164,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertEquals(multiset, multiset);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetRemove() {
         if (!isRemoveSupported()) {
@@ -185,6 +189,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertEquals("Should have count of 1", 1, multiset.getCount("A"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetRemoveAll() {
         if (!isRemoveSupported()) {
@@ -207,6 +212,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertEquals("Should have count of 1", 1, multiset.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetContains() {
         if (!isAddSupported()) {
@@ -231,6 +237,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertTrue("MultiSet has at least 1 'B'", multiset.contains("B"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetContainsAll() {
         if (!isAddSupported()) {
@@ -285,6 +292,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertTrue("MultiSet containsAll of 1 'A' 1 'B'", multiset.containsAll(known1A1B));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetSize() {
         if (!isAddSupported()) {
@@ -310,6 +318,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertEquals("Should have 2 total item", 2, multiset.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetRetainAll() {
         if (!isAddSupported()) {
@@ -330,6 +339,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertEquals("Should have 3 total items", 3, multiset.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetIterator() {
         if (!isAddSupported()) {
@@ -361,6 +371,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertEquals("MultiSet should have 1 'A'", 1, multiset.getCount("A"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetIteratorFail() {
         if (!isAddSupported()) {
@@ -382,6 +393,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetIteratorFailNoMore() {
         if (!isAddSupported()) {
@@ -404,6 +416,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetIteratorFailDoubleRemove() {
         if (!isAddSupported()) {
@@ -432,6 +445,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertEquals(1, multiset.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetIteratorRemoveProtectsInvariants() {
         if (!isAddSupported()) {
@@ -458,6 +472,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertFalse(it2.hasNext());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetEntrySetUpdatedToZero() {
         if (!isAddSupported()) {
@@ -474,6 +489,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertEquals(0, entry.getCount());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetToArray() {
         if (!isAddSupported()) {
@@ -498,6 +514,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertEquals(1, c);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetToArrayPopulate() {
         if (!isAddSupported()) {
@@ -522,6 +539,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertEquals(1, c);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetEquals() {
         if (!isAddSupported()) {
@@ -546,6 +564,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertTrue(multiset.equals(multiset2));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetEqualsHashMultiSet() {
         if (!isAddSupported()) {
@@ -570,6 +589,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         assertTrue(multiset.equals(multiset2));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testMultiSetHashCode() {
         if (!isAddSupported()) {
@@ -684,6 +704,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
      * Compare the current serialized form of the MultiSet
      * against the canonical version in SCM.
      */
+    @Test
     public void testEmptyMultiSetCompatibility() throws IOException, ClassNotFoundException {
         // test to make sure the canonical form has been preserved
         final MultiSet<T> multiset = makeObject();
@@ -698,6 +719,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
      * Compare the current serialized form of the MultiSet
      * against the canonical version in SCM.
      */
+    @Test
     public void testFullMultiSetCompatibility() throws IOException, ClassNotFoundException {
         // test to make sure the canonical form has been preserved
         final MultiSet<T> multiset = makeFullCollection();

--- a/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.commons.collections4.multiset;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiSet;
 
@@ -33,7 +31,7 @@ public class HashMultiSetTest<T> extends AbstractMultiSetTest<T> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(HashMultiSetTest.class);
     }
 

--- a/src/test/java/org/apache/commons/collections4/multiset/PredicatedMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/PredicatedMultiSetTest.java
@@ -18,12 +18,11 @@ package org.apache.commons.collections4.multiset;
 
 import java.util.Set;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiSet;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractMultiSetTest} for exercising the
@@ -37,7 +36,7 @@ public class PredicatedMultiSetTest<T> extends AbstractMultiSetTest<T> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(PredicatedMultiSetTest.class);
     }
 
@@ -64,6 +63,7 @@ public class PredicatedMultiSetTest<T> extends AbstractMultiSetTest<T> {
 
     //--------------------------------------------------------------------------
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testLegalAddRemove() {
         final MultiSet<T> multiset = makeTestMultiSet();
@@ -82,6 +82,7 @@ public class PredicatedMultiSetTest<T> extends AbstractMultiSetTest<T> {
             set.contains(els[0]));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalAdd() {
         final MultiSet<T> multiset = makeTestMultiSet();
@@ -95,6 +96,7 @@ public class PredicatedMultiSetTest<T> extends AbstractMultiSetTest<T> {
         assertFalse("Collection shouldn't contain illegal element", multiset.contains(i));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalDecorate() {
         final HashMultiSet<Object> elements = new HashMultiSet<>();

--- a/src/test/java/org/apache/commons/collections4/multiset/SynchronizedMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/SynchronizedMultiSetTest.java
@@ -16,8 +16,6 @@
  */
 package org.apache.commons.collections4.multiset;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiSet;
 
@@ -33,7 +31,7 @@ public class SynchronizedMultiSetTest<T> extends AbstractMultiSetTest<T> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(SynchronizedMultiSetTest.class);
     }
 

--- a/src/test/java/org/apache/commons/collections4/multiset/UnmodifiableMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/UnmodifiableMultiSetTest.java
@@ -18,11 +18,10 @@ package org.apache.commons.collections4.multiset;
 
 import java.util.Arrays;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiSet;
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractMultiSetTest} for exercising the
@@ -36,7 +35,7 @@ public class UnmodifiableMultiSetTest<E> extends AbstractMultiSetTest<E> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(UnmodifiableMultiSetTest.class);
     }
 
@@ -72,12 +71,13 @@ public class UnmodifiableMultiSetTest<E> extends AbstractMultiSetTest<E> {
         return false;
     }
 
-
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullCollection() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final MultiSet<E> multiset = makeFullCollection();
         assertSame(multiset, UnmodifiableMultiSet.unmodifiableMultiSet(multiset));
@@ -88,7 +88,7 @@ public class UnmodifiableMultiSetTest<E> extends AbstractMultiSetTest<E> {
         } catch (final NullPointerException ex) {}
     }
 
-
+    @Test
     public void testAdd() {
         final MultiSet<E> multiset = makeFullCollection();
         final MultiSet<E> unmodifiableMultiSet =  UnmodifiableMultiSet.unmodifiableMultiSet(multiset);
@@ -98,6 +98,7 @@ public class UnmodifiableMultiSetTest<E> extends AbstractMultiSetTest<E> {
         } catch (final UnsupportedOperationException ex) {}
     }
 
+    @Test
     public void testRemove() {
         final MultiSet<E> multiset = makeFullCollection();
         final MultiSet<E> unmodifiableMultiSet =  UnmodifiableMultiSet.unmodifiableMultiSet(multiset);
@@ -107,6 +108,7 @@ public class UnmodifiableMultiSetTest<E> extends AbstractMultiSetTest<E> {
         } catch (final UnsupportedOperationException ex) {}
     }
 
+    @Test
     public void testSetCount() {
         final MultiSet<E> multiset = makeFullCollection();
         final MultiSet<E> unmodifiableMultiSet =  UnmodifiableMultiSet.unmodifiableMultiSet(multiset);
@@ -116,6 +118,7 @@ public class UnmodifiableMultiSetTest<E> extends AbstractMultiSetTest<E> {
         } catch (final UnsupportedOperationException ex) {}
     }
 
+    @Test
     public void testEntrySet() {
         final MultiSet<E> multiset = makeFullCollection();
         final MultiSet<E> unmodifiableMultiSet =  UnmodifiableMultiSet.unmodifiableMultiSet(multiset);

--- a/src/test/java/org/apache/commons/collections4/properties/EmptyPropertiesTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/EmptyPropertiesTest.java
@@ -107,6 +107,7 @@ public class EmptyPropertiesTest {
         assertNotEquals(p, PropertiesFactory.EMPTY_PROPERTIES);
     }
 
+    @Test
     public void testForEach() {
         PropertiesFactory.EMPTY_PROPERTIES.forEach((k, v) -> fail());
     }

--- a/src/test/java/org/apache/commons/collections4/properties/PropertiesFactoryTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/PropertiesFactoryTest.java
@@ -28,8 +28,8 @@ public class PropertiesFactoryTest extends AbstractPropertiesFactoryTest<Propert
         super(PropertiesFactory.INSTANCE, fileExtension);
     }
 
-    @Override
     @Test
+    @Override
     public void testInstance() {
         Assertions.assertNotNull(PropertiesFactory.INSTANCE);
     }

--- a/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesFactoryTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesFactoryTest.java
@@ -25,8 +25,8 @@ public class SortedPropertiesFactoryTest extends AbstractPropertiesFactoryTest<S
         super(SortedPropertiesFactory.INSTANCE, fileExtension);
     }
 
-    @Override
     @Test
+    @Override
     public void testInstance() {
         Assertions.assertNotNull(SortedPropertiesFactory.INSTANCE);
     }

--- a/src/test/java/org/apache/commons/collections4/queue/AbstractQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/AbstractQueueTest.java
@@ -26,6 +26,7 @@ import java.util.NoSuchElementException;
 import java.util.Queue;
 
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link java.util.Queue} methods and contracts.
@@ -126,6 +127,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests {@link Queue#offer(Object)}.
      */
+    @Test
     public void testQueueOffer() {
         if (!isAddSupported()) {
             return;
@@ -158,6 +160,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests {@link Queue#element()}.
      */
+    @Test
     public void testQueueElement() {
         resetEmpty();
 
@@ -203,6 +206,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests {@link Queue#peek()}.
      */
+    @Test
     public void testQueuePeek() {
         if (!isRemoveSupported()) {
             return;
@@ -238,6 +242,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests {@link Queue#remove()}.
      */
+    @Test
     public void testQueueRemove() {
         if (!isRemoveSupported()) {
             return;
@@ -273,6 +278,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
     /**
      *  Tests {@link Queue#poll()}.
      */
+    @Test
     public void testQueuePoll() {
         if (!isRemoveSupported()) {
             return;
@@ -297,6 +303,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
         assertNull(element);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testEmptyQueueSerialization() throws IOException, ClassNotFoundException {
         final Queue<E> queue = makeObject();
@@ -311,6 +318,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
         assertEquals("Both queues are empty", 0, queue2.size());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testFullQueueSerialization() throws IOException, ClassNotFoundException {
         final Queue<E> queue = makeFullCollection();
@@ -330,6 +338,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
      * Compare the current serialized form of the Queue
      * against the canonical version in SCM.
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testEmptyQueueCompatibility() throws IOException, ClassNotFoundException {
         /*
@@ -353,6 +362,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
      * Compare the current serialized form of the Queue
      * against the canonical version in SCM.
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testFullQueueCompatibility() throws IOException, ClassNotFoundException {
         /*

--- a/src/test/java/org/apache/commons/collections4/queue/CircularFifoQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/CircularFifoQueueTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 
+import org.junit.Test;
+
 /**
  * Test cases for CircularFifoQueue.
  *
@@ -108,6 +110,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
     /**
      * Tests that the removal operation actually removes the first element.
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testCircularFifoQueueCircular() {
         final List<E> list = new ArrayList<>();
@@ -136,6 +139,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
     /**
      * Tests that the removal operation actually removes the first element.
      */
+    @Test
     public void testCircularFifoQueueRemove() {
         resetFull();
         final int size = getConfirmed().size();
@@ -157,6 +161,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
     /**
      * Tests that the constructor correctly throws an exception.
      */
+    @Test
     public void testConstructorException1() {
         try {
             new CircularFifoQueue<E>(0);
@@ -169,6 +174,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
     /**
      * Tests that the constructor correctly throws an exception.
      */
+    @Test
     public void testConstructorException2() {
         try {
             new CircularFifoQueue<E>(-20);
@@ -181,6 +187,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
     /**
      * Tests that the constructor correctly throws an exception.
      */
+    @Test
     public void testConstructorException3() {
         try {
             new CircularFifoQueue<E>(null);
@@ -190,6 +197,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         fail();
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveError1() throws Exception {
         // based on bug 33071
@@ -209,6 +217,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         assertEquals("[1, 2, 5]", fifo.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveError2() throws Exception {
         // based on bug 33071
@@ -230,6 +239,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         assertEquals("[2, 5, 6]", fifo.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveError3() throws Exception {
         // based on bug 33071
@@ -253,6 +263,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         assertEquals("[2, 5, 6, 7]", fifo.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveError4() throws Exception {
         // based on bug 33071
@@ -271,6 +282,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         assertEquals("[3, 5, 6, 7]", fifo.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveError5() throws Exception {
         // based on bug 33071
@@ -289,6 +301,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         assertEquals("[3, 4, 6, 7]", fifo.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveError6() throws Exception {
         // based on bug 33071
@@ -307,6 +320,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         assertEquals("[3, 4, 5, 7]", fifo.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveError7() throws Exception {
         // based on bug 33071
@@ -325,6 +339,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         assertEquals("[3, 4, 5, 6]", fifo.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveError8() throws Exception {
         // based on bug 33071
@@ -344,6 +359,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         assertEquals("[4, 5, 6, 8]", fifo.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveError9() throws Exception {
         // based on bug 33071
@@ -363,6 +379,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         assertEquals("[4, 5, 6, 7]", fifo.toString());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRepeatedSerialization() throws Exception {
         // bug 31433
@@ -399,6 +416,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         assertTrue(b3.contains("c"));
     }
 
+    @Test
     public void testGetIndex() {
         resetFull();
 
@@ -417,6 +435,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         }
     }
 
+    @Test
     public void testAddNull() {
         final CircularFifoQueue<E> b = new CircularFifoQueue<>(2);
         try {
@@ -428,6 +447,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         fail();
     }
 
+    @Test
     public void testDefaultSizeAndGetError1() {
         final CircularFifoQueue<E> fifo = new CircularFifoQueue<>();
         assertEquals(32, fifo.maxSize());
@@ -445,6 +465,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         fail();
     }
 
+    @Test
     public void testDefaultSizeAndGetError2() {
         final CircularFifoQueue<E> fifo = new CircularFifoQueue<>();
         assertEquals(32, fifo.maxSize());

--- a/src/test/java/org/apache/commons/collections4/queue/PredicatedQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/PredicatedQueueTest.java
@@ -25,6 +25,7 @@ import java.util.Queue;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.collection.PredicatedCollectionTest;
 import org.apache.commons.collections4.functors.TruePredicate;
+import org.junit.Test;
 
 /**
  * Extension of {@link PredicatedCollectionTest} for exercising the
@@ -76,6 +77,7 @@ public class PredicatedQueueTest<E> extends AbstractQueueTest<E> {
         return decorateCollection(new LinkedList<E>(), testPredicate);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testGet() {
         final Queue<E> queue = makeTestQueue();
@@ -88,6 +90,7 @@ public class PredicatedQueueTest<E> extends AbstractQueueTest<E> {
         assertEquals("Queue get", "one", queue.peek());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemove() {
         final Queue<E> queue = makeTestQueue();

--- a/src/test/java/org/apache/commons/collections4/queue/SynchronizedQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/SynchronizedQueueTest.java
@@ -21,8 +21,7 @@ import java.util.Queue;
 
 import org.apache.commons.collections4.BulkTest;
 import org.junit.Ignore;
-
-import junit.framework.Test;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractQueueTest} for exercising the {@link SynchronizedQueue} implementation.
@@ -31,7 +30,7 @@ import junit.framework.Test;
  */
 public class SynchronizedQueueTest<T> extends AbstractQueueTest<T> {
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(SynchronizedQueueTest.class);
     }
 
@@ -51,6 +50,7 @@ public class SynchronizedQueueTest<T> extends AbstractQueueTest<T> {
         return SynchronizedQueue.synchronizedQueue(new LinkedList<T>());
     }
 
+    @Test
     @Ignore("Run once")
     public void testCreate() throws Exception {
         Queue<T> queue = makeObject();

--- a/src/test/java/org/apache/commons/collections4/queue/TransformedQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/TransformedQueueTest.java
@@ -24,6 +24,7 @@ import java.util.Queue;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -61,6 +62,7 @@ public class TransformedQueueTest<E> extends AbstractQueueTest<E> {
         return TransformedQueue.transformingQueue(list, (Transformer<E, E>) TransformedCollectionTest.NOOP_TRANSFORMER);
     }
 
+    @Test
     public void testTransformedQueue() {
         final Queue<Object> queue = TransformedQueue.transformingQueue(new LinkedList<>(),
                 TransformedCollectionTest.STRING_TO_INTEGER_TRANSFORMER);
@@ -79,6 +81,7 @@ public class TransformedQueueTest<E> extends AbstractQueueTest<E> {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
     public void testTransformedQueue_decorateTransform() {
         final Queue originalQueue = new LinkedList();
         final Object[] elements = {"1", "3", "5", "7", "2", "4", "6"};

--- a/src/test/java/org/apache/commons/collections4/queue/UnmodifiableQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/UnmodifiableQueueTest.java
@@ -23,6 +23,7 @@ import java.util.Queue;
 
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -77,6 +78,7 @@ public class UnmodifiableQueueTest<E> extends AbstractQueueTest<E> {
         return false;
     }
 
+    @Test
     @Override
     public void testQueueRemove() {
         resetEmpty();
@@ -86,11 +88,13 @@ public class UnmodifiableQueueTest<E> extends AbstractQueueTest<E> {
         } catch (final UnsupportedOperationException ex) {}
     }
 
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullCollection() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final Queue<E> queue = makeFullCollection();
         assertSame(queue, UnmodifiableQueue.unmodifiableQueue(queue));
@@ -101,6 +105,7 @@ public class UnmodifiableQueueTest<E> extends AbstractQueueTest<E> {
         } catch (final NullPointerException ex) {}
     }
 
+    @Test
     public void testOffer() {
         final Queue<E> queue = makeFullCollection();
         final E e = null;
@@ -110,6 +115,7 @@ public class UnmodifiableQueueTest<E> extends AbstractQueueTest<E> {
         } catch (final UnsupportedOperationException ex) {}
     }
 
+    @Test
     public void testPoll() {
         final Queue<E> queue = makeFullCollection();
         try {

--- a/src/test/java/org/apache/commons/collections4/set/AbstractSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/AbstractSetTest.java
@@ -22,6 +22,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
+import org.junit.Test;
 
 /**
  * Abstract test class for {@link Set} methods and contracts.
@@ -138,6 +139,7 @@ public abstract class AbstractSetTest<E> extends AbstractCollectionTest<E> {
     /**
      * Tests {@link Set#equals(Object)}.
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testSetEquals() {
         resetEmpty();
@@ -160,6 +162,7 @@ public abstract class AbstractSetTest<E> extends AbstractCollectionTest<E> {
     /**
      * Tests {@link Set#hashCode()}.
      */
+    @Test
     public void testSetHashCode() {
         resetEmpty();
         assertEquals("Empty sets have equal hashCodes",

--- a/src/test/java/org/apache/commons/collections4/set/CompositeSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/CompositeSetTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.collections4.set.CompositeSet.SetMutator;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSetTest} for exercising the
@@ -58,24 +59,28 @@ public class CompositeSetTest<E> extends AbstractSetTest<E> {
         return set;
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testContains() {
         final CompositeSet<E> set = new CompositeSet<>(buildOne(), buildTwo());
         assertTrue(set.contains("1"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testContainsAll() {
         final CompositeSet<E> set = new CompositeSet<>(buildOne(), buildTwo());
         assertFalse(set.containsAll(null));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveAll() {
         final CompositeSet<E> set = new CompositeSet<>(buildOne(), buildTwo());
         assertFalse(set.removeAll(null));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveUnderlying() {
         final Set<E> one = buildOne();
@@ -88,6 +93,7 @@ public class CompositeSetTest<E> extends AbstractSetTest<E> {
         assertFalse(set.contains("3"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRemoveComposited() {
         final Set<E> one = buildOne();
@@ -100,6 +106,7 @@ public class CompositeSetTest<E> extends AbstractSetTest<E> {
         assertFalse(one.contains("3"));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testFailedCollisionResolution() {
         final Set<E> one = buildOne();
@@ -137,6 +144,7 @@ public class CompositeSetTest<E> extends AbstractSetTest<E> {
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testAddComposited() {
         final Set<E> one = buildOne();
@@ -167,6 +175,7 @@ public class CompositeSetTest<E> extends AbstractSetTest<E> {
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testAddCompositedCollision() {
         final HashSet<E> set1 = new HashSet<>();

--- a/src/test/java/org/apache/commons/collections4/set/ListOrderedSet2Test.java
+++ b/src/test/java/org/apache/commons/collections4/set/ListOrderedSet2Test.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.junit.Test;
+
 /**
  * Extension of {@link AbstractSetTest} for exercising the {@link ListOrderedSet}
  * implementation.
@@ -52,6 +54,7 @@ public class ListOrderedSet2Test<E> extends AbstractSetTest<E> {
         return set;
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testOrdering() {
         final ListOrderedSet<E> set = setupSet();
@@ -85,6 +88,7 @@ public class ListOrderedSet2Test<E> extends AbstractSetTest<E> {
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testListAddRemove() {
         final ListOrderedSet<E> set = makeObject();
@@ -115,6 +119,7 @@ public class ListOrderedSet2Test<E> extends AbstractSetTest<E> {
         assertSame(TWO, view.get(1));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testListAddIndexed() {
         final ListOrderedSet<E> set = makeObject();

--- a/src/test/java/org/apache/commons/collections4/set/ListOrderedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/ListOrderedSetTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.collections4.IteratorUtils;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSetTest} for exercising the
@@ -61,6 +62,7 @@ public class ListOrderedSetTest<E>
         return set;
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testOrdering() {
         final ListOrderedSet<E> set = setupSet();
@@ -96,6 +98,7 @@ public class ListOrderedSetTest<E>
         }
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testListAddRemove() {
         final ListOrderedSet<E> set = makeObject();
@@ -126,6 +129,7 @@ public class ListOrderedSetTest<E>
         assertSame(TWO, view.get(1));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testListAddIndexed() {
         final ListOrderedSet<E> set = makeObject();
@@ -164,6 +168,7 @@ public class ListOrderedSetTest<E>
         assertSame(ONE, set.get(3));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testListAddReplacing() {
         final ListOrderedSet<E> set = makeObject();
@@ -179,6 +184,7 @@ public class ListOrderedSetTest<E>
         assertSame(a, set.asList().get(0));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testRetainAll() {
         final List<E> list = new ArrayList<>(10);
@@ -203,6 +209,7 @@ public class ListOrderedSetTest<E>
         assertEquals(Integer.valueOf(0), orderedSet.get(4));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testDuplicates() {
         final List<E> list = new ArrayList<>(10);
@@ -248,6 +255,7 @@ public class ListOrderedSetTest<E>
         }
     }
 
+    @Test
     public void testDecorator() {
         try {
             ListOrderedSet.listOrderedSet((List<E>) null);

--- a/src/test/java/org/apache/commons/collections4/set/MapBackedSet2Test.java
+++ b/src/test/java/org/apache/commons/collections4/set/MapBackedSet2Test.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.apache.commons.collections4.map.LinkedMap;
+import org.junit.Test;
 
 /**
  * JUnit test.
@@ -47,6 +48,7 @@ public class MapBackedSet2Test<E> extends AbstractSetTest<E> {
         return set;
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testOrdering() {
         final Set<E> set = setupSet();
@@ -80,10 +82,12 @@ public class MapBackedSet2Test<E> extends AbstractSetTest<E> {
         }
     }
 
+    @Test
     @Override
     public void testCanonicalEmptyCollectionExists() {
     }
 
+    @Test
     @Override
     public void testCanonicalFullCollectionExists() {
     }

--- a/src/test/java/org/apache/commons/collections4/set/PredicatedNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/PredicatedNavigableSetTest.java
@@ -22,11 +22,10 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.TreeSet;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractNavigableSetTest} for exercising the
@@ -40,7 +39,7 @@ public class PredicatedNavigableSetTest<E> extends AbstractNavigableSetTest<E> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(PredicatedNavigableSetTest.class);
     }
 
@@ -67,11 +66,13 @@ public class PredicatedNavigableSetTest<E> extends AbstractNavigableSetTest<E> {
         return PredicatedNavigableSet.predicatedNavigableSet(new TreeSet<E>(), testPredicate);
     }
 
+    @Test
     public void testGetSet() {
         final PredicatedNavigableSet<E> set = makeTestSet();
         assertNotNull("returned set should not be null", set.decorated());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalAdd() {
         final NavigableSet<E> set = makeTestSet();
@@ -85,6 +86,7 @@ public class PredicatedNavigableSetTest<E> extends AbstractNavigableSetTest<E> {
         assertFalse("Collection shouldn't contain illegal element", set.contains(testString));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalAddAll() {
         final NavigableSet<E> set = makeTestSet();
@@ -105,6 +107,7 @@ public class PredicatedNavigableSetTest<E> extends AbstractNavigableSetTest<E> {
         assertFalse("Set shouldn't contain illegal element", set.contains("Afour"));
     }
 
+    @Test
     public void testComparator() {
         final NavigableSet<E> set = makeTestSet();
         final Comparator<? super E> c = set.comparator();

--- a/src/test/java/org/apache/commons/collections4/set/PredicatedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/PredicatedSetTest.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSetTest} for exercising the
@@ -62,11 +63,13 @@ public class PredicatedSetTest<E> extends AbstractSetTest<E> {
         return decorateSet(new HashSet<E>(), testPredicate);
     }
 
+    @Test
     public void testGetSet() {
         final PredicatedSet<E> set = makeTestSet();
         assertNotNull("returned set should not be null", set.decorated());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalAdd() {
         final Set<E> set = makeTestSet();
@@ -80,6 +83,7 @@ public class PredicatedSetTest<E> extends AbstractSetTest<E> {
         assertFalse("Collection shouldn't contain illegal element", set.contains(i));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalAddAll() {
         final Set<E> set = makeTestSet();

--- a/src/test/java/org/apache/commons/collections4/set/PredicatedSortedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/PredicatedSortedSetTest.java
@@ -22,11 +22,10 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSortedSetTest} for exercising the
@@ -40,7 +39,7 @@ public class PredicatedSortedSetTest<E> extends AbstractSortedSetTest<E> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(PredicatedSortedSetTest.class);
     }
 
@@ -64,11 +63,13 @@ public class PredicatedSortedSetTest<E> extends AbstractSortedSetTest<E> {
         return PredicatedSortedSet.predicatedSortedSet(new TreeSet<E>(), testPredicate);
     }
 
+    @Test
     public void testGetSet() {
         final PredicatedSortedSet<E> set = makeTestSet();
         assertNotNull("returned set should not be null", set.decorated());
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalAdd() {
         final SortedSet<E> set = makeTestSet();
@@ -82,6 +83,7 @@ public class PredicatedSortedSetTest<E> extends AbstractSortedSetTest<E> {
         assertFalse("Collection shouldn't contain illegal element", set.contains(testString));
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testIllegalAddAll() {
         final SortedSet<E> set = makeTestSet();
@@ -102,6 +104,7 @@ public class PredicatedSortedSetTest<E> extends AbstractSortedSetTest<E> {
         assertFalse("Set shouldn't contain illegal element", set.contains("Afour"));
     }
 
+    @Test
     public void testComparator() {
         final SortedSet<E> set = makeTestSet();
         final Comparator<? super E> c = set.comparator();

--- a/src/test/java/org/apache/commons/collections4/set/TransformedNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/TransformedNavigableSetTest.java
@@ -22,11 +22,10 @@ import java.util.NavigableSet;
 import java.util.TreeSet;
 import java.util.Set;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractNavigableSetTest} for exercising the
@@ -40,7 +39,7 @@ public class TransformedNavigableSetTest<E> extends AbstractNavigableSetTest<E> 
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(TransformedNavigableSetTest.class);
     }
 
@@ -59,6 +58,7 @@ public class TransformedNavigableSetTest<E> extends AbstractNavigableSetTest<E> 
                 (Transformer<E, E>) TransformedCollectionTest.NOOP_TRANSFORMER);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testTransformedSet() {
         final NavigableSet<E> set = TransformedNavigableSet.transformingNavigableSet(new TreeSet<E>(),
@@ -74,6 +74,7 @@ public class TransformedNavigableSetTest<E> extends AbstractNavigableSetTest<E> 
         assertTrue(set.remove(Integer.valueOf((String) els[0])));
     }
 
+    @Test
     public void testTransformedSet_decorateTransform() {
         final Set<Object> originalSet = new TreeSet<>();
         final Object[] els = {"1", "3", "5", "7", "2", "4", "6"};

--- a/src/test/java/org/apache/commons/collections4/set/TransformedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/TransformedSetTest.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSetTest} for exercising the {@link TransformedSet}
@@ -61,6 +62,7 @@ public class TransformedSetTest<E> extends AbstractSetTest<E> {
                 (Transformer<E, E>) TransformedCollectionTest.NOOP_TRANSFORMER);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testTransformedSet() {
         final Set<E> set = TransformedSet.transformingSet(new HashSet<E>(),
@@ -79,6 +81,7 @@ public class TransformedSetTest<E> extends AbstractSetTest<E> {
 
     }
 
+    @Test
     public void testTransformedSet_decorateTransform() {
         final Set<Object> originalSet = new HashSet<>();
         final Object[] els = {"1", "3", "5", "7", "2", "4", "6"};

--- a/src/test/java/org/apache/commons/collections4/set/TransformedSortedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/TransformedSortedSetTest.java
@@ -22,11 +22,10 @@ import java.util.TreeSet;
 import java.util.Set;
 import java.util.SortedSet;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSortedSetTest} for exercising the {@link TransformedSortedSet}
@@ -40,7 +39,7 @@ public class TransformedSortedSetTest<E> extends AbstractSortedSetTest<E> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(TransformedSortedSetTest.class);
     }
 
@@ -57,6 +56,7 @@ public class TransformedSortedSetTest<E> extends AbstractSortedSetTest<E> {
         return TransformedSortedSet.transformingSortedSet(set, (Transformer<E, E>) TransformedCollectionTest.NOOP_TRANSFORMER);
     }
 
+    @Test
     @SuppressWarnings("unchecked")
     public void testTransformedSet() {
         final SortedSet<E> set = TransformedSortedSet.transformingSortedSet(new TreeSet<E>(),
@@ -72,6 +72,7 @@ public class TransformedSortedSetTest<E> extends AbstractSortedSetTest<E> {
         assertTrue(set.remove(Integer.valueOf((String) els[0])));
     }
 
+    @Test
     public void testTransformedSet_decorateTransform() {
         final Set<Object> originalSet = new TreeSet<>();
         final Object[] els = {"1", "3", "5", "7", "2", "4", "6"};

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableNavigableSetTest.java
@@ -23,9 +23,8 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.TreeSet;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
+import org.junit.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -43,7 +42,7 @@ public class UnmodifiableNavigableSetTest<E> extends AbstractNavigableSetTest<E>
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(UnmodifiableNavigableSetTest.class);
     }
 
@@ -80,6 +79,7 @@ public class UnmodifiableNavigableSetTest<E> extends AbstractNavigableSetTest<E>
     /**
      * Verify that base set and subsets are not modifiable
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testUnmodifiable() {
         setupSet();
@@ -94,6 +94,7 @@ public class UnmodifiableNavigableSetTest<E> extends AbstractNavigableSetTest<E>
         verifyUnmodifiable(set.subSet((E) Integer.valueOf(1), true, (E) Integer.valueOf(3), true));
     }
 
+    @Test
     public void testDecorateFactory() {
         final NavigableSet<E> set = makeFullCollection();
         assertSame(set, UnmodifiableNavigableSet.unmodifiableNavigableSet(set));
@@ -121,6 +122,7 @@ public class UnmodifiableNavigableSetTest<E> extends AbstractNavigableSetTest<E>
         }
     }
 
+    @Test
     public void testComparator() {
         setupSet();
         final Comparator<? super E> c = set.comparator();

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableSetTest.java
@@ -22,10 +22,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Unmodifiable;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSetTest} for exercising the
@@ -39,7 +38,7 @@ public class UnmodifiableSetTest<E> extends AbstractSetTest<E> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(UnmodifiableSetTest.class);
     }
 
@@ -65,11 +64,13 @@ public class UnmodifiableSetTest<E> extends AbstractSetTest<E> {
         return false;
     }
 
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullCollection() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final Set<E> set = makeFullCollection();
         assertSame(set, UnmodifiableSet.unmodifiableSet(set));

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableSortedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableSortedSetTest.java
@@ -23,9 +23,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSortedSetTest} for exercising the
@@ -41,7 +40,7 @@ public class UnmodifiableSortedSetTest<E> extends AbstractSortedSetTest<E> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(UnmodifiableSortedSetTest.class);
     }
 
@@ -78,6 +77,7 @@ public class UnmodifiableSortedSetTest<E> extends AbstractSortedSetTest<E> {
     /**
      * Verify that base set and subsets are not modifiable
      */
+    @Test
     @SuppressWarnings("unchecked")
     public void testUnmodifiable() {
         setupSet();
@@ -87,6 +87,7 @@ public class UnmodifiableSortedSetTest<E> extends AbstractSortedSetTest<E> {
         verifyUnmodifiable(set.subSet((E) Integer.valueOf(1), (E) Integer.valueOf(3)));
     }
 
+    @Test
     public void testDecorateFactory() {
         final SortedSet<E> set = makeFullCollection();
         assertSame(set, UnmodifiableSortedSet.unmodifiableSortedSet(set));
@@ -140,6 +141,7 @@ public class UnmodifiableSortedSetTest<E> extends AbstractSortedSetTest<E> {
         }
     }
 
+    @Test
     public void testComparator() {
         setupSet();
         final Comparator<? super E> c = set.comparator();

--- a/src/test/java/org/apache/commons/collections4/splitmap/TransformedSplitMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/splitmap/TransformedSplitMapTest.java
@@ -26,6 +26,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.functors.NOPTransformer;
+import org.junit.Test;
 
 /**
  * Tests for {@link TransformedSplitMap}
@@ -46,6 +47,7 @@ public class TransformedSplitMapTest extends BulkTest {
     }
 
     // -----------------------------------------------------------------------
+    @Test
     public void testTransformedMap() {
         final TransformedSplitMap<Integer, String, Object, Class<?>> map = TransformedSplitMap.transformingMap(
                 new HashMap<String, Class<?>>(), intToString, objectToClass);
@@ -90,6 +92,7 @@ public class TransformedSplitMapTest extends BulkTest {
 
     // -----------------------------------------------------------------------
 
+    @Test
     public void testMapIterator() {
         final TransformedSplitMap<String, String, String, Integer> map =
                 TransformedSplitMap.transformingMap(new HashMap<String, Integer>(),
@@ -106,6 +109,7 @@ public class TransformedSplitMapTest extends BulkTest {
         }
     }
 
+    @Test
     public void testEmptyMap() throws IOException, ClassNotFoundException {
         final TransformedSplitMap<String, String, String, String> map =
                 TransformedSplitMap.transformingMap(new HashMap<String, String>(),
@@ -122,6 +126,7 @@ public class TransformedSplitMapTest extends BulkTest {
         assertEquals( map.entrySet(), readMap.entrySet() );
     }
 
+    @Test
     public void testFullMap() throws IOException, ClassNotFoundException {
         final TransformedSplitMap<String, String, String, String> map = TransformedSplitMap.transformingMap(
                 new HashMap<String, String>(),

--- a/src/test/java/org/apache/commons/collections4/trie/PatriciaTrie2Test.java
+++ b/src/test/java/org/apache/commons/collections4/trie/PatriciaTrie2Test.java
@@ -16,8 +16,6 @@
  */
 package org.apache.commons.collections4.trie;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.map.AbstractOrderedMapTest;
@@ -33,7 +31,7 @@ public class PatriciaTrie2Test<V> extends AbstractOrderedMapTest<String, V> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(PatriciaTrie2Test.class);
     }
 

--- a/src/test/java/org/apache/commons/collections4/trie/PatriciaTrieTest.java
+++ b/src/test/java/org/apache/commons/collections4/trie/PatriciaTrieTest.java
@@ -26,12 +26,11 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.SortedMap;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Trie;
 import org.apache.commons.collections4.map.AbstractSortedMapTest;
 import org.junit.jupiter.api.Assertions;
+import org.junit.Test;
 
 /**
  * JUnit tests for the PatriciaTrie.
@@ -44,7 +43,7 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(PatriciaTrieTest.class);
     }
 
@@ -58,6 +57,7 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
         return false;
     }
 
+    @Test
     public void testPrefixMap() {
         final PatriciaTrie<String> trie = new PatriciaTrie<>();
 
@@ -286,6 +286,7 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
         Assertions.assertFalse(iterator.hasNext());
     }
 
+    @Test
     public void testPrefixMapRemoval() {
         final PatriciaTrie<String> trie = new PatriciaTrie<>();
 
@@ -329,6 +330,7 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
         Assertions.assertFalse(iter.hasNext());
     }
 
+    @Test
     public void testPrefixMapSizes() {
         // COLLECTIONS-525
         final PatriciaTrie<String> aTree = new PatriciaTrie<>();
@@ -349,6 +351,7 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
         assertEquals(2, aTree.prefixMap("点").size());
     }
 
+    @Test
     public void testPrefixMapSizes2() {
         final char u8000 = Character.toChars(32768)[0]; // U+8000 (1000000000000000)
         final char char_b = 'b'; // 1100010
@@ -369,6 +372,7 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
         assertTrue(trie.prefixMap(prefixString).containsKey(longerString));
     }
 
+    @Test
     public void testPrefixMapClear() {
         final Trie<String, Integer> trie = new PatriciaTrie<>();
         trie.put("Anna", 1);
@@ -390,6 +394,7 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
         assertEquals(Arrays.asList(2, 3, 7, 1), new ArrayList<>(trie.values()));
     }
 
+    @Test
     public void testPrefixMapClearNothing() {
         final Trie<String, Integer> trie = new PatriciaTrie<>();
         final SortedMap<String, Integer> prefixMap = trie.prefixMap("And");
@@ -404,6 +409,7 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
         assertEquals(new ArrayList<Integer>(0), new ArrayList<>(trie.values()));
     }
 
+    @Test
     public void testPrefixMapClearUsingRemove() {
         final Trie<String, Integer> trie = new PatriciaTrie<>();
         trie.put("Anna", 1);

--- a/src/test/java/org/apache/commons/collections4/trie/UnmodifiableTrieTest.java
+++ b/src/test/java/org/apache/commons/collections4/trie/UnmodifiableTrieTest.java
@@ -18,12 +18,11 @@ package org.apache.commons.collections4.trie;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import junit.framework.Test;
-
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Trie;
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.map.AbstractSortedMapTest;
+import org.junit.Test;
 
 /**
  * Extension of {@link AbstractSortedMapTest} for exercising the
@@ -37,7 +36,7 @@ public class UnmodifiableTrieTest<V> extends AbstractSortedMapTest<String, V> {
         super(testName);
     }
 
-    public static Test suite() {
+    public static junit.framework.Test suite() {
         return BulkTest.makeSuite(UnmodifiableTrieTest.class);
     }
 
@@ -70,11 +69,13 @@ public class UnmodifiableTrieTest<V> extends AbstractSortedMapTest<String, V> {
         return UnmodifiableTrie.unmodifiableTrie(m);
     }
 
+    @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);
         assertTrue(makeFullMap() instanceof Unmodifiable);
     }
 
+    @Test
     public void testDecorateFactory() {
         final Trie<String, V> trie = makeFullMap();
         assertSame(trie, UnmodifiableTrie.unmodifiableTrie(trie));


### PR DESCRIPTION
Ensure all tests have @Test annotation. So highlight how many are discovered using the legacy `public void test` method prefix. It also highlights now many tests are still to be upgraded.