### PR TITLE
[COLLECTIONS-806] Continue JUnit v5

### DIFF
--- a/src/test/java/org/apache/commons/collections4/AbstractObjectTestInterface.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractObjectTestInterface.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4;
+
+/**
+ * Abstract object test interface, extracted from AbstractObjectTest for easier reuse.
+ */
+public interface AbstractObjectTestInterface {
+
+    String getCompatibilityVersion();
+
+}

--- a/src/test/java/org/apache/commons/collections4/AbstractObjectTestUtils.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractObjectTestUtils.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+import static org.apache.commons.collections4.BulkTestConstants.TEST_DATA_PATH;
+
+/**
+ * Abstract object test utils, extracted from AbstractObjectTest for easier reuse.
+ */
+public final class AbstractObjectTestUtils {
+
+    public static String getCanonicalEmptyCollectionName(final Object object, final AbstractObjectTestInterface test) {
+        final StringBuilder retval = new StringBuilder();
+        retval.append(TEST_DATA_PATH);
+        String colName = object.getClass().getName();
+        colName = colName.substring(colName.lastIndexOf(".") + 1);
+        retval.append(colName);
+        retval.append(".emptyCollection.version");
+        retval.append(test.getCompatibilityVersion());
+        retval.append(".obj");
+        return retval.toString();
+    }
+
+    public static String getCanonicalFullCollectionName(final Object object, final AbstractObjectTestInterface test) {
+        final StringBuilder retval = new StringBuilder();
+        retval.append(TEST_DATA_PATH);
+        String colName = object.getClass().getName();
+        colName = colName.substring(colName.lastIndexOf(".") + 1);
+        retval.append(colName);
+        retval.append(".fullCollection.version");
+        retval.append(test.getCompatibilityVersion());
+        retval.append(".obj");
+        return retval.toString();
+    }
+
+    public static Object serializeDeserialize(final Object obj) throws Exception {
+        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        final ObjectOutputStream out = new ObjectOutputStream(buffer);
+        out.writeObject(obj);
+        out.close();
+
+        final ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()));
+        final Object dest = in.readObject();
+        in.close();
+
+        return dest;
+    }
+
+    /**
+     * Writes a Serializable or Externalizable object as
+     * a file at the given path.  NOT USEFUL as part
+     * of a unit test; this is just a utility method
+     * for creating disk-based objects in SCM that can become
+     * the basis for compatibility tests using
+     * readExternalFormFromDisk(String path)
+     *
+     * @param o Object to serialize
+     * @param path path to write the serialized Object
+     * @throws IOException
+     */
+    public static void writeExternalFormToDisk(final Serializable o, final String path) throws IOException {
+        try (FileOutputStream fileStream = new FileOutputStream(path)) {
+            writeExternalFormToStream(o, fileStream);
+        }
+    }
+
+    /**
+     * Converts a Serializable or Externalizable object to
+     * bytes.  Useful for in-memory tests of serialization
+     *
+     * @param o Object to convert to bytes
+     * @return serialized form of the Object
+     * @throws IOException
+     */
+    public static byte[] writeExternalFormToBytes(final Serializable o) throws IOException {
+        final ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        writeExternalFormToStream(o, byteStream);
+        return byteStream.toByteArray();
+    }
+
+    /**
+     * Reads a Serialized or Externalized Object from disk.
+     * Useful for creating compatibility tests between
+     * different SCM versions of the same class
+     *
+     * @param path path to the serialized Object
+     * @return the Object at the given path
+     * @throws IOException
+     * @throws ClassNotFoundException
+     */
+    public static Object readExternalFormFromDisk(final String path) throws IOException, ClassNotFoundException {
+        try (FileInputStream stream = new FileInputStream(path)) {
+            return readExternalFormFromStream(stream);
+        }
+    }
+
+    /**
+     * Read a Serialized or Externalized Object from bytes.
+     * Useful for verifying serialization in memory.
+     *
+     * @param b byte array containing a serialized Object
+     * @return Object contained in the bytes
+     * @throws IOException
+     * @throws ClassNotFoundException
+     */
+    public static Object readExternalFormFromBytes(final byte[] b) throws IOException, ClassNotFoundException {
+        final ByteArrayInputStream stream = new ByteArrayInputStream(b);
+        return readExternalFormFromStream(stream);
+    }
+
+    // private implementation
+    private static Object readExternalFormFromStream(final InputStream stream) throws IOException, ClassNotFoundException {
+        final ObjectInputStream oStream = new ObjectInputStream(stream);
+        return oStream.readObject();
+    }
+
+    private static void writeExternalFormToStream(final Serializable o, final OutputStream stream) throws IOException {
+        final ObjectOutputStream oStream = new ObjectOutputStream(stream);
+        oStream.writeObject(o);
+    }
+
+}

--- a/src/test/java/org/apache/commons/collections4/BulkTest.java
+++ b/src/test/java/org/apache/commons/collections4/BulkTest.java
@@ -147,12 +147,6 @@ public class BulkTest extends TestCase implements Cloneable {
     // Given one BulkTest instance, we can just clone it and reset the
     // method name for every simple test it defines.
 
-    /** Path to test data resources */
-    protected static final String TEST_DATA_PATH = "src/test/resources/org/apache/commons/collections4/data/test/";
-
-    /** Path to test properties resources */
-    public static final String TEST_PROPERTIES_PATH = "src/test/resources/org/apache/commons/collections4/properties/";
-
     /**
      *  The full name of this bulk test instance.  This is the full name
      *  that is compared to {@link #ignoredTests} to see if this

--- a/src/test/java/org/apache/commons/collections4/BulkTestConstants.java
+++ b/src/test/java/org/apache/commons/collections4/BulkTestConstants.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4;
+
+/**
+ * Bulk test constants, extracted from BulkTest for easier reuse.
+ */
+public interface BulkTestConstants {
+
+    /** Path to test data resources */
+    String TEST_DATA_PATH = "src/test/resources/org/apache/commons/collections4/data/test/";
+
+    /** Path to test properties resources */
+    String TEST_PROPERTIES_PATH = "src/test/resources/org/apache/commons/collections4/properties/";
+
+}

--- a/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
@@ -34,6 +34,9 @@ import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.set.AbstractSetTest;
 import org.junit.Test;
 
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalEmptyCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalFullCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.readExternalFormFromDisk;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -685,7 +688,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         // test to make sure the canonical form has been preserved
         final Bag<T> bag = makeObject();
         if (bag instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
-            final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(bag));
+            final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(bag, this));
             assertTrue("Bag is empty", bag2.isEmpty());
             assertEquals(bag, bag2);
         }
@@ -700,7 +703,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         // test to make sure the canonical form has been preserved
         final Bag<T> bag = makeFullCollection();
         if (bag instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
-            final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalFullCollectionName(bag));
+            final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalFullCollectionName(bag, this));
             assertEquals("Bag is the right size", bag.size(), bag2.size());
             assertEquals(bag, bag2);
         }

--- a/src/test/java/org/apache/commons/collections4/bag/CollectionBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/CollectionBagTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalEmptyCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalFullCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.readExternalFormFromDisk;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -95,7 +99,7 @@ public class CollectionBagTest<T> extends AbstractCollectionTest<T> {
         // test to make sure the canonical form has been preserved
         final Bag<T> bag = makeObject();
         if (bag instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
-            final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(bag));
+            final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(bag, this));
             assertTrue("Bag is empty", bag2.isEmpty());
             assertEquals(bag, bag2);
         }
@@ -110,7 +114,7 @@ public class CollectionBagTest<T> extends AbstractCollectionTest<T> {
         // test to make sure the canonical form has been preserved
         final Bag<T> bag = (Bag<T>) makeFullCollection();
         if (bag instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
-            final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalFullCollectionName(bag));
+            final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalFullCollectionName(bag, this));
             assertEquals("Bag is the right size", bag.size(), bag2.size());
             assertEquals(bag, bag2);
         }

--- a/src/test/java/org/apache/commons/collections4/bag/CollectionSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/CollectionSortedBagTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalEmptyCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalFullCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.readExternalFormFromDisk;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -133,7 +137,7 @@ public class CollectionSortedBagTest<T> extends AbstractCollectionTest<T> {
         // test to make sure the canonical form has been preserved
         final Bag<T> bag = makeObject();
         if (bag instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
-            final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(bag));
+            final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(bag, this));
             assertEquals("Bag is empty", 0, bag2.size());
             assertEquals(bag, bag2);
         }
@@ -148,7 +152,7 @@ public class CollectionSortedBagTest<T> extends AbstractCollectionTest<T> {
         // test to make sure the canonical form has been preserved
         final SortedBag<T> bag = (SortedBag<T>) makeFullCollection();
         if (bag instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
-            final SortedBag<?> bag2 = (SortedBag<?>) readExternalFormFromDisk(getCanonicalFullCollectionName(bag));
+            final SortedBag<?> bag2 = (SortedBag<?>) readExternalFormFromDisk(getCanonicalFullCollectionName(bag, this));
             assertEquals("Bag is the right size", bag.size(), bag2.size());
             assertEquals(bag, bag2);
         }

--- a/src/test/java/org/apache/commons/collections4/comparators/AbstractComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/AbstractComparatorTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.comparators;
 
+import static org.apache.commons.collections4.AbstractObjectTestUtils.readExternalFormFromDisk;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.writeExternalFormToDisk;
+import static org.apache.commons.collections4.BulkTestConstants.TEST_DATA_PATH;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorIterableTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorIterableTest.java
@@ -16,26 +16,20 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.commons.collections4.BulkTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for IteratorIterable.
- *
  */
-public class IteratorIterableTest extends BulkTest {
-
-    public static junit.framework.Test suite() {
-        return BulkTest.makeSuite(IteratorIterableTest.class);
-    }
-
-    public IteratorIterableTest(final String name) {
-        super(name);
-    }
+public class IteratorIterableTest {
 
     private Iterator<Integer> createIterator() {
         final List<Integer> list = new ArrayList<>();
@@ -82,5 +76,5 @@ public class IteratorIterableTest extends BulkTest {
         }
         assertTrue(expected > 0);
     }
-}
 
+}

--- a/src/test/java/org/apache/commons/collections4/list/AbstractListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/AbstractListTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections4.list;
 
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalEmptyCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalFullCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.readExternalFormFromBytes;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.readExternalFormFromDisk;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.writeExternalFormToBytes;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -942,7 +947,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         final List<E> list = makeObject();
         if (list instanceof Serializable && !skipSerializedCanonicalTests()
                 && isTestSerialization()) {
-            final List<E> list2 = (List<E>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(list));
+            final List<E> list2 = (List<E>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(list, this));
             assertEquals("List is empty", 0, list2.size());
             assertEquals(list, list2);
         }
@@ -966,7 +971,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         // test to make sure the canonical form has been preserved
         final List<E> list = makeFullCollection();
         if (list instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
-            final List<E> list2 = (List<E>) readExternalFormFromDisk(getCanonicalFullCollectionName(list));
+            final List<E> list2 = (List<E>) readExternalFormFromDisk(getCanonicalFullCollectionName(list, this));
             if (list2.size() == 4) {
                 // old serialized tests
                 return;

--- a/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalEmptyCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalFullCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.readExternalFormFromDisk;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.Serializable;
@@ -758,7 +761,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         final Map<K, V> map = makeObject();
         if (map instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             @SuppressWarnings("unchecked")
-            final Map<K, V> map2 = (Map<K, V>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(map));
+            final Map<K, V> map2 = (Map<K, V>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(map, this));
             assertEquals("Map is empty", 0, map2.size());
         }
     }
@@ -781,7 +784,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         final Map<K, V> map = makeFullMap();
         if (map instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             @SuppressWarnings("unchecked")
-            final Map<K, V> map2 = (Map<K, V>) readExternalFormFromDisk(getCanonicalFullCollectionName(map));
+            final Map<K, V> map2 = (Map<K, V>) readExternalFormFromDisk(getCanonicalFullCollectionName(map, this));
             assertEquals("Map is the right size", getSampleKeys().length, map2.size());
         }
     }

--- a/src/test/java/org/apache/commons/collections4/map/MultiValueMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/MultiValueMapTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalEmptyCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalFullCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.readExternalFormFromDisk;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayInputStream;
@@ -477,14 +480,14 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
     @Test
     public void testEmptyMapCompatibility() throws Exception {
         final Map<?, ?> map = makeEmptyMap();
-        final Map<?, ?> map2 = (Map<?, ?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(map));
+        final Map<?, ?> map2 = (Map<?, ?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(map, this));
         assertEquals("Map is empty", 0, map2.size());
     }
 
     @Test
     public void testFullMapCompatibility() throws Exception {
         final Map<?, ?> map = (Map<?, ?>) makeObject();
-        final Map<?, ?> map2 = (Map<?, ?>) readExternalFormFromDisk(getCanonicalFullCollectionName(map));
+        final Map<?, ?> map2 = (Map<?, ?>) readExternalFormFromDisk(getCanonicalFullCollectionName(map, this));
         assertEquals("Map is the right size", map.size(), map2.size());
         for (final Object key : map.keySet()) {
             assertEquals( "Map had inequal elements", map.get(key), map2.get(key) );

--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.multimap;
 
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalEmptyCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalFullCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.readExternalFormFromDisk;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
@@ -852,7 +855,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
     public void testEmptyMapCompatibility() throws Exception {
         final MultiValuedMap<?, ?> map = makeObject();
         final MultiValuedMap<?, ?> map2 =
-                (MultiValuedMap<?, ?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(map));
+                (MultiValuedMap<?, ?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(map, this));
         assertEquals("Map is empty", 0, map2.size());
     }
 
@@ -861,7 +864,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
     public void testFullMapCompatibility() throws Exception {
         final MultiValuedMap map = makeFullMap();
         final MultiValuedMap map2 =
-                (MultiValuedMap) readExternalFormFromDisk(getCanonicalFullCollectionName(map));
+                (MultiValuedMap) readExternalFormFromDisk(getCanonicalFullCollectionName(map, this));
         assertEquals("Map is the right size", map.size(), map2.size());
         for (final Object key : map.keySet()) {
             assertTrue("Map had inequal elements",

--- a/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.multiset;
 
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalEmptyCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalFullCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.readExternalFormFromDisk;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -699,7 +702,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         // test to make sure the canonical form has been preserved
         final MultiSet<T> multiset = makeObject();
         if (multiset instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
-            final MultiSet<?> multiset2 = (MultiSet<?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(multiset));
+            final MultiSet<?> multiset2 = (MultiSet<?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(multiset, this));
             assertTrue("MultiSet is empty", multiset2.isEmpty());
             assertEquals(multiset, multiset2);
         }
@@ -714,7 +717,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         // test to make sure the canonical form has been preserved
         final MultiSet<T> multiset = makeFullCollection();
         if (multiset instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
-            final MultiSet<?> multiset2 = (MultiSet<?>) readExternalFormFromDisk(getCanonicalFullCollectionName(multiset));
+            final MultiSet<?> multiset2 = (MultiSet<?>) readExternalFormFromDisk(getCanonicalFullCollectionName(multiset, this));
             assertEquals("MultiSet is the right size", multiset.size(), multiset2.size());
             assertEquals(multiset, multiset2);
         }

--- a/src/test/java/org/apache/commons/collections4/properties/AbstractPropertiesFactoryTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/AbstractPropertiesFactoryTest.java
@@ -16,13 +16,14 @@
  */
 package org.apache.commons.collections4.properties;
 
+import static org.apache.commons.collections4.BulkTestConstants.TEST_PROPERTIES_PATH;
+
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Properties;
 
-import org.apache.commons.collections4.BulkTest;
 import org.junit.Assume;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
@@ -46,7 +47,7 @@ public abstract class AbstractPropertiesFactoryTest<T extends Properties> {
     protected AbstractPropertiesFactoryTest(final AbstractPropertiesFactory<T> factory, final String fileExtension) {
         this.factory = factory;
         this.fileExtension = fileExtension;
-        this.pathString = BulkTest.TEST_PROPERTIES_PATH + "test" + fileExtension;
+        this.pathString = TEST_PROPERTIES_PATH + "test" + fileExtension;
     }
 
     private void assertContents(final T properties) {

--- a/src/test/java/org/apache/commons/collections4/queue/AbstractQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/AbstractQueueTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections4.queue;
 
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalEmptyCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.getCanonicalFullCollectionName;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.readExternalFormFromBytes;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.readExternalFormFromDisk;
+import static org.apache.commons.collections4.AbstractObjectTestUtils.writeExternalFormToBytes;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -339,7 +344,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
         final Queue<E> queue = makeObject();
         if (queue instanceof Serializable && !skipSerializedCanonicalTests()
                 && isTestSerialization()) {
-            final Queue<E> queue2 = (Queue<E>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(queue));
+            final Queue<E> queue2 = (Queue<E>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(queue, this));
             assertEquals("Queue is empty", 0, queue2.size());
         }
     }
@@ -362,7 +367,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
         // test to make sure the canonical form has been preserved
         final Queue<E> queue = makeFullCollection();
         if (queue instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
-            final Queue<E> queue2 = (Queue<E>) readExternalFormFromDisk(getCanonicalFullCollectionName(queue));
+            final Queue<E> queue2 = (Queue<E>) readExternalFormFromDisk(getCanonicalFullCollectionName(queue, this));
             assertEquals("Queues are not the right size", queue.size(), queue2.size());
         }
     }

--- a/src/test/java/org/apache/commons/collections4/queue/SynchronizedQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/SynchronizedQueueTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.queue;
 
+import static org.apache.commons.collections4.AbstractObjectTestUtils.writeExternalFormToDisk;
+import static org.apache.commons.collections4.BulkTestConstants.TEST_DATA_PATH;
+
 import java.util.LinkedList;
 import java.util.Queue;
 
@@ -55,10 +58,10 @@ public class SynchronizedQueueTest<T> extends AbstractQueueTest<T> {
     public void testCreate() throws Exception {
         Queue<T> queue = makeObject();
         writeExternalFormToDisk((java.io.Serializable) queue,
-            BulkTest.TEST_DATA_PATH + "SynchronizedQueue.emptyCollection.version4.2.obj");
+            TEST_DATA_PATH + "SynchronizedQueue.emptyCollection.version4.2.obj");
         queue = makeFullCollection();
         writeExternalFormToDisk((java.io.Serializable) queue,
-            BulkTest.TEST_DATA_PATH + "SynchronizedQueue.fullCollection.version4.2.obj");
+            TEST_DATA_PATH + "SynchronizedQueue.fullCollection.version4.2.obj");
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/splitmap/TransformedSplitMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/splitmap/TransformedSplitMapTest.java
@@ -16,17 +16,22 @@
  */
 package org.apache.commons.collections4.splitmap;
 
+import static org.apache.commons.collections4.BulkTestConstants.TEST_DATA_PATH;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.math.BigInteger;
 import java.util.HashMap;
 
-import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.functors.NOPTransformer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link TransformedSplitMap}
@@ -34,7 +39,7 @@ import org.junit.Test;
  * @since 4.0
  */
 @SuppressWarnings("boxing")
-public class TransformedSplitMapTest extends BulkTest {
+public class TransformedSplitMapTest {
 
     private final Transformer<Integer, String> intToString = String::valueOf;
 
@@ -42,11 +47,8 @@ public class TransformedSplitMapTest extends BulkTest {
 
     private final Transformer<String, Integer> stringToInt = Integer::valueOf;
 
-    public TransformedSplitMapTest(final String testName) {
-        super(testName);
-    }
-
     // -----------------------------------------------------------------------
+
     @Test
     public void testTransformedMap() {
         final TransformedSplitMap<Integer, String, Object, Class<?>> map = TransformedSplitMap.transformingMap(
@@ -117,12 +119,12 @@ public class TransformedSplitMapTest extends BulkTest {
                                                     NOPTransformer.<String>nopTransformer() );
 
         final ObjectInputStream in =
-                new ObjectInputStream( new FileInputStream( TEST_DATA_PATH+"/TransformedSplitMap.emptyCollection.version4.obj" ) );
+                new ObjectInputStream( new FileInputStream( TEST_DATA_PATH + "/TransformedSplitMap.emptyCollection.version4.obj" ) );
         final Object readObject = in.readObject();
         in.close();
 
         final TransformedSplitMap<?, ?, ?, ?> readMap = (TransformedSplitMap<?, ?, ?, ?>) readObject;
-        assertTrue( "Map should be empty", readMap.isEmpty() );
+        assertTrue( readMap.isEmpty(), "Map should be empty" );
         assertEquals( map.entrySet(), readMap.entrySet() );
     }
 
@@ -143,7 +145,7 @@ public class TransformedSplitMapTest extends BulkTest {
         in.close();
 
         final TransformedSplitMap<?, ?, ?, ?> readMap = (TransformedSplitMap<?, ?, ?, ?>) readObject;
-        assertFalse( "Map should not be empty", readMap.isEmpty() );
+        assertFalse( readMap.isEmpty(), "Map should not be empty");
         assertEquals( map.entrySet(), readMap.entrySet() );
     }
 
@@ -166,4 +168,5 @@ public class TransformedSplitMapTest extends BulkTest {
 //                new FileOutputStream( "src/test/resources/data/test/TransformedSplitMap.fullCollection.version4.obj" ) );
 //        out.writeObject( map );
 //    }
+
 }


### PR DESCRIPTION
Break Inherifance need for BulkTest constants

TransformedSplitMapTest break inheritance of BulkTest

IteratorIterableTest break inheritance of BulkTest

Break Inheritance need for AbstractObjectTest

Trying to reduce requirement for methods via inheritance, so breaking out common static or helper methods.