### PR TITLE
COLLECTIONS-807: Upgraded org.junit.Test to org.junit.jupiter.api.Test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,6 +489,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${commons.junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <version>2.2</version>

--- a/src/test/java/org/apache/commons/collections4/AbstractArrayListTest.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractArrayListTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.ArrayList;
 
 import org.apache.commons.collections4.list.AbstractListTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for ArrayList.

--- a/src/test/java/org/apache/commons/collections4/AbstractLinkedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractLinkedListTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.list.AbstractListTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests base {@link java.util.LinkedList} methods and contracts.

--- a/src/test/java/org/apache/commons/collections4/AbstractObjectTest.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractObjectTest.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.collections4;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/org/apache/commons/collections4/AbstractTreeMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractTreeMapTest.java
@@ -19,7 +19,7 @@ package org.apache.commons.collections4;
 import java.util.TreeMap;
 
 import org.apache.commons.collections4.map.AbstractMapTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests TreeMap.

--- a/src/test/java/org/apache/commons/collections4/ArrayStackTest.java
+++ b/src/test/java/org/apache/commons/collections4/ArrayStackTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.EmptyStackException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests ArrayStack.
@@ -28,8 +28,8 @@ import org.junit.Test;
 @SuppressWarnings("deprecation") // we test a deprecated class
 public class ArrayStackTest<E> extends AbstractArrayListTest<E> {
 
-    public ArrayStackTest(final String testName) {
-        super(testName);
+    public ArrayStackTest() {
+        super(ArrayStackTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/BulkTest.java
+++ b/src/test/java/org/apache/commons/collections4/BulkTest.java
@@ -414,16 +414,16 @@ class BulkTestSuiteMaker {
 
     private static <T> Constructor<T> getTestCaseConstructor(final Class<T> c) {
         try {
-            return c.getConstructor(String.class);
+            return c.getConstructor();
         } catch (final NoSuchMethodException e) {
-            throw new IllegalArgumentException(c + " must provide a (String) constructor");
+            throw new IllegalArgumentException(c + " must provide an empty constructor");
         }
     }
 
     private static <T extends BulkTest> BulkTest makeTestCase(final Class<T> c, final Method m) {
         final Constructor<T> con = getTestCaseConstructor(c);
         try {
-            return con.newInstance(m.getName());
+            return con.newInstance();
         } catch (final InvocationTargetException e) {
             e.printStackTrace();
             throw new RuntimeException(); // FIXME;

--- a/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
@@ -32,7 +32,7 @@ import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.set.AbstractSetTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/org/apache/commons/collections4/bag/CollectionBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/CollectionBagTest.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@link CollectionBag}.
@@ -38,11 +38,9 @@ public class CollectionBagTest<T> extends AbstractCollectionTest<T> {
 
     /**
      * JUnit constructor.
-     *
-     * @param testName  the test class name
      */
-    public CollectionBagTest(final String testName) {
-        super(testName);
+    public CollectionBagTest() {
+        super(CollectionBagTest.class.getSimpleName());
     }
 
 

--- a/src/test/java/org/apache/commons/collections4/bag/CollectionSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/CollectionSortedBagTest.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.SortedBag;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@link CollectionSortedBag}.
@@ -39,11 +39,9 @@ public class CollectionSortedBagTest<T> extends AbstractCollectionTest<T> {
 
     /**
      * JUnit constructor.
-     *
-     * @param testName  the test class name
      */
-    public CollectionSortedBagTest(final String testName) {
-        super(testName);
+    public CollectionSortedBagTest() {
+        super(CollectionSortedBagTest.class.getSimpleName());
     }
 
 

--- a/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
@@ -26,8 +26,8 @@ import org.apache.commons.collections4.BulkTest;
  */
 public class HashBagTest<T> extends AbstractBagTest<T> {
 
-    public HashBagTest(final String testName) {
-        super(testName);
+    public HashBagTest() {
+        super(HashBagTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/bag/PredicatedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/PredicatedBagTest.java
@@ -24,7 +24,7 @@ import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractBagTest} for exercising the {@link PredicatedBag}
@@ -34,8 +34,8 @@ import org.junit.Test;
  */
 public class PredicatedBagTest<T> extends AbstractBagTest<T> {
 
-    public PredicatedBagTest(final String testName) {
-        super(testName);
+    public PredicatedBagTest() {
+        super(PredicatedBagTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/bag/PredicatedSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/PredicatedSortedBagTest.java
@@ -24,7 +24,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.SortedBag;
 import org.apache.commons.collections4.functors.TruePredicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSortedBagTest} for exercising the {@link PredicatedSortedBag}
@@ -36,8 +36,8 @@ public class PredicatedSortedBagTest<T> extends AbstractSortedBagTest<T> {
 
     private final SortedBag<T> nullBag = null;
 
-    public PredicatedSortedBagTest(final String testName) {
-        super(testName);
+    public PredicatedSortedBagTest() {
+        super(PredicatedSortedBagTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/bag/SynchronizedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/SynchronizedBagTest.java
@@ -27,8 +27,8 @@ import org.apache.commons.collections4.BulkTest;
  */
 public class SynchronizedBagTest<T> extends AbstractBagTest<T> {
 
-    public SynchronizedBagTest(final String testName) {
-        super(testName);
+    public SynchronizedBagTest() {
+        super(SynchronizedBagTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/bag/TransformedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/TransformedBagTest.java
@@ -20,7 +20,7 @@ import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractBagTest} for exercising the {@link TransformedBag}
@@ -30,8 +30,8 @@ import org.junit.Test;
  */
 public class TransformedBagTest<T> extends AbstractBagTest<T> {
 
-    public TransformedBagTest(final String testName) {
-        super(testName);
+    public TransformedBagTest() {
+        super(TransformedBagTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/bag/TransformedSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/TransformedSortedBagTest.java
@@ -20,7 +20,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.SortedBag;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSortedBagTest} for exercising the {@link TransformedSortedBag}
@@ -30,8 +30,8 @@ import org.junit.Test;
  */
 public class TransformedSortedBagTest<T> extends AbstractSortedBagTest<T> {
 
-    public TransformedSortedBagTest(final String testName) {
-        super(testName);
+    public TransformedSortedBagTest() {
+        super(TransformedSortedBagTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/bag/TreeBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/TreeBagTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.SortedBag;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractBagTest} for exercising the {@link TreeBag}
@@ -29,8 +29,8 @@ import org.junit.Test;
  */
 public class TreeBagTest<T> extends AbstractSortedBagTest<T> {
 
-    public TreeBagTest(final String testName) {
-        super(testName);
+    public TreeBagTest() {
+        super(TreeBagTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/bag/UnmodifiableBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/UnmodifiableBagTest.java
@@ -24,7 +24,7 @@ import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -34,8 +34,8 @@ import org.junit.Test;
  */
 public class UnmodifiableBagTest<E> extends AbstractBagTest<E> {
 
-    public UnmodifiableBagTest(final String testName) {
-        super(testName);
+    public UnmodifiableBagTest() {
+        super(UnmodifiableBagTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/bag/UnmodifiableSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/UnmodifiableSortedBagTest.java
@@ -24,7 +24,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.SortedBag;
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -34,8 +34,8 @@ import org.junit.Test;
  */
 public class UnmodifiableSortedBagTest<E> extends AbstractSortedBagTest<E> {
 
-    public UnmodifiableSortedBagTest(final String testName) {
-        super(testName);
+    public UnmodifiableSortedBagTest() {
+        super(UnmodifiableSortedBagTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractBidiMapTest.java
@@ -29,7 +29,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.iterators.AbstractMapIteratorTest;
 import org.apache.commons.collections4.map.AbstractIterableMapTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link BidiMap} methods and contracts.

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapTest.java
@@ -29,7 +29,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.OrderedBidiMap;
 import org.apache.commons.collections4.iterators.AbstractMapIteratorTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link OrderedBidiMap} methods and contracts.

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractSortedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractSortedBidiMapTest.java
@@ -30,7 +30,7 @@ import java.util.TreeSet;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.SortedBidiMap;
 import org.apache.commons.collections4.map.AbstractSortedMapTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link SortedBidiMap} methods and contracts.

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualHashBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualHashBidiMapTest.java
@@ -27,8 +27,8 @@ public class DualHashBidiMapTest<K, V> extends AbstractBidiMapTest<K, V> {
         return BulkTest.makeSuite(DualHashBidiMapTest.class);
     }
 
-    public DualHashBidiMapTest(final String testName) {
-        super(testName);
+    public DualHashBidiMapTest() {
+        super(DualHashBidiMapTest.class.getSimpleName());
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualLinkedHashBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualLinkedHashBidiMapTest.java
@@ -28,8 +28,8 @@ public class DualLinkedHashBidiMapTest<K, V> extends AbstractBidiMapTest<K, V> {
         return BulkTest.makeSuite(DualLinkedHashBidiMapTest.class);
     }
 
-    public DualLinkedHashBidiMapTest(final String testName) {
-        super(testName);
+    public DualLinkedHashBidiMapTest() {
+        super(DualLinkedHashBidiMapTest.class.getSimpleName());
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap2Test.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap2Test.java
@@ -31,7 +31,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.SortedBidiMap;
 import org.apache.commons.collections4.comparators.ComparableComparator;
 import org.apache.commons.collections4.comparators.ReverseComparator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests.
@@ -44,8 +44,8 @@ public class DualTreeBidiMap2Test<K extends Comparable<K>, V extends Comparable<
         return BulkTest.makeSuite(DualTreeBidiMap2Test.class);
     }
 
-    public DualTreeBidiMap2Test(final String testName) {
-        super(testName);
+    public DualTreeBidiMap2Test() {
+        super(DualTreeBidiMap2Test.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMapTest.java
@@ -28,8 +28,8 @@ public class DualTreeBidiMapTest<K extends Comparable<K>, V extends Comparable<V
         return BulkTest.makeSuite(DualTreeBidiMapTest.class);
     }
 
-    public DualTreeBidiMapTest(final String testName) {
-        super(testName);
+    public DualTreeBidiMapTest() {
+        super(DualTreeBidiMapTest.class.getSimpleName());
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/bidimap/TreeBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/TreeBidiMapTest.java
@@ -31,8 +31,8 @@ public class TreeBidiMapTest<K extends Comparable<K>, V extends Comparable<V>> e
         return BulkTest.makeSuite(TreeBidiMapTest.class);
     }
 
-    public TreeBidiMapTest(final String testName) {
-        super(testName);
+    public TreeBidiMapTest() {
+        super(TreeBidiMapTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableBidiMapTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import org.apache.commons.collections4.BidiMap;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Unmodifiable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests.
@@ -35,8 +35,8 @@ public class UnmodifiableBidiMapTest<K, V> extends AbstractBidiMapTest<K, V> {
         return BulkTest.makeSuite(UnmodifiableBidiMapTest.class);
     }
 
-    public UnmodifiableBidiMapTest(final String testName) {
-        super(testName);
+    public UnmodifiableBidiMapTest() {
+        super(UnmodifiableBidiMapTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableOrderedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableOrderedBidiMapTest.java
@@ -24,7 +24,7 @@ import java.util.TreeMap;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.OrderedBidiMap;
 import org.apache.commons.collections4.Unmodifiable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests.
@@ -35,8 +35,8 @@ public class UnmodifiableOrderedBidiMapTest<K extends Comparable<K>, V extends C
         return BulkTest.makeSuite(UnmodifiableOrderedBidiMapTest.class);
     }
 
-    public UnmodifiableOrderedBidiMapTest(final String testName) {
-        super(testName);
+    public UnmodifiableOrderedBidiMapTest() {
+        super(UnmodifiableOrderedBidiMapTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableSortedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableSortedBidiMapTest.java
@@ -24,7 +24,7 @@ import java.util.TreeMap;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.SortedBidiMap;
 import org.apache.commons.collections4.Unmodifiable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests.
@@ -35,8 +35,8 @@ public class UnmodifiableSortedBidiMapTest<K extends Comparable<K>, V extends Co
         return BulkTest.makeSuite(UnmodifiableSortedBidiMapTest.class);
     }
 
-    public UnmodifiableSortedBidiMapTest(final String testName) {
-        super(testName);
+    public UnmodifiableSortedBidiMapTest() {
+        super(UnmodifiableSortedBidiMapTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.apache.commons.collections4.AbstractObjectTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link java.util.Collection} methods and contracts.

--- a/src/test/java/org/apache/commons/collections4/collection/CompositeCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/CompositeCollectionTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -43,8 +43,8 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
 
     protected Collection<E> two;
 
-    public CompositeCollectionTest(final String name) {
-        super(name);
+    public CompositeCollectionTest() {
+        super(CompositeCollectionTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
@@ -25,7 +25,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import org.apache.commons.collections4.Transformer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -36,8 +36,8 @@ import org.junit.Test;
 @SuppressWarnings("boxing")
 public class IndexedCollectionTest extends AbstractCollectionTest<String> {
 
-    public IndexedCollectionTest(final String name) {
-        super(name);
+    public IndexedCollectionTest() {
+        super(IndexedCollectionTest.class.getSimpleName());
     }
 
    //------------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/collections4/collection/PredicatedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/PredicatedCollectionTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -35,8 +35,8 @@ import org.junit.Test;
  */
 public class PredicatedCollectionTest<E> extends AbstractCollectionTest<E> {
 
-    public PredicatedCollectionTest(final String name) {
-        super(name);
+    public PredicatedCollectionTest() {
+        super(PredicatedCollectionTest.class.getSimpleName());
     }
 
    //------------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/collections4/collection/SynchronizedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/SynchronizedCollectionTest.java
@@ -28,8 +28,8 @@ import java.util.Collection;
  */
 public class SynchronizedCollectionTest<E> extends AbstractCollectionTest<E> {
 
-    public SynchronizedCollectionTest(final String testName) {
-        super(testName);
+    public SynchronizedCollectionTest() {
+        super(SynchronizedCollectionTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/collection/TransformedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/TransformedCollectionTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the {@link TransformedCollection}
@@ -52,8 +52,8 @@ public class TransformedCollectionTest extends AbstractCollectionTest<Object> {
     public static final Transformer<Object, Object> STRING_TO_INTEGER_TRANSFORMER = new StringToInteger();
     public static final Transformer<Object, Object> TO_LOWER_CASE_TRANSFORMER = new ToLowerCase();
 
-    public TransformedCollectionTest(final String testName) {
-        super(testName);
+    public TransformedCollectionTest() {
+        super(TransformedCollectionTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/collection/UnmodifiableBoundedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/UnmodifiableBoundedCollectionTest.java
@@ -25,7 +25,7 @@ import java.util.Collection;
 import org.apache.commons.collections4.BoundedCollection;
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.list.FixedSizeList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -33,8 +33,8 @@ import org.junit.Test;
  */
 public class UnmodifiableBoundedCollectionTest<E> extends AbstractCollectionTest<E> {
 
-    public UnmodifiableBoundedCollectionTest(final String testName) {
-        super(testName);
+    public UnmodifiableBoundedCollectionTest() {
+        super(UnmodifiableBoundedCollectionTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/collection/UnmodifiableCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/UnmodifiableCollectionTest.java
@@ -24,7 +24,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.collections4.Unmodifiable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -34,8 +34,8 @@ import org.junit.Test;
  */
 public class UnmodifiableCollectionTest<E> extends AbstractCollectionTest<E> {
 
-    public UnmodifiableCollectionTest(final String testName) {
-        super(testName);
+    public UnmodifiableCollectionTest() {
+        super(UnmodifiableCollectionTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/comparators/AbstractComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/AbstractComparatorTest.java
@@ -25,7 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.apache.commons.collections4.AbstractObjectTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for testing the Comparator interface.

--- a/src/test/java/org/apache/commons/collections4/comparators/BooleanComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/BooleanComparatorTest.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -36,8 +36,8 @@ public class BooleanComparatorTest extends AbstractComparatorTest<Boolean> {
     // conventional
     // ------------------------------------------------------------------------
 
-    public BooleanComparatorTest(final String testName) {
-        super(testName);
+    public BooleanComparatorTest() {
+        super(BooleanComparatorTest.class.getSimpleName());
     }
 
     // collections testing framework

--- a/src/test/java/org/apache/commons/collections4/comparators/ComparableComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/ComparableComparatorTest.java
@@ -28,8 +28,8 @@ import java.util.List;
 @SuppressWarnings("boxing")
 public class ComparableComparatorTest extends AbstractComparatorTest<Integer> {
 
-    public ComparableComparatorTest(final String testName) {
-        super(testName);
+    public ComparableComparatorTest() {
+        super(ComparableComparatorTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/comparators/ComparatorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/ComparatorChainTest.java
@@ -24,15 +24,15 @@ import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for ComparatorChain.
  */
 public class ComparatorChainTest extends AbstractComparatorTest<ComparatorChainTest.PseudoRow> {
 
-    public ComparatorChainTest(final String testName) {
-        super(testName);
+    public ComparatorChainTest() {
+        super(ComparatorChainTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/comparators/FixedOrderComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/FixedOrderComparatorTest.java
@@ -24,7 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for FixedOrderComparator.
@@ -51,8 +51,8 @@ public class FixedOrderComparatorTest extends AbstractComparatorTest<String> {
     // Initialization and busywork
     //
 
-    public FixedOrderComparatorTest(final String name) {
-        super(name);
+    public FixedOrderComparatorTest() {
+        super(FixedOrderComparatorTest.class.getSimpleName());
     }
 
     //

--- a/src/test/java/org/apache/commons/collections4/comparators/ReverseComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/ReverseComparatorTest.java
@@ -25,7 +25,7 @@ import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for ReverseComparator.
@@ -33,8 +33,8 @@ import org.junit.Test;
  */
 public class ReverseComparatorTest extends AbstractComparatorTest<Integer> {
 
-    public ReverseComparatorTest(final String testName) {
-        super(testName);
+    public ReverseComparatorTest() {
+        super(ReverseComparatorTest.class.getSimpleName());
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/comparators/TransformingComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/TransformingComparatorTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import org.apache.commons.collections4.ComparatorUtils;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for TransformingComparator.
@@ -35,8 +35,8 @@ public class TransformingComparatorTest extends AbstractComparatorTest<Integer> 
     // Initialization and busywork
     //
 
-    public TransformingComparatorTest(final String name) {
-        super(name);
+    public TransformingComparatorTest() {
+        super(TransformingComparatorTest.class.getSimpleName());
     }
 
     //

--- a/src/test/java/org/apache/commons/collections4/functors/ComparatorPredicateTest.java
+++ b/src/test/java/org/apache/commons/collections4/functors/ComparatorPredicateTest.java
@@ -21,7 +21,7 @@ import static org.apache.commons.collections4.functors.ComparatorPredicate.*;
 import java.util.Comparator;
 
 import org.apache.commons.collections4.Predicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
 public class ComparatorPredicateTest extends AbstractPredicateTest {

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractIteratorTest.java
@@ -22,7 +22,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.AbstractObjectTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract class for testing the Iterator interface.

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractListIteratorTest.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract class for testing the ListIterator interface.

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractMapIteratorTest.java
@@ -24,7 +24,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 import org.apache.commons.collections4.MapIterator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract class for testing the MapIterator interface.

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractOrderedMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractOrderedMapIteratorTest.java
@@ -27,7 +27,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 import org.apache.commons.collections4.OrderedMapIterator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract class for testing the OrderedMapIterator interface.

--- a/src/test/java/org/apache/commons/collections4/iterators/ArrayIterator2Test.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ArrayIterator2Test.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the ArrayIterator with primitive type arrays.
@@ -31,8 +31,8 @@ public class ArrayIterator2Test<E> extends AbstractIteratorTest<E> {
 
     protected int[] testArray = { 2, 4, 6, 8 };
 
-    public ArrayIterator2Test(final String testName) {
-        super(testName);
+    public ArrayIterator2Test() {
+        super(ArrayIterator2Test.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/iterators/ArrayIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ArrayIteratorTest.java
@@ -19,7 +19,7 @@ package org.apache.commons.collections4.iterators;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -32,8 +32,8 @@ public class ArrayIteratorTest<E> extends AbstractIteratorTest<E> {
 
     protected String[] testArray = { "One", "Two", "Three" };
 
-    public ArrayIteratorTest(final String testName) {
-        super(testName);
+    public ArrayIteratorTest() {
+        super(ArrayIteratorTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/iterators/ArrayListIterator2Test.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ArrayListIterator2Test.java
@@ -22,8 +22,8 @@ package org.apache.commons.collections4.iterators;
  */
 public class ArrayListIterator2Test<E> extends ArrayIterator2Test<E> {
 
-    public ArrayListIterator2Test(final String testName) {
-        super(testName);
+    public ArrayListIterator2Test() {
+        super();
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/iterators/ArrayListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ArrayListIteratorTest.java
@@ -19,7 +19,7 @@ package org.apache.commons.collections4.iterators;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -29,8 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 public class ArrayListIteratorTest<E> extends ArrayIteratorTest<E> {
 
-    public ArrayListIteratorTest(final String testName) {
-        super(testName);
+    public ArrayListIteratorTest() {
+        super();
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/iterators/BoundedIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/BoundedIteratorTest.java
@@ -29,7 +29,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * A unit test to test the basic functions of {@link BoundedIterator}.
@@ -43,12 +44,12 @@ public class BoundedIteratorTest<E> extends AbstractIteratorTest<E> {
 
     private List<E> testList;
 
-    public BoundedIteratorTest(final String testName) {
-        super(testName);
+    public BoundedIteratorTest() {
+        super(BoundedIteratorTest.class.getSimpleName());
     }
 
     @SuppressWarnings("unchecked")
-    @Override
+    @BeforeEach
     public void setUp()
         throws Exception {
         super.setUp();

--- a/src/test/java/org/apache/commons/collections4/iterators/CollatingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/CollatingIteratorTest.java
@@ -22,7 +22,8 @@ import java.util.Comparator;
 import java.util.List;
 
 import org.apache.commons.collections4.comparators.ComparableComparator;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test suite for {@link CollatingIterator}.
@@ -33,8 +34,8 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
 
     //------------------------------------------------------------ Conventional
 
-    public CollatingIteratorTest(final String testName) {
-        super(testName);
+    public CollatingIteratorTest() {
+        super(CollatingIteratorTest.class.getSimpleName());
     }
 
     //--------------------------------------------------------------- Lifecycle
@@ -44,7 +45,7 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
     private ArrayList<Integer> odds = null;
     private ArrayList<Integer> fib = null;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         comparator = new ComparableComparator<>();

--- a/src/test/java/org/apache/commons/collections4/iterators/FilterIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/FilterIteratorTest.java
@@ -28,7 +28,8 @@ import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.NotNullPredicate;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the filter iterator.
@@ -36,8 +37,8 @@ import org.junit.Test;
 public class FilterIteratorTest<E> extends AbstractIteratorTest<E> {
 
     /** Creates new TestFilterIterator */
-    public FilterIteratorTest(final String name) {
-        super(name);
+    public FilterIteratorTest() {
+        super(FilterIteratorTest.class.getSimpleName());
     }
 
     private String[] array;
@@ -47,7 +48,7 @@ public class FilterIteratorTest<E> extends AbstractIteratorTest<E> {
     /**
      * Set up instance variables required by this test case.
      */
-    @Override
+    @BeforeEach
     public void setUp() {
         array = new String[] { "a", "b", "c" };
         initIterator();

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
@@ -26,7 +26,8 @@ import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.collections4.Predicate;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the IteratorChain class.
@@ -41,11 +42,11 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
     protected List<String> list2 = null;
     protected List<String> list3 = null;
 
-    public IteratorChainTest(final String testName) {
-        super(testName);
+    public IteratorChainTest() {
+        super(IteratorChainTest.class.getSimpleName());
     }
 
-    @Override
+    @BeforeEach
     public void setUp() {
         list1 = new ArrayList<>();
         list1.add("One");

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorIterableTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorIterableTest.java
@@ -21,7 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for IteratorIterable.
@@ -33,8 +33,8 @@ public class IteratorIterableTest extends BulkTest {
         return BulkTest.makeSuite(IteratorIterableTest.class);
     }
 
-    public IteratorIterableTest(final String name) {
-        super(name);
+    public IteratorIterableTest() {
+        super(IteratorIterableTest.class.getSimpleName());
     }
 
     private Iterator<Integer> createIterator() {

--- a/src/test/java/org/apache/commons/collections4/iterators/LazyIteratorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/LazyIteratorChainTest.java
@@ -26,7 +26,8 @@ import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.collections4.Predicate;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the LazyIteratorChain class.
@@ -41,11 +42,11 @@ public class LazyIteratorChainTest extends AbstractIteratorTest<String> {
     protected List<String> list2 = null;
     protected List<String> list3 = null;
 
-    public LazyIteratorChainTest(final String testName) {
-        super(testName);
+    public LazyIteratorChainTest() {
+        super(LazyIteratorChainTest.class.getSimpleName());
     }
 
-    @Override
+    @BeforeEach
     public void setUp() {
         list1 = new ArrayList<>();
         list1.add("One");

--- a/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapper2Test.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapper2Test.java
@@ -22,7 +22,8 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.ResettableListIterator;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -37,11 +38,11 @@ public class ListIteratorWrapper2Test<E> extends AbstractIteratorTest<E> {
 
     protected List<E> list1 = null;
 
-    public ListIteratorWrapper2Test(final String testName) {
-        super(testName);
+    public ListIteratorWrapper2Test() {
+        super(ListIteratorWrapper2Test.class.getSimpleName());
     }
 
-    @Override
+    @BeforeEach
     @SuppressWarnings("unchecked")
     public void setUp() {
         list1 = new ArrayList<>();

--- a/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapperTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapperTest.java
@@ -24,7 +24,8 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.ResettableListIterator;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the ListIteratorWrapper to insure that it simulates
@@ -38,11 +39,11 @@ public class ListIteratorWrapperTest<E> extends AbstractIteratorTest<E> {
 
     protected List<E> list1 = null;
 
-    public ListIteratorWrapperTest(final String testName) {
-        super(testName);
+    public ListIteratorWrapperTest() {
+        super(ListIteratorWrapperTest.class.getSimpleName());
     }
 
-    @Override
+    @BeforeEach
     @SuppressWarnings("unchecked")
     public void setUp() {
         list1 = new ArrayList<>();

--- a/src/test/java/org/apache/commons/collections4/iterators/NodeListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/NodeListIteratorTest.java
@@ -21,7 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Iterator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -40,14 +41,13 @@ public class NodeListIteratorTest extends AbstractIteratorTest<Node> {
     private boolean createIteratorWithStandardConstr = true;
 
     /**
-     * Constructor
-     * @param testName
+     * Junit Constructor
      */
-    public NodeListIteratorTest(final String testName) {
-        super(testName);
+    public NodeListIteratorTest() {
+        super(NodeListIteratorTest.class.getSimpleName());
     }
 
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         super.setUp();
 

--- a/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayIteratorTest.java
@@ -21,7 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the ObjectArrayIterator.
@@ -30,8 +30,8 @@ public class ObjectArrayIteratorTest<E> extends AbstractIteratorTest<E> {
 
     protected String[] testArray = { "One", "Two", "Three" };
 
-    public ObjectArrayIteratorTest(final String testName) {
-        super(testName);
+    public ObjectArrayIteratorTest() {
+        super(ObjectArrayIteratorTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayListIterator2Test.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayListIterator2Test.java
@@ -24,8 +24,8 @@ public class ObjectArrayListIterator2Test<E> extends AbstractListIteratorTest<E>
 
     protected String[] testArray = { "One", "Two", "Three" };
 
-    public ObjectArrayListIterator2Test(final String testName) {
-        super(testName);
+    public ObjectArrayListIterator2Test() {
+        super(ObjectArrayListIterator2Test.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayListIteratorTest.java
@@ -19,7 +19,7 @@ package org.apache.commons.collections4.iterators;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -29,8 +29,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 public class ObjectArrayListIteratorTest<E> extends ObjectArrayIteratorTest<E> {
 
-    public ObjectArrayListIteratorTest(final String testName) {
-        super(testName);
+    public ObjectArrayListIteratorTest() {
+        super();
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/iterators/ObjectGraphIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ObjectGraphIteratorTest.java
@@ -25,7 +25,8 @@ import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.collections4.Transformer;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Testcase.
@@ -39,11 +40,11 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
     protected List<String> list3 = null;
     protected List<Iterator<String>> iteratorList = null;
 
-    public ObjectGraphIteratorTest(final String testName) {
-        super(testName);
+    public ObjectGraphIteratorTest() {
+        super(ObjectGraphIteratorTest.class.getSimpleName());
     }
 
-    @Override
+    @BeforeEach
     public void setUp() {
         list1 = new ArrayList<>();
         list1.add("One");

--- a/src/test/java/org/apache/commons/collections4/iterators/PeekingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/PeekingIteratorTest.java
@@ -25,7 +25,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the PeekingIterator.
@@ -36,15 +37,15 @@ public class PeekingIteratorTest<E> extends AbstractIteratorTest<E> {
 
     private List<E> testList;
 
-    public PeekingIteratorTest(final String testName) {
-        super(testName);
+    public PeekingIteratorTest() {
+        super(PeekingIteratorTest.class.getSimpleName());
     }
 
     /**
      * {@inheritDoc}
      */
     @SuppressWarnings("unchecked")
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         super.setUp();
         testList = new ArrayList<>(Arrays.asList((E[]) testArray));

--- a/src/test/java/org/apache/commons/collections4/iterators/PermutationIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/PermutationIteratorTest.java
@@ -26,7 +26,8 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for PermutationIterator.
@@ -39,11 +40,11 @@ public class PermutationIteratorTest extends AbstractIteratorTest<List<Character
     protected Character[] testArray = { 'A', 'B', 'C' };
     protected List<Character> testList;
 
-    public PermutationIteratorTest(final String testName) {
-        super(testName);
+    public PermutationIteratorTest() {
+        super(PermutationIteratorTest.class.getSimpleName());
     }
 
-    @Override
+    @BeforeEach
     public void setUp() {
         testList = new ArrayList<>();
         testList.addAll(Arrays.asList(testArray));

--- a/src/test/java/org/apache/commons/collections4/iterators/PushbackIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/PushbackIteratorTest.java
@@ -22,7 +22,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the PushbackIterator.
@@ -34,15 +35,15 @@ public class PushbackIteratorTest<E> extends AbstractIteratorTest<E> {
 
     private List<E> testList;
 
-    public PushbackIteratorTest(final String testName) {
-        super(testName);
+    public PushbackIteratorTest() {
+        super(PushbackIteratorTest.class.getSimpleName());
     }
 
     /**
      * {@inheritDoc}
      */
     @SuppressWarnings("unchecked")
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         super.setUp();
         testList = new ArrayList<>(Arrays.asList((E[]) testArray));

--- a/src/test/java/org/apache/commons/collections4/iterators/ReverseListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ReverseListIteratorTest.java
@@ -26,7 +26,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.ResettableListIterator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the ReverseListIterator.
@@ -35,8 +35,8 @@ public class ReverseListIteratorTest<E> extends AbstractListIteratorTest<E> {
 
     protected String[] testArray = { "One", "Two", "Three", "Four" };
 
-    public ReverseListIteratorTest(final String testName) {
-        super(testName);
+    public ReverseListIteratorTest() {
+        super(ReverseListIteratorTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/iterators/SingletonIterator2Test.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/SingletonIterator2Test.java
@@ -20,7 +20,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.ResettableIterator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the SingletonIterator to ensure that the next() method will actually
@@ -31,8 +31,8 @@ public class SingletonIterator2Test<E> extends AbstractIteratorTest<E> {
 
     private static final Object testValue = "foo";
 
-    public SingletonIterator2Test(final String testName) {
-        super(testName);
+    public SingletonIterator2Test() {
+        super(SingletonIterator2Test.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/iterators/SingletonIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/SingletonIteratorTest.java
@@ -20,7 +20,7 @@ import java.util.Iterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.ResettableIterator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the SingletonIterator to ensure that the next() method will actually
@@ -31,8 +31,8 @@ public class SingletonIteratorTest<E> extends AbstractIteratorTest<E> {
 
     private static final Object testValue = "foo";
 
-    public SingletonIteratorTest(final String testName) {
-        super(testName);
+    public SingletonIteratorTest() {
+        super(SingletonIteratorTest.class.getSimpleName());
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/iterators/SingletonListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/SingletonListIteratorTest.java
@@ -20,7 +20,7 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.ResettableListIterator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the SingletonListIterator.
@@ -30,8 +30,8 @@ public class SingletonListIteratorTest<E> extends AbstractListIteratorTest<E> {
 
     private static final Object testValue = "foo";
 
-    public SingletonListIteratorTest(final String testName) {
-        super(testName);
+    public SingletonListIteratorTest() {
+        super(SingletonListIteratorTest.class.getSimpleName());
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/iterators/SkippingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/SkippingIteratorTest.java
@@ -25,7 +25,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * A unit test to test the basic functions of {@link SkippingIterator}.
@@ -39,12 +40,12 @@ public class SkippingIteratorTest<E> extends AbstractIteratorTest<E> {
 
     private List<E> testList;
 
-    public SkippingIteratorTest(final String testName) {
-        super(testName);
+    public SkippingIteratorTest() {
+        super(SkippingIteratorTest.class.getSimpleName());
     }
 
     @SuppressWarnings("unchecked")
-    @Override
+    @BeforeEach
     public void setUp()
         throws Exception {
         super.setUp();

--- a/src/test/java/org/apache/commons/collections4/iterators/UniqueFilterIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UniqueFilterIteratorTest.java
@@ -21,7 +21,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the UniqueFilterIterator class.
@@ -35,11 +36,11 @@ public class UniqueFilterIteratorTest<E> extends AbstractIteratorTest<E> {
 
     protected List<E> list1 = null;
 
-    public UniqueFilterIteratorTest(final String testName) {
-        super(testName);
+    public UniqueFilterIteratorTest() {
+        super(UniqueFilterIteratorTest.class.getSimpleName());
     }
 
-    @Override
+    @BeforeEach
     @SuppressWarnings("unchecked")
     public void setUp() {
         list1 = new ArrayList<>();

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableIteratorTest.java
@@ -25,7 +25,8 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.collections4.Unmodifiable;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the UnmodifiableIterator.
@@ -35,15 +36,15 @@ public class UnmodifiableIteratorTest<E> extends AbstractIteratorTest<E> {
     protected String[] testArray = { "One", "Two", "Three" };
     protected List<E> testList;
 
-    public UnmodifiableIteratorTest(final String testName) {
-        super(testName);
+    public UnmodifiableIteratorTest() {
+        super(UnmodifiableIteratorTest.class.getSimpleName());
     }
 
     /**
      * {@inheritDoc}
      */
     @SuppressWarnings("unchecked")
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         super.setUp();
         testList = new ArrayList<>(Arrays.asList((E[]) testArray));

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableListIteratorTest.java
@@ -23,7 +23,8 @@ import java.util.List;
 import java.util.ListIterator;
 
 import org.apache.commons.collections4.Unmodifiable;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -35,15 +36,15 @@ public class UnmodifiableListIteratorTest<E> extends AbstractListIteratorTest<E>
     protected String[] testArray = {"One", "Two", "Three"};
     protected List<E> testList;
 
-    public UnmodifiableListIteratorTest(final String testName) {
-        super(testName);
+    public UnmodifiableListIteratorTest() {
+        super(UnmodifiableListIteratorTest.class.getSimpleName());
     }
 
     /**
      * {@inheritDoc}
      */
     @SuppressWarnings("unchecked")
-    @Override
+    @BeforeEach
     protected void setUp() throws Exception {
         super.setUp();
         testList = new ArrayList<>(Arrays.asList((E[]) testArray));

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableMapIteratorTest.java
@@ -25,15 +25,15 @@ import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.bidimap.DualHashBidiMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the UnmodifiableMapIterator.
  */
 public class UnmodifiableMapIteratorTest<K, V> extends AbstractMapIteratorTest<K, V> {
 
-    public UnmodifiableMapIteratorTest(final String testName) {
-        super(testName);
+    public UnmodifiableMapIteratorTest() {
+        super(UnmodifiableMapIteratorTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableOrderedMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableOrderedMapIteratorTest.java
@@ -26,15 +26,15 @@ import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.OrderedMapIterator;
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.map.ListOrderedMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the UnmodifiableOrderedMapIterator.
  */
 public class UnmodifiableOrderedMapIteratorTest<K, V> extends AbstractOrderedMapIteratorTest<K, V> {
 
-    public UnmodifiableOrderedMapIteratorTest(final String testName) {
-        super(testName);
+    public UnmodifiableOrderedMapIteratorTest() {
+        super(UnmodifiableOrderedMapIteratorTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/iterators/ZippingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ZippingIteratorTest.java
@@ -19,7 +19,8 @@ package org.apache.commons.collections4.iterators;
 import java.util.ArrayList;
 
 import org.apache.commons.collections4.IteratorUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test suite for {@link ZippingIterator}.
@@ -30,8 +31,8 @@ public class ZippingIteratorTest extends AbstractIteratorTest<Integer> {
 
     //------------------------------------------------------------ Conventional
 
-    public ZippingIteratorTest(final String testName) {
-        super(testName);
+    public ZippingIteratorTest() {
+        super(ZippingIteratorTest.class.getSimpleName());
     }
 
     //--------------------------------------------------------------- Lifecycle
@@ -40,7 +41,7 @@ public class ZippingIteratorTest extends AbstractIteratorTest<Integer> {
     private ArrayList<Integer> odds = null;
     private ArrayList<Integer> fib = null;
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         evens = new ArrayList<>();

--- a/src/test/java/org/apache/commons/collections4/list/AbstractLinkedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/AbstractLinkedListTest.java
@@ -20,7 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link AbstractLinkedList}.

--- a/src/test/java/org/apache/commons/collections4/list/AbstractListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/AbstractListTest.java
@@ -37,7 +37,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.iterators.AbstractListIteratorTest;
 import org.junit.jupiter.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link java.util.List} methods and contracts.

--- a/src/test/java/org/apache/commons/collections4/list/Collections701Test.java
+++ b/src/test/java/org/apache/commons/collections4/list/Collections701Test.java
@@ -21,7 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 /**

--- a/src/test/java/org/apache/commons/collections4/list/CursorableLinkedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/CursorableLinkedListTest.java
@@ -29,15 +29,16 @@ import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class.
  */
 public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
 
-    public CursorableLinkedListTest(final String testName) {
-        super(testName);
+    public CursorableLinkedListTest() {
+        super(CursorableLinkedListTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {
@@ -46,7 +47,7 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
 
     private CursorableLinkedList<E> list;
 
-    @Override
+    @BeforeEach
     public void setUp() {
         list = new CursorableLinkedList<>();
     }

--- a/src/test/java/org/apache/commons/collections4/list/FixedSizeListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/FixedSizeListTest.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractListTest} for exercising the {@link FixedSizeList}
@@ -33,8 +33,8 @@ import org.junit.Test;
  */
 public class FixedSizeListTest<E> extends AbstractListTest<E> {
 
-    public FixedSizeListTest(final String testName) {
-        super(testName);
+    public FixedSizeListTest() {
+        super(FixedSizeListTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/list/GrowthListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/GrowthListTest.java
@@ -27,7 +27,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.junit.jupiter.api.function.Executable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractListTest} for exercising the {@link GrowthList}.
@@ -36,8 +36,8 @@ import org.junit.Test;
  */
 public class GrowthListTest<E> extends AbstractListTest<E> {
 
-    public GrowthListTest(final String testName) {
-        super(testName);
+    public GrowthListTest() {
+        super(GrowthListTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/list/LazyListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/LazyListTest.java
@@ -19,7 +19,7 @@ package org.apache.commons.collections4.list;
 import org.apache.commons.collections4.AbstractObjectTest;
 import org.apache.commons.collections4.Factory;
 import org.apache.commons.collections4.Transformer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -28,8 +28,8 @@ import java.util.List;
 
 public class LazyListTest extends AbstractObjectTest {
 
-    public LazyListTest(final String testName) {
-        super(testName);
+    public LazyListTest() {
+        super(LazyListTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/list/NodeCachingLinkedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/NodeCachingLinkedListTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for NodeCachingLinkedList, a performance optimised LinkedList.
@@ -28,8 +28,8 @@ import org.junit.Test;
  */
 public class NodeCachingLinkedListTest<E> extends AbstractLinkedListTest<E> {
 
-    public NodeCachingLinkedListTest(final String testName) {
-        super(testName);
+    public NodeCachingLinkedListTest() {
+        super(NodeCachingLinkedListTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/list/PredicatedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/PredicatedListTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractListTest} for exercising the
@@ -33,8 +33,8 @@ import org.junit.Test;
  */
 public class PredicatedListTest<E> extends AbstractListTest<E> {
 
-    public PredicatedListTest(final String testName) {
-        super(testName);
+    public PredicatedListTest() {
+        super(PredicatedListTest.class.getSimpleName());
     }
 
  //-------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
@@ -17,7 +17,7 @@
 package org.apache.commons.collections4.list;
 
 import org.apache.commons.collections4.set.UnmodifiableSet;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 
@@ -43,8 +43,8 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
 
     boolean extraVerify = true;
 
-    public SetUniqueListTest(final String testName) {
-        super(testName);
+    public SetUniqueListTest() {
+        super(SetUniqueListTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/list/TransformedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/TransformedListTest.java
@@ -23,7 +23,7 @@ import java.util.ListIterator;
 
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractListTest} for exercising the {@link TransformedList}
@@ -33,8 +33,8 @@ import org.junit.Test;
  */
 public class TransformedListTest<E> extends AbstractListTest<E> {
 
-    public TransformedListTest(final String testName) {
-        super(testName);
+    public TransformedListTest() {
+        super(TransformedListTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/list/TreeListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/TreeListTest.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.ListIterator;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests
@@ -30,8 +30,8 @@ import org.junit.Test;
  */
 public class TreeListTest<E> extends AbstractListTest<E> {
 
-    public TreeListTest(final String name) {
-        super(name);
+    public TreeListTest() {
+        super(TreeListTest.class.getSimpleName());
     }
 
 //    public static void main(String[] args) {

--- a/src/test/java/org/apache/commons/collections4/list/UnmodifiableListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/UnmodifiableListTest.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractListTest} for exercising the
@@ -34,8 +34,8 @@ import org.junit.Test;
  */
 public class UnmodifiableListTest<E> extends AbstractListTest<E> {
 
-    public UnmodifiableListTest(final String testName) {
-        super(testName);
+    public UnmodifiableListTest() {
+        super(UnmodifiableListTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/map/AbstractIterableMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractIterableMapTest.java
@@ -26,7 +26,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.iterators.AbstractMapIteratorTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link IterableMap} methods and contracts.

--- a/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
@@ -37,7 +37,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.keyvalue.DefaultMapEntry;
 import org.apache.commons.collections4.set.AbstractSetTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link java.util.Map} methods and contracts.

--- a/src/test/java/org/apache/commons/collections4/map/AbstractOrderedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractOrderedMapTest.java
@@ -32,7 +32,7 @@ import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.OrderedMapIterator;
 import org.apache.commons.collections4.comparators.NullComparator;
 import org.apache.commons.collections4.iterators.AbstractOrderedMapIteratorTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link OrderedMap} methods and contracts.

--- a/src/test/java/org/apache/commons/collections4/map/AbstractSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractSortedMapTest.java
@@ -27,7 +27,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link java.util.SortedMap} methods and contracts.

--- a/src/test/java/org/apache/commons/collections4/map/CaseInsensitiveMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/CaseInsensitiveMapTest.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the {@link CaseInsensitiveMap} implementation.
@@ -34,8 +34,8 @@ public class CaseInsensitiveMapTest<K, V> extends AbstractIterableMapTest<K, V> 
         return BulkTest.makeSuite(CaseInsensitiveMapTest.class);
     }
 
-    public CaseInsensitiveMapTest(final String testName) {
-        super(testName);
+    public CaseInsensitiveMapTest() {
+        super(CaseInsensitiveMapTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/map/CompositeMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/CompositeMapTest.java
@@ -22,7 +22,8 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Collection;
 
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractMapTest} for exercising the
@@ -35,11 +36,11 @@ public class CompositeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
     /** used as a flag in MapMutator tests */
     private boolean pass = false;
 
-    public CompositeMapTest(final String testName) {
-        super(testName);
+    public CompositeMapTest() {
+        super(CompositeMapTest.class.getSimpleName());
     }
 
-    @Override
+    @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         this.pass = false;

--- a/src/test/java/org/apache/commons/collections4/map/DefaultedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/DefaultedMapTest.java
@@ -28,7 +28,7 @@ import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
 import org.apache.commons.collections4.functors.ConstantFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractMapTest} for exercising the
@@ -41,8 +41,8 @@ public class DefaultedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
     protected final Factory<V> nullFactory = FactoryUtils.<V>nullFactory();
     protected final Transformer<K, V> nullTransformer = TransformerUtils.<K, V>nullTransformer();
 
-    public DefaultedMapTest(final String testName) {
-        super(testName);
+    public DefaultedMapTest() {
+        super(DefaultedMapTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/map/FixedSizeMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/FixedSizeMapTest.java
@@ -29,8 +29,8 @@ import org.apache.commons.collections4.IterableMap;
  */
 public class FixedSizeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
-    public FixedSizeMapTest(final String testName) {
-        super(testName);
+    public FixedSizeMapTest() {
+        super(FixedSizeMapTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/map/FixedSizeSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/FixedSizeSortedMapTest.java
@@ -29,8 +29,8 @@ import org.apache.commons.collections4.BulkTest;
  */
 public class FixedSizeSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
 
-    public FixedSizeSortedMapTest(final String testName) {
-        super(testName);
+    public FixedSizeSortedMapTest() {
+        super(FixedSizeSortedMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
@@ -29,7 +29,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.iterators.AbstractMapIteratorTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests.
@@ -44,8 +44,8 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
     private static final String TWENTY = "20";
     private static final String THIRTY = "30";
 
-    public Flat3MapTest(final String testName) {
-        super(testName);
+    public Flat3MapTest() {
+        super(Flat3MapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/map/HashedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/HashedMapTest.java
@@ -17,7 +17,7 @@
 package org.apache.commons.collections4.map;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests.
@@ -25,8 +25,8 @@ import org.junit.Test;
  */
 public class HashedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
-    public HashedMapTest(final String testName) {
-        super(testName);
+    public HashedMapTest() {
+        super(HashedMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/map/LRUMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LRUMapTest.java
@@ -29,15 +29,15 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.ResettableIterator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests.
  */
 public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
 
-    public LRUMapTest(final String testName) {
-        super(testName);
+    public LRUMapTest() {
+        super(LRUMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/map/LazyMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LazyMapTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import org.apache.commons.collections4.Factory;
 import org.apache.commons.collections4.FactoryUtils;
 import org.apache.commons.collections4.Transformer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractMapTest} for exercising the
@@ -37,8 +37,8 @@ public class LazyMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
     private static final Factory<Integer> oneFactory = FactoryUtils.constantFactory(1);
 
-    public LazyMapTest(final String testName) {
-        super(testName);
+    public LazyMapTest() {
+        super(LazyMapTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/map/LazySortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LazySortedMapTest.java
@@ -30,7 +30,7 @@ import org.apache.commons.collections4.Factory;
 import org.apache.commons.collections4.FactoryUtils;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link LazyMapTest} for exercising the
@@ -54,8 +54,8 @@ public class LazySortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
 
     protected final Comparator<String> reverseStringComparator = new ReverseStringComparator();
 
-    public LazySortedMapTest(final String testName) {
-        super(testName);
+    public LazySortedMapTest() {
+        super(LazySortedMapTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/map/LinkedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LinkedMapTest.java
@@ -26,7 +26,7 @@ import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.ResettableIterator;
 import org.apache.commons.collections4.list.AbstractListTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests.
@@ -34,8 +34,8 @@ import org.junit.Test;
  */
 public class LinkedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
 
-    public LinkedMapTest(final String testName) {
-        super(testName);
+    public LinkedMapTest() {
+        super(LinkedMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/map/ListOrderedMap2Test.java
+++ b/src/test/java/org/apache/commons/collections4/map/ListOrderedMap2Test.java
@@ -22,7 +22,7 @@ import java.util.List;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.list.AbstractListTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractOrderedMapTest} for exercising the {@link ListOrderedMap}
@@ -32,8 +32,8 @@ import org.junit.Test;
  */
 public class ListOrderedMap2Test<K, V> extends AbstractOrderedMapTest<K, V> {
 
-    public ListOrderedMap2Test(final String testName) {
-        super(testName);
+    public ListOrderedMap2Test() {
+        super(ListOrderedMap2Test.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/map/ListOrderedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ListOrderedMapTest.java
@@ -28,7 +28,7 @@ import java.util.TreeMap;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.list.AbstractListTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractOrderedMapTest} for exercising the {@link ListOrderedMap}
@@ -38,8 +38,8 @@ import org.junit.Test;
  */
 public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
 
-    public ListOrderedMapTest(final String testName) {
-        super(testName);
+    public ListOrderedMapTest() {
+        super(ListOrderedMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/map/MultiKeyMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/MultiKeyMapTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.keyvalue.MultiKey;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests.
@@ -39,8 +39,8 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
     static final Integer I7 = Integer.valueOf(7);
     static final Integer I8 = Integer.valueOf(8);
 
-    public MultiKeyMapTest(final String testName) {
-        super(testName);
+    public MultiKeyMapTest() {
+        super(MultiKeyMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/map/MultiValueMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/MultiValueMapTest.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import org.apache.commons.collections4.AbstractObjectTest;
 import org.apache.commons.collections4.IteratorUtils;
 import org.apache.commons.collections4.MultiMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * TestMultiValueMap.
@@ -45,8 +45,8 @@ import org.junit.Test;
 @Deprecated
 public class MultiValueMapTest<K, V> extends AbstractObjectTest {
 
-    public MultiValueMapTest(final String testName) {
-        super(testName);
+    public MultiValueMapTest() {
+        super(MultiValueMapTest.class.getSimpleName());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.map.PassiveExpiringMap.ExpirationPolicy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests.
@@ -58,8 +58,8 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
         return BulkTest.makeSuite(PassiveExpiringMapTest.class);
     }
 
-    public PassiveExpiringMapTest(final String testName) {
-        super(testName);
+    public PassiveExpiringMapTest() {
+        super(PassiveExpiringMapTest.class.getSimpleName());
     }
 
 //    public void testCreate() throws Exception {

--- a/src/test/java/org/apache/commons/collections4/map/PredicatedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PredicatedMapTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractMapTest} for exercising the
@@ -39,8 +39,8 @@ public class PredicatedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
     protected static final Predicate<Object> testPredicate = o -> o instanceof String;
 
-    public PredicatedMapTest(final String testName) {
-        super(testName);
+    public PredicatedMapTest() {
+        super(PredicatedMapTest.class.getSimpleName());
     }
 
     protected IterableMap<K, V> decorateMap(final Map<K, V> map, final Predicate<? super K> keyPredicate,

--- a/src/test/java/org/apache/commons/collections4/map/PredicatedSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PredicatedSortedMapTest.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link PredicatedMapTest} for exercising the
@@ -51,8 +51,8 @@ public class PredicatedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
 
     protected final Comparator<K> reverseStringComparator = new ReverseStringComparator();
 
-    public PredicatedSortedMapTest(final String testName) {
-        super(testName);
+    public PredicatedSortedMapTest() {
+        super(PredicatedSortedMapTest.class.getSimpleName());
     }
 
     protected SortedMap<K, V> decorateMap(final SortedMap<K, V> map, final Predicate<? super K> keyPredicate,

--- a/src/test/java/org/apache/commons/collections4/map/ReferenceIdentityMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ReferenceIdentityMapTest.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for ReferenceIdentityMap.
@@ -56,8 +56,8 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
 
     WeakReference<V> valueReference;
 
-    public ReferenceIdentityMapTest(final String testName) {
-        super(testName);
+    public ReferenceIdentityMapTest() {
+        super(ReferenceIdentityMapTest.class.getSimpleName());
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/apache/commons/collections4/map/ReferenceMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ReferenceMapTest.java
@@ -34,15 +34,15 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.map.AbstractHashedMap.HashEntry;
 import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceEntry;
 import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for ReferenceMap.
  */
 public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
-    public ReferenceMapTest(final String testName) {
-        super(testName);
+    public ReferenceMapTest() {
+        super(ReferenceMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/map/SingletonMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/SingletonMapTest.java
@@ -22,7 +22,7 @@ import org.apache.commons.collections4.BoundedMap;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.KeyValue;
 import org.apache.commons.collections4.OrderedMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests.
@@ -34,8 +34,8 @@ public class SingletonMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
     private static final Integer TWO = Integer.valueOf(2);
     private static final String TEN = "10";
 
-    public SingletonMapTest(final String testName) {
-        super(testName);
+    public SingletonMapTest() {
+        super(SingletonMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/map/StaticBucketMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/StaticBucketMapTest.java
@@ -17,7 +17,7 @@
 package org.apache.commons.collections4.map;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests.
@@ -26,8 +26,8 @@ import org.junit.Test;
  */
 public class StaticBucketMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
-    public StaticBucketMapTest(final String name) {
-        super(name);
+    public StaticBucketMapTest() {
+        super(StaticBucketMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/map/TransformedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/TransformedMapTest.java
@@ -24,7 +24,7 @@ import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractMapTest} for exercising the {@link TransformedMap}
@@ -34,8 +34,8 @@ import org.junit.Test;
  */
 public class TransformedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
-    public TransformedMapTest(final String testName) {
-        super(testName);
+    public TransformedMapTest() {
+        super(TransformedMapTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/map/TransformedSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/TransformedSortedMapTest.java
@@ -27,7 +27,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSortedMapTest} for exercising the {@link TransformedSortedMap}
@@ -37,8 +37,8 @@ import org.junit.Test;
  */
 public class TransformedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
 
-    public TransformedSortedMapTest(final String testName) {
-        super(testName);
+    public TransformedSortedMapTest() {
+        super(TransformedSortedMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/map/UnmodifiableMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/UnmodifiableMapTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.Unmodifiable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractMapTest} for exercising the
@@ -33,8 +33,8 @@ import org.junit.Test;
  */
 public class UnmodifiableMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
-    public UnmodifiableMapTest(final String testName) {
-        super(testName);
+    public UnmodifiableMapTest() {
+        super(UnmodifiableMapTest.class.getSimpleName());
     }
 
     //-------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/collections4/map/UnmodifiableOrderedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/UnmodifiableOrderedMapTest.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 
 import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.Unmodifiable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractOrderedMapTest} for exercising the
@@ -32,8 +32,8 @@ import org.junit.Test;
  */
 public class UnmodifiableOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
 
-    public UnmodifiableOrderedMapTest(final String testName) {
-        super(testName);
+    public UnmodifiableOrderedMapTest() {
+        super(UnmodifiableOrderedMapTest.class.getSimpleName());
     }
 
     //-------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/collections4/map/UnmodifiableSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/UnmodifiableSortedMapTest.java
@@ -22,7 +22,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 import org.apache.commons.collections4.Unmodifiable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSortedMapTest} for exercising the
@@ -32,8 +32,8 @@ import org.junit.Test;
  */
 public class UnmodifiableSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
 
-    public UnmodifiableSortedMapTest(final String testName) {
-        super(testName);
+    public UnmodifiableSortedMapTest() {
+        super(UnmodifiableSortedMapTest.class.getSimpleName());
     }
 
     //-------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -42,7 +42,7 @@ import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.map.AbstractMapTest;
 import org.apache.commons.collections4.multiset.AbstractMultiSetTest;
 import org.apache.commons.collections4.set.AbstractSetTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link MultiValuedMap} contract and methods.

--- a/src/test/java/org/apache/commons/collections4/multimap/ArrayListValuedHashMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/ArrayListValuedHashMapTest.java
@@ -26,7 +26,7 @@ import java.util.ArrayList;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.ListValuedMap;
 import org.apache.commons.collections4.MultiValuedMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test ArrayListValuedHashMap
@@ -35,8 +35,8 @@ import org.junit.Test;
  */
 public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest<K, V> {
 
-    public ArrayListValuedHashMapTest(final String testName) {
-        super(testName);
+    public ArrayListValuedHashMapTest() {
+        super(ArrayListValuedHashMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/multimap/HashSetValuedHashMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/HashSetValuedHashMapTest.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.SetValuedMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test HashSetValuedHashMap
@@ -33,8 +33,8 @@ import org.junit.Test;
  */
 public class HashSetValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest<K, V> {
 
-    public HashSetValuedHashMapTest(final String testName) {
-        super(testName);
+    public HashSetValuedHashMapTest() {
+        super(HashSetValuedHashMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
@@ -23,7 +23,7 @@ import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for TransformedMultiValuedMap
@@ -32,8 +32,8 @@ import org.junit.Test;
  */
 public class TransformedMultiValuedMapTest<K, V> extends AbstractMultiValuedMapTest<K, V> {
 
-    public TransformedMultiValuedMapTest(final String testName) {
-        super(testName);
+    public TransformedMultiValuedMapTest() {
+        super(TransformedMultiValuedMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/multimap/UnmodifiableMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/UnmodifiableMultiValuedMapTest.java
@@ -31,7 +31,7 @@ import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.MultiSet;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.Unmodifiable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for UnmodifiableMultiValuedMap
@@ -40,8 +40,8 @@ import org.junit.Test;
  */
 public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMapTest<K, V> {
 
-    public UnmodifiableMultiValuedMapTest(final String testName) {
-        super(testName);
+    public UnmodifiableMultiValuedMapTest() {
+        super(UnmodifiableMultiValuedMapTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
@@ -34,7 +34,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiSet;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.set.AbstractSetTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link org.apache.commons.collections4.MultiSet MultiSet}

--- a/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
@@ -27,8 +27,8 @@ import org.apache.commons.collections4.MultiSet;
  */
 public class HashMultiSetTest<T> extends AbstractMultiSetTest<T> {
 
-    public HashMultiSetTest(final String testName) {
-        super(testName);
+    public HashMultiSetTest() {
+        super(HashMultiSetTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/multiset/PredicatedMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/PredicatedMultiSetTest.java
@@ -24,7 +24,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiSet;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractMultiSetTest} for exercising the
@@ -34,8 +34,8 @@ import org.junit.Test;
  */
 public class PredicatedMultiSetTest<T> extends AbstractMultiSetTest<T> {
 
-    public PredicatedMultiSetTest(final String testName) {
-        super(testName);
+    public PredicatedMultiSetTest() {
+        super(PredicatedMultiSetTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/multiset/SynchronizedMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/SynchronizedMultiSetTest.java
@@ -27,8 +27,8 @@ import org.apache.commons.collections4.MultiSet;
  */
 public class SynchronizedMultiSetTest<T> extends AbstractMultiSetTest<T> {
 
-    public SynchronizedMultiSetTest(final String testName) {
-        super(testName);
+    public SynchronizedMultiSetTest() {
+        super(SynchronizedMultiSetTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/multiset/UnmodifiableMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/UnmodifiableMultiSetTest.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiSet;
 import org.apache.commons.collections4.Unmodifiable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractMultiSetTest} for exercising the
@@ -33,8 +33,8 @@ import org.junit.Test;
  */
 public class UnmodifiableMultiSetTest<E> extends AbstractMultiSetTest<E> {
 
-    public UnmodifiableMultiSetTest(final String testName) {
-        super(testName);
+    public UnmodifiableMultiSetTest() {
+        super(UnmodifiableMultiSetTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/properties/AbstractPropertiesFactoryTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/AbstractPropertiesFactoryTest.java
@@ -21,32 +21,31 @@ import java.io.FileInputStream;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.Assume;
 import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
 public abstract class AbstractPropertiesFactoryTest<T extends Properties> {
 
-    @Parameters(name = "{0}")
-    public static Object[][] getParameters() {
-        return new Object[][] { { ".properties" }, { ".xml" } };
-
+    public static Stream<Arguments> getParameters() {
+        return Stream.of(
+                arguments(".properties"),
+                arguments(".xml")
+        );
     }
 
     private final AbstractPropertiesFactory<T> factory;
-    private final String pathString;
-    private final String fileExtension;
 
-    protected AbstractPropertiesFactoryTest(final AbstractPropertiesFactory<T> factory, final String fileExtension) {
+    protected AbstractPropertiesFactoryTest(final AbstractPropertiesFactory<T> factory) {
         this.factory = factory;
-        this.fileExtension = fileExtension;
-        this.pathString = BulkTest.TEST_PROPERTIES_PATH + "test" + fileExtension;
     }
 
     private void assertContents(final T properties) {
@@ -63,8 +62,12 @@ public abstract class AbstractPropertiesFactoryTest<T extends Properties> {
         Assertions.assertEquals("value11", properties.getProperty("key11"));
     }
 
-    private boolean isXmlTest() {
+    private boolean isXmlTest(final String fileExtension) {
         return ".xml".equals(fileExtension);
+    }
+
+    private String getPathString(final String fileExtension) {
+        return BulkTest.TEST_PROPERTIES_PATH + "test" + fileExtension;
     }
 
     @Test
@@ -72,59 +75,68 @@ public abstract class AbstractPropertiesFactoryTest<T extends Properties> {
         Assertions.assertNotNull(PropertiesFactory.INSTANCE);
     }
 
-    @Test
-    public void testLoadClassLoaderMissingResource() throws Exception {
+    @ParameterizedTest
+    @MethodSource(value = "getParameters")
+    public void testLoadClassLoaderMissingResource(final String fileExtension) throws Exception {
         Assertions.assertNull(factory.load(ClassLoader.getSystemClassLoader(), "missing/test" + fileExtension));
     }
 
-    @Test
-    public void testLoadClassLoaderResource() throws Exception {
+    @ParameterizedTest
+    @MethodSource(value = "getParameters")
+    public void testLoadClassLoaderResource(final String fileExtension) throws Exception {
         assertContents(factory.load(ClassLoader.getSystemClassLoader(), "org/apache/commons/collections4/properties/test" + fileExtension));
     }
 
-    @Test
-    public void testLoadFile() throws Exception {
-        assertContents(factory.load(Paths.get(pathString).toFile()));
+    @ParameterizedTest
+    @MethodSource(value = "getParameters")
+    public void testLoadFile(final String fileExtension) throws Exception {
+        assertContents(factory.load(Paths.get(getPathString(fileExtension)).toFile()));
     }
 
-    @Test
-    public void testLoadFileName() throws Exception {
-        assertContents(factory.load(pathString));
+    @ParameterizedTest
+    @MethodSource(value = "getParameters")
+    public void testLoadFileName(final String fileExtension) throws Exception {
+        assertContents(factory.load(getPathString(fileExtension)));
     }
 
-    @Test
-    public void testLoadInputStream() throws Exception {
+    @ParameterizedTest
+    @MethodSource(value = "getParameters")
+    public void testLoadInputStream(final String fileExtension) throws Exception {
         // Can't tell what we are reading
-        Assume.assumeFalse(isXmlTest());
+        Assumptions.assumeFalse(isXmlTest(fileExtension));
         //
-        try (FileInputStream inputStream = new FileInputStream(pathString)) {
+        try (FileInputStream inputStream = new FileInputStream(getPathString(fileExtension))) {
             assertContents(factory.load(inputStream));
         }
     }
 
-    @Test
-    public void testLoadPath() throws Exception {
-        assertContents(factory.load(Paths.get(pathString)));
+    @ParameterizedTest
+    @MethodSource(value = "getParameters")
+    public void testLoadPath(final String fileExtension) throws Exception {
+        assertContents(factory.load(Paths.get(getPathString(fileExtension))));
     }
 
-    @Test
-    public void testLoadReader() throws Exception {
+    @ParameterizedTest
+    @MethodSource(value = "getParameters")
+    public void testLoadReader(final String fileExtension) throws Exception {
         // Can't tell what we are reading
-        Assume.assumeFalse(isXmlTest());
+        Assumptions.assumeFalse(isXmlTest(fileExtension));
         //
-        try (BufferedReader inputStream = Files.newBufferedReader(Paths.get(pathString))) {
+        try (BufferedReader inputStream = Files.newBufferedReader(Paths.get(getPathString(fileExtension)))) {
             assertContents(factory.load(inputStream));
         }
     }
 
-    @Test
-    public void testLoadUri() throws Exception {
-        assertContents(factory.load(Paths.get(pathString).toUri()));
+    @ParameterizedTest
+    @MethodSource(value = "getParameters")
+    public void testLoadUri(final String fileExtension) throws Exception {
+        assertContents(factory.load(Paths.get(getPathString(fileExtension)).toUri()));
     }
 
-    @Test
-    public void testLoadUrl() throws Exception {
-        assertContents(factory.load(Paths.get(pathString).toUri().toURL()));
+    @ParameterizedTest
+    @MethodSource(value = "getParameters")
+    public void testLoadUrl(final String fileExtension) throws Exception {
+        assertContents(factory.load(Paths.get(getPathString(fileExtension)).toUri().toURL()));
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/properties/EmptyPropertiesTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/EmptyPropertiesTest.java
@@ -261,31 +261,36 @@ public class EmptyPropertiesTest {
         final String comments = "Hello world!";
         // actual
         try (ByteArrayOutputStream actual = new ByteArrayOutputStream()) {
-            try (PrintStream out = new PrintStream(actual)) {
-                PropertiesFactory.EMPTY_PROPERTIES.save(out, comments);
-            }
+            PropertiesFactory.EMPTY_PROPERTIES.save(actual, comments);
             // expected
             try (ByteArrayOutputStream expected = new ByteArrayOutputStream()) {
-                try (PrintStream out = new PrintStream(expected)) {
-                    PropertiesFactory.INSTANCE.createProperties().save(out, comments);
-                }
-                assertArrayEquals(expected.toByteArray(), actual.toByteArray(), () -> {
-                    String s = null;
-                    try {
-                        s = new String(expected.toByteArray(), "UTF-8");
-                    } catch (UnsupportedEncodingException e) {
-                        fail(e.getMessage(), e);
-                    }
-                    return String.format("Expected String '%s' with length '%s'", s, s.length());
-                });
+                PropertiesFactory.INSTANCE.createProperties().save(expected, comments);
+
+                // Properties.save stores the specified comment appended with current time stamp in the next line
+                String expectedComment = getFirstLine(expected.toString("UTF-8"));
+                String actualComment = getFirstLine(actual.toString("UTF-8"));
+                assertEquals(expectedComment, actualComment, () ->
+                        String.format("Expected String '%s' with length '%s'", expectedComment, expectedComment.length()));
                 expected.reset();
                 try (PrintStream out = new PrintStream(expected)) {
                     new Properties().save(out, comments);
                 }
-                assertArrayEquals(expected.toByteArray(), actual.toByteArray(), () -> new String(expected.toByteArray()));
+                assertArrayEquals(expected.toByteArray(), actual.toByteArray(), expected::toString);
+            } catch (UnsupportedEncodingException e) {
+                fail(e.getMessage(), e);
             }
         }
     }
+
+    /**
+     * Returns the first line from multi-lined string separated by a line separator character
+     * @param x the multi-lined String
+     * @return the first line from x
+     */
+    private String getFirstLine(final String x) {
+        return x.split("\\R", 2)[0];
+    }
+
 
     @Test
     public void testSetProperty() {

--- a/src/test/java/org/apache/commons/collections4/properties/PropertiesFactoryTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/PropertiesFactoryTest.java
@@ -19,13 +19,13 @@ package org.apache.commons.collections4.properties;
 
 import java.util.Properties;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class PropertiesFactoryTest extends AbstractPropertiesFactoryTest<Properties> {
 
-    public PropertiesFactoryTest(final String fileExtension) {
-        super(PropertiesFactory.INSTANCE, fileExtension);
+    public PropertiesFactoryTest() {
+        super(PropertiesFactory.INSTANCE);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesFactoryTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesFactoryTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.commons.collections4.properties;
 
-import org.junit.Test;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class SortedPropertiesFactoryTest extends AbstractPropertiesFactoryTest<SortedProperties> {
 
-    public SortedPropertiesFactoryTest(final String fileExtension) {
-        super(SortedPropertiesFactory.INSTANCE, fileExtension);
+    public SortedPropertiesFactoryTest() {
+        super(SortedPropertiesFactory.INSTANCE);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesTest.java
@@ -20,7 +20,7 @@ import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class SortedPropertiesTest {

--- a/src/test/java/org/apache/commons/collections4/queue/AbstractQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/AbstractQueueTest.java
@@ -28,7 +28,7 @@ import java.util.NoSuchElementException;
 import java.util.Queue;
 
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link java.util.Queue} methods and contracts.

--- a/src/test/java/org/apache/commons/collections4/queue/CircularFifoQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/CircularFifoQueueTest.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test cases for CircularFifoQueue.
@@ -38,8 +38,8 @@ import org.junit.Test;
  */
 public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
 
-    public CircularFifoQueueTest(final String testName) {
-        super(testName);
+    public CircularFifoQueueTest() {
+        super(CircularFifoQueueTest.class.getSimpleName());
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/queue/PredicatedQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/PredicatedQueueTest.java
@@ -25,7 +25,7 @@ import java.util.Queue;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.collection.PredicatedCollectionTest;
 import org.apache.commons.collections4.functors.TruePredicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link PredicatedCollectionTest} for exercising the
@@ -35,8 +35,8 @@ import org.junit.Test;
  */
 public class PredicatedQueueTest<E> extends AbstractQueueTest<E> {
 
-    public PredicatedQueueTest(final String testName) {
-        super(testName);
+    public PredicatedQueueTest() {
+        super(PredicatedQueueTest.class.getSimpleName());
     }
 
     //---------------------------------------------------------------

--- a/src/test/java/org/apache/commons/collections4/queue/SynchronizedQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/SynchronizedQueueTest.java
@@ -21,7 +21,7 @@ import java.util.Queue;
 
 import org.apache.commons.collections4.BulkTest;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractQueueTest} for exercising the {@link SynchronizedQueue} implementation.
@@ -34,8 +34,8 @@ public class SynchronizedQueueTest<T> extends AbstractQueueTest<T> {
         return BulkTest.makeSuite(SynchronizedQueueTest.class);
     }
 
-    public SynchronizedQueueTest(final String testName) {
-        super(testName);
+    public SynchronizedQueueTest() {
+        super(SynchronizedQueueTest.class.getSimpleName());
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/collections4/queue/TransformedQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/TransformedQueueTest.java
@@ -24,7 +24,7 @@ import java.util.Queue;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -34,8 +34,8 @@ import org.junit.Test;
  */
 public class TransformedQueueTest<E> extends AbstractQueueTest<E> {
 
-    public TransformedQueueTest(final String testName) {
-        super(testName);
+    public TransformedQueueTest() {
+        super(TransformedQueueTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/queue/UnmodifiableQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/UnmodifiableQueueTest.java
@@ -25,7 +25,7 @@ import java.util.Queue;
 
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
@@ -35,8 +35,8 @@ import org.junit.Test;
  */
 public class UnmodifiableQueueTest<E> extends AbstractQueueTest<E> {
 
-    public UnmodifiableQueueTest(final String testName) {
-        super(testName);
+    public UnmodifiableQueueTest() {
+        super(UnmodifiableQueueTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/set/AbstractSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/AbstractSetTest.java
@@ -22,7 +22,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Abstract test class for {@link Set} methods and contracts.

--- a/src/test/java/org/apache/commons/collections4/set/CompositeSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/CompositeSetTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.collections4.set.CompositeSet.SetMutator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSetTest} for exercising the
@@ -34,8 +34,8 @@ import org.junit.Test;
  */
 public class CompositeSetTest<E> extends AbstractSetTest<E> {
 
-    public CompositeSetTest(final String name) {
-        super(name);
+    public CompositeSetTest() {
+        super(CompositeSetTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/set/ListOrderedSet2Test.java
+++ b/src/test/java/org/apache/commons/collections4/set/ListOrderedSet2Test.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSetTest} for exercising the {@link ListOrderedSet}
@@ -35,8 +35,8 @@ public class ListOrderedSet2Test<E> extends AbstractSetTest<E> {
     private static final Integer TWO = Integer.valueOf(2);
     private static final Integer THREE = Integer.valueOf(3);
 
-    public ListOrderedSet2Test(final String testName) {
-        super(testName);
+    public ListOrderedSet2Test() {
+        super(ListOrderedSet2Test.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/set/ListOrderedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/ListOrderedSetTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.collections4.IteratorUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSetTest} for exercising the
@@ -46,8 +46,8 @@ public class ListOrderedSetTest<E>
 
     private static final Integer THREE = Integer.valueOf(3);
 
-    public ListOrderedSetTest(final String testName) {
-        super(testName);
+    public ListOrderedSetTest() {
+        super(ListOrderedSetTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/set/MapBackedSet2Test.java
+++ b/src/test/java/org/apache/commons/collections4/set/MapBackedSet2Test.java
@@ -20,7 +20,7 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.apache.commons.collections4.map.LinkedMap;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit test.
@@ -29,8 +29,8 @@ import org.junit.Test;
  */
 public class MapBackedSet2Test<E> extends AbstractSetTest<E> {
 
-    public MapBackedSet2Test(final String testName) {
-        super(testName);
+    public MapBackedSet2Test() {
+        super(MapBackedSet2Test.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/set/MapBackedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/MapBackedSetTest.java
@@ -27,8 +27,8 @@ import org.apache.commons.collections4.map.HashedMap;
  */
 public class MapBackedSetTest<E> extends AbstractSetTest<E> {
 
-    public MapBackedSetTest(final String testName) {
-        super(testName);
+    public MapBackedSetTest() {
+        super(MapBackedSetTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/set/PredicatedNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/PredicatedNavigableSetTest.java
@@ -27,7 +27,7 @@ import java.util.TreeSet;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractNavigableSetTest} for exercising the
@@ -37,8 +37,8 @@ import org.junit.Test;
  */
 public class PredicatedNavigableSetTest<E> extends AbstractNavigableSetTest<E> {
 
-    public PredicatedNavigableSetTest(final String testName) {
-        super(testName);
+    public PredicatedNavigableSetTest() {
+        super(PredicatedNavigableSetTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/set/PredicatedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/PredicatedSetTest.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSetTest} for exercising the
@@ -33,8 +33,8 @@ import org.junit.Test;
  */
 public class PredicatedSetTest<E> extends AbstractSetTest<E> {
 
-    public PredicatedSetTest(final String testName) {
-        super(testName);
+    public PredicatedSetTest() {
+        super(PredicatedSetTest.class.getSimpleName());
     }
 
  //-------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/collections4/set/PredicatedSortedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/PredicatedSortedSetTest.java
@@ -27,7 +27,7 @@ import java.util.TreeSet;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.TruePredicate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSortedSetTest} for exercising the
@@ -37,8 +37,8 @@ import org.junit.Test;
  */
 public class PredicatedSortedSetTest<E> extends AbstractSortedSetTest<E> {
 
-    public PredicatedSortedSetTest(final String testName) {
-        super(testName);
+    public PredicatedSortedSetTest() {
+        super(PredicatedSortedSetTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/set/TransformedNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/TransformedNavigableSetTest.java
@@ -25,7 +25,7 @@ import java.util.Set;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractNavigableSetTest} for exercising the
@@ -35,8 +35,8 @@ import org.junit.Test;
  */
 public class TransformedNavigableSetTest<E> extends AbstractNavigableSetTest<E> {
 
-    public TransformedNavigableSetTest(final String testName) {
-        super(testName);
+    public TransformedNavigableSetTest() {
+        super(TransformedNavigableSetTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/set/TransformedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/TransformedSetTest.java
@@ -23,7 +23,7 @@ import java.util.Set;
 
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSetTest} for exercising the {@link TransformedSet}
@@ -33,8 +33,8 @@ import org.junit.Test;
  */
 public class TransformedSetTest<E> extends AbstractSetTest<E> {
 
-    public TransformedSetTest(final String testName) {
-        super(testName);
+    public TransformedSetTest() {
+        super(TransformedSetTest.class.getSimpleName());
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/set/TransformedSortedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/TransformedSortedSetTest.java
@@ -25,7 +25,7 @@ import java.util.SortedSet;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSortedSetTest} for exercising the {@link TransformedSortedSet}
@@ -35,8 +35,8 @@ import org.junit.Test;
  */
 public class TransformedSortedSetTest<E> extends AbstractSortedSetTest<E> {
 
-    public TransformedSortedSetTest(final String testName) {
-        super(testName);
+    public TransformedSortedSetTest() {
+        super(TransformedSortedSetTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableNavigableSetTest.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -38,8 +38,8 @@ public class UnmodifiableNavigableSetTest<E> extends AbstractNavigableSetTest<E>
     protected UnmodifiableNavigableSet<E> set = null;
     protected ArrayList<E> array = null;
 
-    public UnmodifiableNavigableSetTest(final String testName) {
-        super(testName);
+    public UnmodifiableNavigableSetTest() {
+        super(UnmodifiableNavigableSetTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableSetTest.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Unmodifiable;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSetTest} for exercising the
@@ -34,8 +34,8 @@ import org.junit.Test;
  */
 public class UnmodifiableSetTest<E> extends AbstractSetTest<E> {
 
-    public UnmodifiableSetTest(final String testName) {
-        super(testName);
+    public UnmodifiableSetTest() {
+        super(UnmodifiableSetTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableSortedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableSortedSetTest.java
@@ -27,7 +27,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSortedSetTest} for exercising the
@@ -39,8 +39,8 @@ public class UnmodifiableSortedSetTest<E> extends AbstractSortedSetTest<E> {
     protected UnmodifiableSortedSet<E> set = null;
     protected ArrayList<E> array = null;
 
-    public UnmodifiableSortedSetTest(final String testName) {
-        super(testName);
+    public UnmodifiableSortedSetTest() {
+        super(UnmodifiableSortedSetTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/splitmap/TransformedSplitMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/splitmap/TransformedSplitMapTest.java
@@ -26,7 +26,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.functors.NOPTransformer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link TransformedSplitMap}
@@ -42,8 +42,8 @@ public class TransformedSplitMapTest extends BulkTest {
 
     private final Transformer<String, Integer> stringToInt = Integer::valueOf;
 
-    public TransformedSplitMapTest(final String testName) {
-        super(testName);
+    public TransformedSplitMapTest() {
+        super(TransformedSplitMapTest.class.getSimpleName());
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/collections4/trie/PatriciaTrie2Test.java
+++ b/src/test/java/org/apache/commons/collections4/trie/PatriciaTrie2Test.java
@@ -27,8 +27,8 @@ import org.apache.commons.collections4.map.AbstractOrderedMapTest;
  */
 public class PatriciaTrie2Test<V> extends AbstractOrderedMapTest<String, V> {
 
-    public PatriciaTrie2Test(final String testName) {
-        super(testName);
+    public PatriciaTrie2Test() {
+        super(PatriciaTrie2Test.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/trie/PatriciaTrieTest.java
+++ b/src/test/java/org/apache/commons/collections4/trie/PatriciaTrieTest.java
@@ -30,7 +30,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Trie;
 import org.apache.commons.collections4.map.AbstractSortedMapTest;
 import org.junit.jupiter.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * JUnit tests for the PatriciaTrie.
@@ -39,8 +39,8 @@ import org.junit.Test;
  */
 public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
 
-    public PatriciaTrieTest(final String testName) {
-        super(testName);
+    public PatriciaTrieTest() {
+        super(PatriciaTrieTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {

--- a/src/test/java/org/apache/commons/collections4/trie/UnmodifiableTrieTest.java
+++ b/src/test/java/org/apache/commons/collections4/trie/UnmodifiableTrieTest.java
@@ -22,7 +22,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Trie;
 import org.apache.commons.collections4.Unmodifiable;
 import org.apache.commons.collections4.map.AbstractSortedMapTest;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSortedMapTest} for exercising the
@@ -32,8 +32,8 @@ import org.junit.Test;
  */
 public class UnmodifiableTrieTest<V> extends AbstractSortedMapTest<String, V> {
 
-    public UnmodifiableTrieTest(final String testName) {
-        super(testName);
+    public UnmodifiableTrieTest() {
+        super(UnmodifiableTrieTest.class.getSimpleName());
     }
 
     public static junit.framework.Test suite() {


### PR DESCRIPTION
**Jira:** https://issues.apache.org/jira/browse/COLLECTIONS-807

**Description:** COLLECTIONS-807 is a subtask of the main task [COLLECTIONS-777-Fully migrate to JUnit 5](https://issues.apache.org/jira/browse/COLLECTIONS-777)

**Subtask COLLECTIONS-807 description:**  Upgrade org.junit.Test to org.junit.jupiter.api.Test

**Major Changes**
1. pom.xml
Added the dependency _junit-jupiter-params_ in order to fix the parameterized test case issues after upgrading the Test annotation in the classes AbstractPropertiesFactoryTest.java, SortedPropertiesFactoryTest.java, PropertiesFactoryTest.java
```
<dependency>
  <groupId>org.junit.jupiter</groupId>
  <artifactId>junit-jupiter-params</artifactId>
  <version>${commons.junit.version}</version>
  <scope>test</scope>
</dependency>
```

2. Annotated setup() methods with @BeforeEach annotation
Example:
```
@Override
public void setUp() {
    testList = new ArrayList<>();
    testList.addAll(Arrays.asList(testArray));
}
```
Rewritten to
```
@BeforeEach
public void setUp() {
    testList = new ArrayList<>();
    testList.addAll(Arrays.asList(testArray));
}
```

3. Removed the String parameter testName from all the Junit test classes.
Reason: Junit below 5 was supporting the constructor to have a String parameter, which will be injected with the current Display name of the test case being run. This is no more supported in JUnit 5. Since JUnit 5, a constructor with arguments is considered to as a Parameterized test case. To remove the test execution issue after upgrading the annotation, removed the parameter from constructor, instead pass the current class name (which is equal to the test case name) to the super classes.

```
public BooleanComparatorTest(String testName) {
    super(testName);
}
```

Rewritten as

```
public BooleanComparatorTest() {
    super(BooleanComparatorTest.class.getSimpleName());
}
```