### PR TITLE
[COLLECTIONS-812] Open both streams with try-with-resources, and assert that only the text is the same, not the time

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -94,6 +94,9 @@
     <action issue="COLLECTIONS-802" type="fix" dev="kinow" due-to="samabcde, Ben Manes">
       ReferenceMap iterator remove violates contract #300.
     </action>
+    <action issue="COLLECTIONS-812" type="fix" dev="kinow" due-to="Ng Tsz Sum">
+      Fix flaky EmptyPropertiesTest#testSave.
+    </action>
     <!-- ADD -->
     <action issue="COLLECTIONS-760" dev="kinow" type="add" due-to="Isira Seneviratne">
       Add tests for MapUtils.


### PR DESCRIPTION
This fixes the unit test that failed intermittently in GH Actions.