### PR TITLE
COLLECTIONS-770 When creating an iterator chain containing other iterator chains flatten the resulting internal object.

### DIFF
--- a/src/main/java/org/apache/commons/collections4/iterators/UnmodifiableIterator.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/UnmodifiableIterator.java
@@ -18,6 +18,7 @@ package org.apache.commons.collections4.iterators;
 
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.apache.commons.collections4.Unmodifiable;
 
@@ -34,6 +35,16 @@ public final class UnmodifiableIterator<E> implements Iterator<E>, Unmodifiable 
 
     /** The iterator being decorated */
     private final Iterator<? extends E> iterator;
+
+    /**
+     * Obtain an Optional holding the nested IteratorChain, if it exists.
+     * @return Optional holding the iterator if it is an IteratorChain.
+     */
+    Optional<IteratorChain<? extends E>> getIteratorChain() {
+      return Optional.ofNullable(iterator instanceof IteratorChain
+                                     ? (IteratorChain<? extends E>)iterator
+                                     : null);
+    }
 
     /**
      * Decorates the specified iterator such that it cannot be modified.


### PR DESCRIPTION
Contributed on behalf of the @opencastsoftware open source team

I am slightly wary of opening up UnmodifiableIterator, but this seems to solve the performance degradation of nested IteratorChains seen in COLLECTIONS-770

