### PR TITLE
COLLECTIONS-823: Modified ArrayCountingBloomFilter.forEachBitMap to be more efficient

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bloomfilter/ArrayCountingBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/ArrayCountingBloomFilter.java
@@ -234,7 +234,7 @@ public final class ArrayCountingBloomFilter implements CountingBloomFilter {
         int blocksm1 = BitMap.numberOfBitMaps(shape.getNumberOfBits()) - 1;
         int i = 0;
         long value;
-        // must break final block separate as the the number of bits may not fall on the long boundary
+        // must break final block separate as the number of bits may not fall on the long boundary
         for (int j = 0; j < blocksm1; j++) {
             value = 0;
             for (int k = 0; k < Long.SIZE; k++) {

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/ArrayCountingBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/ArrayCountingBloomFilter.java
@@ -231,7 +231,7 @@ public final class ArrayCountingBloomFilter implements CountingBloomFilter {
     @Override
     public boolean forEachBitMap(LongPredicate consumer) {
         Objects.requireNonNull(consumer, "consumer");
-        int blocksm1 = BitMap.numberOfBitMaps(shape.getNumberOfBits()) - 1;
+        final int blocksm1 = BitMap.numberOfBitMaps(counts.length) - 1;
         int i = 0;
         long value;
         // must break final block separate as the number of bits may not fall on the long boundary


### PR DESCRIPTION
Resolves https://issues.apache.org/jira/projects/COLLECTIONS/issues/COLLECTIONS-823

Modifies `ArrayCountingBloomFilter.forEachBitmap()` to be more efficient. by not creating an array of longs but building each long and calling the consumer in turn.