### PR TITLE
Implemented clear() for COLLECTIONS-831

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bloomfilter/ArrayCountingBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/ArrayCountingBloomFilter.java
@@ -109,7 +109,7 @@ public final class ArrayCountingBloomFilter implements CountingBloomFilter {
     public void clear() {
         Arrays.fill(counts, 0);
     }
-    
+
     @Override
     public ArrayCountingBloomFilter copy() {
         return new ArrayCountingBloomFilter(this);

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/ArrayCountingBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/ArrayCountingBloomFilter.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.collections4.bloomfilter;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
@@ -104,6 +105,11 @@ public final class ArrayCountingBloomFilter implements CountingBloomFilter {
         this.counts = source.counts.clone();
     }
 
+    @Override
+    public void clear() {
+        Arrays.fill(counts, 0);
+    }
+    
     @Override
     public ArrayCountingBloomFilter copy() {
         return new ArrayCountingBloomFilter(this);

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/BloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/BloomFilter.java
@@ -59,7 +59,7 @@ public interface BloomFilter extends IndexProducer, BitMapProducer {
      * @return The shape the filter was built with.
      */
     Shape getShape();
-    
+
     /**
      * Resets the filter to its initial, unpopulated state.
      */

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/BloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/BloomFilter.java
@@ -66,11 +66,6 @@ public interface BloomFilter extends IndexProducer, BitMapProducer {
     void clear();
 
     /**
-     * Resets the filter to its initial, unpopulated state.
-     */
-    void clear();
-
-    /**
      * Returns {@code true} if this filter contains the specified filter.
      *
      * <p>Specifically this

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/BloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/BloomFilter.java
@@ -59,6 +59,11 @@ public interface BloomFilter extends IndexProducer, BitMapProducer {
      * @return The shape the filter was built with.
      */
     Shape getShape();
+    
+    /**
+     * Resets the filter to its initial, unpopulated state.
+     */
+    void clear();
 
     /**
      * Returns {@code true} if this filter contains the specified filter.

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
@@ -118,6 +118,12 @@ public final class SimpleBloomFilter implements BloomFilter {
     }
 
     @Override
+    public void clear() {
+        Arrays.fill(bitMap, 0L);
+        cardinality = 0;
+    }
+    
+    @Override
     public long[] asBitMapArray() {
         return Arrays.copyOf(bitMap, bitMap.length);
     }

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/SimpleBloomFilter.java
@@ -122,7 +122,7 @@ public final class SimpleBloomFilter implements BloomFilter {
         Arrays.fill(bitMap, 0L);
         cardinality = 0;
     }
-    
+
     @Override
     public long[] asBitMapArray() {
         return Arrays.copyOf(bitMap, bitMap.length);

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/SparseBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/SparseBloomFilter.java
@@ -178,7 +178,7 @@ public final class SparseBloomFilter implements BloomFilter {
     public void clear() {
         indices.clear();
     }
-    
+
     @Override
     public Shape getShape() {
         return shape;

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/SparseBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/SparseBloomFilter.java
@@ -175,6 +175,11 @@ public final class SparseBloomFilter implements BloomFilter {
     }
 
     @Override
+    public void clear() {
+        indices.clear();
+    }
+    
+    @Override
     public Shape getShape() {
         return shape;
     }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBloomFilterTest.java
@@ -183,7 +183,7 @@ public abstract class AbstractBloomFilterTest<T extends BloomFilter> {
         BloomFilter bf1 = createFilter(getTestShape(), from1);
         assertTrue( bf1.cardinality()>0 );
         bf1.clear();
-        assertTrue( bf1.cardinality()==0);
+        assertEquals( 0, bf1.cardinality());
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBloomFilterTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.collections4.bloomfilter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -181,9 +182,9 @@ public abstract class AbstractBloomFilterTest<T extends BloomFilter> {
     @Test
     public void testClear() {
         BloomFilter bf1 = createFilter(getTestShape(), from1);
-        assertTrue( bf1.cardinality()>0 );
+        assertNotEquals( 0, bf1.cardinality() );
         bf1.clear();
-        assertTrue( bf1.cardinality()==0);
+        assertEquals( 0, bf1.cardinality());
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBloomFilterTest.java
@@ -177,7 +177,7 @@ public abstract class AbstractBloomFilterTest<T extends BloomFilter> {
         assertFalse(bf1.contains(bf4));
         assertTrue(bf4.contains(bf1));
     }
-    
+
     @Test
     public void testClear() {
         BloomFilter bf1 = createFilter(getTestShape(), from1);

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBloomFilterTest.java
@@ -186,14 +186,6 @@ public abstract class AbstractBloomFilterTest<T extends BloomFilter> {
         assertTrue( bf1.cardinality()==0);
     }
 
-    @Test
-    public void testClear() {
-        BloomFilter bf1 = createFilter(getTestShape(), from1);
-        assertTrue( bf1.cardinality()>0 );
-        bf1.clear();
-        assertEquals( 0, bf1.cardinality());
-    }
-
     /**
      * Tests that the andCardinality calculations are correct.
      *

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBloomFilterTest.java
@@ -177,6 +177,14 @@ public abstract class AbstractBloomFilterTest<T extends BloomFilter> {
         assertFalse(bf1.contains(bf4));
         assertTrue(bf4.contains(bf1));
     }
+    
+    @Test
+    public void testClear() {
+        BloomFilter bf1 = createFilter(getTestShape(), from1);
+        assertTrue( bf1.cardinality()>0 );
+        bf1.clear();
+        assertTrue( bf1.cardinality()==0);
+    }
 
     /**
      * Tests that the andCardinality calculations are correct.

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/DefaultBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/DefaultBloomFilterTest.java
@@ -113,6 +113,11 @@ public class DefaultBloomFilterTest extends AbstractBloomFilterTest<DefaultBloom
         }
 
         @Override
+        public void clear() {
+            indices.clear();
+        }
+        
+        @Override
         public boolean forEachIndex(IntPredicate consumer) {
             for (Integer i : indices) {
                 if (!consumer.test(i)) {

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/DefaultBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/DefaultBloomFilterTest.java
@@ -116,7 +116,7 @@ public class DefaultBloomFilterTest extends AbstractBloomFilterTest<DefaultBloom
         public void clear() {
             indices.clear();
         }
-        
+
         @Override
         public boolean forEachIndex(IntPredicate consumer) {
             for (Integer i : indices) {


### PR DESCRIPTION

- Defined BloomFilter.clear() to be a reset to unpopulated state.
- Modified BloomFilter implementations.
- Added test case.

Fix for COLLECTIONS-831