### PR TITLE
COLLECTIONS-814 CollectionUtils.removeAll() not throwing NPE

### DIFF
--- a/src/main/java/org/apache/commons/collections4/ListUtils.java
+++ b/src/main/java/org/apache/commons/collections4/ListUtils.java
@@ -533,6 +533,8 @@ public class ListUtils {
      * @since 3.2
      */
     public static <E> List<E> removeAll(final Collection<E> collection, final Collection<?> remove) {
+        Objects.requireNonNull(collection, "collection");
+        Objects.requireNonNull(remove, "remove");
         final List<E> list = new ArrayList<>();
         for (final E obj : collection) {
             if (!remove.contains(obj)) {

--- a/src/test/java/org/apache/commons/collections4/ListUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/ListUtilsTest.java
@@ -369,10 +369,10 @@ public class ListUtilsTest {
 
         assertThrows(NullPointerException.class, () -> ListUtils.removeAll(null, null),
                 "expecting NullPointerException");
-        
+
         assertThrows(NullPointerException.class, () -> ListUtils.removeAll(null, new ArrayList<Object>()),
                 "expecting NullPointerException");
-        
+
         assertThrows(NullPointerException.class, () -> ListUtils.removeAll(new ArrayList<Object>(), null),
                 "expecting NullPointerException");
     }

--- a/src/test/java/org/apache/commons/collections4/ListUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/ListUtilsTest.java
@@ -369,6 +369,12 @@ public class ListUtilsTest {
 
         assertThrows(NullPointerException.class, () -> ListUtils.removeAll(null, null),
                 "expecting NullPointerException");
+        
+        assertThrows(NullPointerException.class, () -> ListUtils.removeAll(null, new ArrayList<Object>()),
+                "expecting NullPointerException");
+        
+        assertThrows(NullPointerException.class, () -> ListUtils.removeAll(new ArrayList<Object>(), null),
+                "expecting NullPointerException");
     }
 
     @Test


### PR DESCRIPTION
[COLLECTIONS-814](https://issues.apache.org/jira/browse/COLLECTIONS-814)
CollectionUtils.removeAll() not throwing proper NullPointerException(NPE) if the first parameter is empty

Add null check in ListUtil.removeAll()