### PR TITLE
Fix flaky test occurred in 'CollectionBagTest.testCollectionToArray2'

### DIFF
--- a/src/test/java/org/apache/commons/collections4/bag/CollectionBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/CollectionBagTest.java
@@ -76,6 +76,11 @@ public class CollectionBagTest<T> extends AbstractCollectionTest<T> {
         return "4";
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
 //    public void testCreate() throws Exception {
 //        resetEmpty();
 //        writeExternalFormToDisk((java.io.Serializable) getCollection(), "src/test/resources/data/test/CollectionBag.emptyCollection.version4.obj");

--- a/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
@@ -45,7 +45,6 @@ public class HashBagTest<T> extends AbstractBagTest<T> {
         return "4";
     }
 
-    
     @Override
     protected int getIterationBehaviour() {
         return UNORDERED;

--- a/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
@@ -45,6 +45,11 @@ public class HashBagTest<T> extends AbstractBagTest<T> {
         return "4";
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
 //    public void testCreate() throws Exception {
 //        Bag<T> bag = makeObject();
 //        writeExternalFormToDisk((java.io.Serializable) bag, "src/test/resources/data/test/HashBag.emptyCollection.version4.obj");

--- a/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
@@ -45,6 +45,7 @@ public class HashBagTest<T> extends AbstractBagTest<T> {
         return "4";
     }
 
+    
     @Override
     protected int getIterationBehaviour() {
         return UNORDERED;

--- a/src/test/java/org/apache/commons/collections4/bag/PredicatedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/PredicatedBagTest.java
@@ -61,6 +61,11 @@ public class PredicatedBagTest<T> extends AbstractBagTest<T> {
         return decorateBag(new HashBag<T>(), stringPredicate());
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     public void testlegalAddRemove() {

--- a/src/test/java/org/apache/commons/collections4/bag/TransformedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/TransformedBagTest.java
@@ -46,6 +46,11 @@ public class TransformedBagTest<T> extends AbstractBagTest<T> {
                 (Transformer<T, T>) TransformedCollectionTest.NOOP_TRANSFORMER);
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     public void testTransformedBag() {

--- a/src/test/java/org/apache/commons/collections4/bag/UnmodifiableBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/UnmodifiableBagTest.java
@@ -74,6 +74,11 @@ public class UnmodifiableBagTest<E> extends AbstractBagTest<E> {
         return false;
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
     @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractBidiMapTest.java
@@ -464,6 +464,10 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
             return main.isRemoveSupported();
         }
 
+        @Override
+        protected int getIterationBehaviour() {
+            return main.getIterationBehaviour();
+        }
     }
 
     public BulkTest bulkTestBidiMapIterator() {

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualHashBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualHashBidiMapTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4.bidimap;
 
 import org.apache.commons.collections4.BulkTest;
+import org.apache.commons.collections4.collection.AbstractCollectionTest;
 
 /**
  * JUnit tests.
@@ -49,7 +50,7 @@ public class DualHashBidiMapTest<K, V> extends AbstractBidiMapTest<K, V> {
 
     @Override
     protected int getIterationBehaviour() {
-        return UNORDERED;
+        return AbstractCollectionTest.UNORDERED;
     }
 
 //    public void testCreate() throws Exception {

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualHashBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualHashBidiMapTest.java
@@ -47,6 +47,11 @@ public class DualHashBidiMapTest<K, V> extends AbstractBidiMapTest<K, V> {
         return new String[] { "DualHashBidiMapTest.bulkTestInverseMap.bulkTestInverseMap" };
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
 //    public void testCreate() throws Exception {
 //        resetEmpty();
 //        writeExternalFormToDisk((java.io.Serializable) map, "src/test/resources/data/test/DualHashBidiMap.emptyCollection.version4.obj");

--- a/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableBidiMapTest.java
@@ -79,6 +79,11 @@ public class UnmodifiableBidiMapTest<K, V> extends AbstractBidiMapTest<K, V> {
         return false;
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
     @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);

--- a/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableBidiMapTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.commons.collections4.BidiMap;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.Unmodifiable;
+import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -81,7 +82,7 @@ public class UnmodifiableBidiMapTest<K, V> extends AbstractBidiMapTest<K, V> {
 
     @Override
     protected int getIterationBehaviour() {
-        return UNORDERED;
+        return AbstractCollectionTest.UNORDERED;
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
@@ -147,7 +147,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
      * then the behaviour is assumed to be ordered and the output order of the iterator is matched by
      * the toArray method.
      */
-    protected static final int UNORDERED = 0x1;
+    public static final int UNORDERED = 0x1;
 
     // These fields are used by reset() and verify(), and any test
     // method that tests a modification.

--- a/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
@@ -63,6 +63,13 @@ import org.junit.jupiter.api.Test;
  * <li>{@link #getOtherValues()}
  * </ul>
  *
+ * <b>Indicate Map Behaviour</b>
+ * <p>
+ * Override these if your map makes specific behaviour guarantees:
+ * <ul>
+ * <li>{@link #getIterationBehaviour()}</li>
+ * </ul>
+ *
  * <b>Supported Operation Methods</b>
  * <p>
  * Override these methods if your map doesn't support certain operations:
@@ -133,6 +140,13 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         final String str = System.getProperty("java.version");
         JDK12 = str.startsWith("1.2");
     }
+
+    /**
+     * Flag to indicate the collection makes no ordering guarantees for the iterator. If this is not used
+     * then the behaviour is assumed to be ordered and the output order of the iterator is matched by
+     * the toArray method.
+     */
+    protected static final int UNORDERED = 0x1;
 
     // These instance variables are initialized with the reset method.
     // Tests for map methods that alter the map (put, putAll, remove)
@@ -522,6 +536,18 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
                     values[i] != newValues[i]
                             && (values[i] == null || !values[i].equals(newValues[i])));
         }
+    }
+
+    /**
+     * Return a flag specifying the iteration behaviour of the collection.
+     * This is used to change the assertions used by specific tests.
+     * The default implementation returns 0 which indicates ordered iteration behaviour.
+     *
+     * @return the iteration behaviour
+     * @see #UNORDERED
+     */
+    protected int getIterationBehaviour(){
+        return 0;
     }
 
     // tests begin here.  Each test adds a little bit of tested functionality.
@@ -1619,6 +1645,11 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
             TestMapEntrySet.this.setConfirmed(AbstractMapTest.this.getConfirmed().entrySet());
         }
 
+        @Override
+        protected int getIterationBehaviour(){
+            return AbstractMapTest.this.getIterationBehaviour();
+        }
+
         @Test
         public void testMapEntrySetIteratorEntry() {
             resetFull();
@@ -1801,6 +1832,12 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
             super.verify();
             AbstractMapTest.this.verify();
         }
+
+        @Override
+        protected int getIterationBehaviour(){
+            return AbstractMapTest.this.getIterationBehaviour();
+        }
+
     }
 
     /**
@@ -1898,6 +1935,11 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         public void verify() {
             super.verify();
             AbstractMapTest.this.verify();
+        }
+
+        @Override
+        protected int getIterationBehaviour(){
+            return AbstractMapTest.this.getIterationBehaviour();
         }
 
         // TODO: should test that a remove on the values collection view

--- a/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
@@ -141,13 +141,6 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         JDK12 = str.startsWith("1.2");
     }
 
-    /**
-     * Flag to indicate the collection makes no ordering guarantees for the iterator. If this is not used
-     * then the behaviour is assumed to be ordered and the output order of the iterator is matched by
-     * the toArray method.
-     */
-    protected static final int UNORDERED = 0x1;
-
     // These instance variables are initialized with the reset method.
     // Tests for map methods that alter the map (put, putAll, remove)
     // first call reset() to create the map and its views; then perform
@@ -544,7 +537,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
      * The default implementation returns 0 which indicates ordered iteration behaviour.
      *
      * @return the iteration behaviour
-     * @see #UNORDERED
+     * @see AbstractCollectionTest#UNORDERED
      */
     protected int getIterationBehaviour(){
         return 0;

--- a/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.collections4.BulkTest;
+import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.map.PassiveExpiringMap.ExpirationPolicy;
 import org.junit.jupiter.api.Test;
 
@@ -93,7 +94,7 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
 
     @Override
     protected int getIterationBehaviour() {
-        return UNORDERED;
+        return AbstractCollectionTest.UNORDERED;
     }
 
     private Map<Integer, String> makeTestMap() {

--- a/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
@@ -91,6 +91,11 @@ public class PassiveExpiringMapTest<K, V> extends AbstractMapTest<K, V> {
         return new PassiveExpiringMap<>();
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
     private Map<Integer, String> makeTestMap() {
         final Map<Integer, String> m =
                 new PassiveExpiringMap<>(new TestExpirationPolicy());

--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -60,6 +60,13 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
     /** MultiValuedHashMap created by reset(). */
     protected MultiValuedMap<K, V> confirmed;
 
+    /**
+     * Flag to indicate the map makes no ordering guarantees for the iterator. If this is not used
+     * then the behaviour is assumed to be ordered and the output order of the iterator is matched by
+     * the toArray method.
+     */
+    protected static final int UNORDERED = 0x1;
+
     public AbstractMultiValuedMapTest(final String testName) {
         super(testName);
     }
@@ -217,7 +224,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
      * The default implementation returns 0 which indicates ordered iteration behaviour.
      *
      * @return the iteration behaviour
-     * @see AbstractCollectionTest#UNORDERED
+     * @see #UNORDERED
      */
     protected int getIterationBehaviour() {
         return 0;

--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -60,13 +60,6 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
     /** MultiValuedHashMap created by reset(). */
     protected MultiValuedMap<K, V> confirmed;
 
-    /**
-     * Flag to indicate the map makes no ordering guarantees for the iterator. If this is not used
-     * then the behaviour is assumed to be ordered and the output order of the iterator is matched by
-     * the toArray method.
-     */
-    protected static final int UNORDERED = 0x1;
-
     public AbstractMultiValuedMapTest(final String testName) {
         super(testName);
     }
@@ -224,9 +217,9 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
      * The default implementation returns 0 which indicates ordered iteration behaviour.
      *
      * @return the iteration behaviour
-     * @see #UNORDERED
+     * @see AbstractCollectionTest#UNORDERED
      */
-    protected int getIterationBehaviour(){
+    protected int getIterationBehaviour() {
         return 0;
     }
 
@@ -973,7 +966,6 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
             return null;
         }
 
-
         @Override
         protected int getIterationBehaviour() {
             return AbstractMultiValuedMapTest.this.getIterationBehaviour();
@@ -1038,7 +1030,6 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         protected int getIterationBehaviour() {
             return AbstractMultiValuedMapTest.this.getIterationBehaviour();
         }
-
     }
 
     /**
@@ -1124,7 +1115,6 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         protected int getIterationBehaviour() {
             return AbstractMultiValuedMapTest.this.getIterationBehaviour();
         }
-
     }
 
     /**
@@ -1199,7 +1189,6 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         protected int getIterationBehaviour() {
             return AbstractMultiValuedMapTest.this.getIterationBehaviour();
         }
-
     }
 
     public BulkTest bulkTestAsMap() {
@@ -1302,7 +1291,6 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         protected int getIterationBehaviour() {
             return AbstractMultiValuedMapTest.this.getIterationBehaviour();
         }
-
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -60,12 +60,6 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
     /** MultiValuedHashMap created by reset(). */
     protected MultiValuedMap<K, V> confirmed;
 
-    /**
-     * Flag to indicate the map makes no ordering guarantees for the iterator. If this is not used
-     * then the behaviour is assumed to be ordered and the output order of the iterator is matched by
-     * the toArray method.
-     */
-    protected static final int UNORDERED = 0x1;
 
     public AbstractMultiValuedMapTest(final String testName) {
         super(testName);
@@ -224,7 +218,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
      * The default implementation returns 0 which indicates ordered iteration behaviour.
      *
      * @return the iteration behaviour
-     * @see #UNORDERED
+     * @see AbstractCollectionTest#UNORDERED
      */
     protected int getIterationBehaviour() {
         return 0;

--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -60,6 +60,13 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
     /** MultiValuedHashMap created by reset(). */
     protected MultiValuedMap<K, V> confirmed;
 
+    /**
+     * Flag to indicate the map makes no ordering guarantees for the iterator. If this is not used
+     * then the behaviour is assumed to be ordered and the output order of the iterator is matched by
+     * the toArray method.
+     */
+    protected static final int UNORDERED = 0x1;
+
     public AbstractMultiValuedMapTest(final String testName) {
         super(testName);
     }
@@ -209,6 +216,18 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         for (int i = 0; i < k.length; i++) {
             confirmed.put(k[i], v[i]);
         }
+    }
+
+    /**
+     * Return a flag specifying the iteration behaviour of the map.
+     * This is used to change the assertions used by specific tests.
+     * The default implementation returns 0 which indicates ordered iteration behaviour.
+     *
+     * @return the iteration behaviour
+     * @see #UNORDERED
+     */
+    protected int getIterationBehaviour(){
+        return 0;
     }
 
     @Test
@@ -954,6 +973,12 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
             return null;
         }
 
+
+        @Override
+        protected int getIterationBehaviour() {
+            return AbstractMultiValuedMapTest.this.getIterationBehaviour();
+        }
+
     }
 
     /**
@@ -1007,6 +1032,11 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         @Override
         public boolean isTestSerialization() {
             return false;
+        }
+
+        @Override
+        protected int getIterationBehaviour() {
+            return AbstractMultiValuedMapTest.this.getIterationBehaviour();
         }
 
     }
@@ -1090,6 +1120,11 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
             return null;
         }
 
+        @Override
+        protected int getIterationBehaviour() {
+            return AbstractMultiValuedMapTest.this.getIterationBehaviour();
+        }
+
     }
 
     /**
@@ -1158,6 +1193,11 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
             AbstractMultiValuedMapTest.this.resetEmpty();
             setCollection(AbstractMultiValuedMapTest.this.getMap().keys());
             TestMultiValuedMapKeys.this.setConfirmed(AbstractMultiValuedMapTest.this.getConfirmed().keys());
+        }
+
+        @Override
+        protected int getIterationBehaviour() {
+            return AbstractMultiValuedMapTest.this.getIterationBehaviour();
         }
 
     }
@@ -1257,6 +1297,12 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         public boolean isTestSerialization() {
             return false;
         }
+
+        @Override
+        protected int getIterationBehaviour() {
+            return AbstractMultiValuedMapTest.this.getIterationBehaviour();
+        }
+
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/multimap/ArrayListValuedHashMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/ArrayListValuedHashMapTest.java
@@ -48,6 +48,11 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
         return new ArrayListValuedHashMap<>();
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     public void testListValuedMapAdd() {

--- a/src/test/java/org/apache/commons/collections4/multimap/ArrayListValuedHashMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/ArrayListValuedHashMapTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.ListValuedMap;
 import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -50,7 +51,7 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
 
     @Override
     protected int getIterationBehaviour() {
-        return UNORDERED;
+        return AbstractCollectionTest.UNORDERED;
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/multimap/HashSetValuedHashMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/HashSetValuedHashMapTest.java
@@ -56,6 +56,11 @@ public class HashSetValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest<K
         return true;
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     public void testSetValuedMapAdd() {

--- a/src/test/java/org/apache/commons/collections4/multimap/HashSetValuedHashMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/HashSetValuedHashMapTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.SetValuedMap;
+import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -58,7 +59,7 @@ public class HashSetValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest<K
 
     @Override
     protected int getIterationBehaviour() {
-        return UNORDERED;
+        return AbstractCollectionTest.UNORDERED;
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
@@ -46,6 +46,11 @@ public class TransformedMultiValuedMapTest<K, V> extends AbstractMultiValuedMapT
                 TransformerUtils.<K>nopTransformer(), TransformerUtils.<V>nopTransformer());
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     public void testKeyTransformedMap() {

--- a/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
@@ -22,6 +22,7 @@ import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.TransformerUtils;
+import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +49,7 @@ public class TransformedMultiValuedMapTest<K, V> extends AbstractMultiValuedMapT
 
     @Override
     protected int getIterationBehaviour() {
-        return UNORDERED;
+        return AbstractCollectionTest.UNORDERED;
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/multimap/UnmodifiableMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/UnmodifiableMultiValuedMapTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.MultiSet;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.Unmodifiable;
+import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -84,7 +85,7 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
 
     @Override
     protected int getIterationBehaviour() {
-        return UNORDERED;
+        return AbstractCollectionTest.UNORDERED;
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/multimap/UnmodifiableMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/UnmodifiableMultiValuedMapTest.java
@@ -82,6 +82,11 @@ public class UnmodifiableMultiValuedMapTest<K, V> extends AbstractMultiValuedMap
         return UnmodifiableMultiValuedMap.<K, V>unmodifiableMultiValuedMap(map);
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
     @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);

--- a/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
@@ -687,6 +687,12 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         public void verify() {
             super.verify();
         }
+
+        @Override
+        protected int getIterationBehaviour() {
+            return AbstractMultiSetTest.this.getIterationBehaviour();
+        }
+
     }
 
 

--- a/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
@@ -692,7 +692,6 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         protected int getIterationBehaviour() {
             return AbstractMultiSetTest.this.getIterationBehaviour();
         }
-
     }
 
 

--- a/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
@@ -46,6 +46,11 @@ public class HashMultiSetTest<T> extends AbstractMultiSetTest<T> {
         return "4.1";
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
 //    public void testCreate() throws Exception {
 //        MultiSet<T> multiset = makeObject();
 //        writeExternalFormToDisk((java.io.Serializable) multiset, "src/test/resources/data/test/HashMultiSet.emptyCollection.version4.1.obj");

--- a/src/test/java/org/apache/commons/collections4/multiset/PredicatedMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/PredicatedMultiSetTest.java
@@ -61,6 +61,11 @@ public class PredicatedMultiSetTest<T> extends AbstractMultiSetTest<T> {
         return decorateMultiSet(new HashMultiSet<T>(), stringPredicate());
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     public void testLegalAddRemove() {

--- a/src/test/java/org/apache/commons/collections4/multiset/SynchronizedMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/SynchronizedMultiSetTest.java
@@ -46,6 +46,11 @@ public class SynchronizedMultiSetTest<T> extends AbstractMultiSetTest<T> {
         return "4.1";
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
 //    public void testCreate() throws Exception {
 //        MultiSet<T> multiset = makeObject();
 //        writeExternalFormToDisk((java.io.Serializable) multiset, "src/test/resources/data/test/SynchronizedMultiSet.emptyCollection.version4.1.obj");

--- a/src/test/java/org/apache/commons/collections4/multiset/UnmodifiableMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/UnmodifiableMultiSetTest.java
@@ -73,6 +73,11 @@ public class UnmodifiableMultiSetTest<E> extends AbstractMultiSetTest<E> {
         return false;
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
     @Test
     public void testUnmodifiable() {
         assertTrue(makeObject() instanceof Unmodifiable);

--- a/src/test/java/org/apache/commons/collections4/set/CompositeSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/CompositeSetTest.java
@@ -191,6 +191,11 @@ public class CompositeSetTest<E> extends AbstractSetTest<E> {
         return "4";
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
 //    public void testCreate() throws Exception {
 //        resetEmpty();
 //        writeExternalFormToDisk((java.io.Serializable) getCollection(), "src/test/resources/data/test/CompositeSet.emptyCollection.version4.obj");

--- a/src/test/java/org/apache/commons/collections4/set/PredicatedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/PredicatedSetTest.java
@@ -99,6 +99,11 @@ public class PredicatedSetTest<E> extends AbstractSetTest<E> {
         return "4";
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
 //    public void testCreate() throws Exception {
 //        resetEmpty();
 //        writeExternalFormToDisk((java.io.Serializable) getCollection(), "src/test/resources/data/test/PredicatedSet.emptyCollection.version4.obj");

--- a/src/test/java/org/apache/commons/collections4/set/TransformedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/TransformedSetTest.java
@@ -102,6 +102,11 @@ public class TransformedSetTest<E> extends AbstractSetTest<E> {
         return "4";
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
 //    public void testCreate() throws Exception {
 //        resetEmpty();
 //        writeExternalFormToDisk((java.io.Serializable) getCollection(), "src/test/resources/data/test/TransformedSet.emptyCollection.version4.obj");

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableSetTest.java
@@ -82,6 +82,11 @@ public class UnmodifiableSetTest<E> extends AbstractSetTest<E> {
         return "4";
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
 //    public void testCreate() throws Exception {
 //        resetEmpty();
 //        writeExternalFormToDisk((java.io.Serializable) getCollection(), "src/test/resources/data/test/UnmodifiableSet.emptyCollection.version4.obj");


### PR DESCRIPTION
### What is the purpose of this PR

- This PR fixes the flaky test  `org.apache.commons.collections4.bag.CollectionBagTest.testCollectionToArray2`
- The mentioned test may fail or pass without changes made to the source code when it is run in different JVMs due to `HashMap`'s non-deterministic iteration order.

### Why the test fails
- As the `CollectionBagTest` uses `HashBag` as its `collection` which uses `HashMap` internally and as per `Java 8` documentation, the ordering of `HashMap` is not constant, so assigning the same hashmap as an array to different objects can change the ordering. So when comparing these two arrays with `assertEquals` the test may fail as their ordering can be different.

### Reproduce the test failure
- Run the test with 'NonDex' maven plugin. The command to recreate the flaky test failure is 
  ` mvn -pl . edu.illinois:nondex-maven-plugin:1.1.2:nondex -debug -Dtest=org.apache.commons.collections4.bag.CollectionBagTest#testCollectionToArray2`

- Fixing the flaky test now may prevent flaky test failures in future Java versions.

### Expected result
- The tests should run successfully when run with 'NonDex' maven with the same command for recreating the flaky test.

### Actual Result
- We get the failure:
    `[ERROR] org.apache.commons.collections4.bag.CollectionBagTest.testCollectionToArray2  Time elapsed: 0.025 s  <<< FAILURE! junit.framework.AssertionFailedError: toArrays should be equal expected:<[10, 6.0, 11, 4, Seven, Eight, 5.0, 15, 2, 12, 16, Thirteen, null, , Three, Nine, One, One, 14]> but was:<[, null, Seven, 2, 5.0, 12, 10, 11, 14, 16, One, One, Nine, Eight, Thirteen, 15, 4, 6.0, Three]>
`
### Fix
- Override the `getIterationBehaviour()' method from `AbstractCollectionTest` and return `UNORDERED` in `CollectionBagTest`.