### PR TITLE
Fix flaky test in CollectionUtilsTest.Java

### DIFF
--- a/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
@@ -687,7 +687,9 @@ public class CollectionUtilsTest extends MockTestCase {
         assertEquals(2, CollectionUtils.get((Object) collectionA, 2));
         assertEquals(2, CollectionUtils.get((Object) collectionA.iterator(), 2));
         final Map<Integer, Integer> map = CollectionUtils.getCardinalityMap(collectionA);
-        assertEquals(map.entrySet().iterator().next(), CollectionUtils.get((Object) map, 0));
+        Map<Integer, Integer> linkedMap = new LinkedHashMap<>();
+        linkedMap.putAll(map);
+        assertEquals(linkedMap.entrySet().iterator().next(), CollectionUtils.get((Object) linkedMap, 0));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
@@ -687,7 +687,8 @@ public class CollectionUtilsTest extends MockTestCase {
         assertEquals(2, CollectionUtils.get((Object) collectionA, 2));
         assertEquals(2, CollectionUtils.get((Object) collectionA.iterator(), 2));
         final Map<Integer, Integer> map = CollectionUtils.getCardinalityMap(collectionA);
-        Map<Integer, Integer> linkedMap = new LinkedHashMap<>();
+        // Test assumes a defined iteration order so convert to a LinkedHashMap
+        final Map<Integer, Integer> linkedMap = new LinkedHashMap<>();
         linkedMap.putAll(map);
         assertEquals(linkedMap.entrySet().iterator().next(), CollectionUtils.get((Object) linkedMap, 0));
     }


### PR DESCRIPTION
The test below in `CollectionUtilsTest.java` was found flaky because of the ordering of result HashMap. The orders of elements in the HashMap are not the same as every time the test being called. In this case, LinkedHashMap was applied to ensure the orders do not cause the flakiness. This code change is trying to fix the [flaky tests](https://docs.gitlab.com/ee/development/testing_guide/flaky_tests.html) mentioned above, because they sometimes fail (as the picture showed) and sometimes pass. The failure could be reproduced by the commands above by using the tool of [NonDex](https://github.com/TestingResearchIllinois/NonDex). The code change is to make sure the tests will always pass in this case.

- `org.apache.commons.collections4.CollectionUtilsTest.get`

The test failures could be reproduced by

1. `mvn install -pl . -am -DskipTests`
2.  run tests with NonDex 
    `mvn -pl . edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.apache.commons.collections4.CollectionUtilsTest#get`
<img width="896" alt="2" src="https://user-images.githubusercontent.com/61256379/200490788-027fa163-7ec5-43cd-9b0f-093bd359c0e9.png">
<img width="890" alt="3" src="https://user-images.githubusercontent.com/61256379/200490798-5413f162-637d-43e5-b9da-3ae766924046.png">