### PR TITLE
[COLLECTIONS-839] migrate Map tests to use junit5 assert

### DIFF
--- a/src/test/java/org/apache/commons/collections4/AbstractArrayListTest.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractArrayListTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 
@@ -41,8 +43,8 @@ public abstract class AbstractArrayListTest<E> extends AbstractListTest<E> {
     @Test
     public void testNewArrayList() {
         final ArrayList<E> list = makeObject();
-        assertTrue("New list is empty", list.isEmpty());
-        assertEquals("New list has size zero", 0, list.size());
+        assertTrue(list.isEmpty(), "New list is empty");
+        assertEquals(0, list.size(), "New list has size zero");
 
         assertThrows(IndexOutOfBoundsException.class, () -> list.get(1));
     }
@@ -53,8 +55,8 @@ public abstract class AbstractArrayListTest<E> extends AbstractListTest<E> {
         final ArrayList<E> list = makeObject();
         list.add((E) "First Item");
         list.add((E) "Last Item");
-        assertEquals("First item is 'First Item'", "First Item", list.get(0));
-        assertEquals("Last Item is 'Last Item'", "Last Item", list.get(1));
+        assertEquals("First Item", list.get(0), "First item is 'First Item'");
+        assertEquals("Last Item", list.get(1), "Last Item is 'Last Item'");
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/AbstractLinkedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractLinkedListTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.collections4;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
@@ -122,8 +123,8 @@ public abstract class AbstractLinkedListTest<T> extends AbstractListTest<T> {
         resetFull();
         final Object first = getCollection().getFirst();
         final Object confirmedFirst = getConfirmedLinkedList().getFirst();
-        assertEquals("Result returned by getFirst() was wrong.",
-                confirmedFirst, first);
+        assertEquals(confirmedFirst, first,
+                "Result returned by getFirst() was wrong.");
         verify();
     }
 
@@ -140,8 +141,8 @@ public abstract class AbstractLinkedListTest<T> extends AbstractListTest<T> {
         resetFull();
         final Object last = getCollection().getLast();
         final Object confirmedLast = getConfirmedLinkedList().getLast();
-        assertEquals("Result returned by getLast() was wrong.",
-                confirmedLast, last);
+        assertEquals(confirmedLast, last,
+                "Result returned by getLast() was wrong.");
         verify();
     }
 
@@ -162,8 +163,8 @@ public abstract class AbstractLinkedListTest<T> extends AbstractListTest<T> {
         resetFull();
         final Object first = getCollection().removeFirst();
         final Object confirmedFirst = getConfirmedLinkedList().removeFirst();
-        assertEquals("Result returned by removeFirst() was wrong.",
-                confirmedFirst, first);
+        assertEquals(confirmedFirst, first,
+                "Result returned by removeFirst() was wrong.");
         verify();
     }
 
@@ -184,8 +185,8 @@ public abstract class AbstractLinkedListTest<T> extends AbstractListTest<T> {
         resetFull();
         final Object last = getCollection().removeLast();
         final Object confirmedLast = getConfirmedLinkedList().removeLast();
-        assertEquals("Result returned by removeLast() was wrong.",
-                confirmedLast, last);
+        assertEquals(confirmedLast, last,
+                "Result returned by removeLast() was wrong.");
         verify();
     }
 

--- a/src/test/java/org/apache/commons/collections4/AbstractObjectTest.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractObjectTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -102,7 +106,7 @@ public abstract class AbstractObjectTest extends BulkTest {
     @Test
     public void testObjectEqualsSelf() {
         final Object obj = makeObject();
-        assertEquals("A Object should equal itself", obj, obj);
+        assertEquals(obj, obj, "A Object should equal itself");
     }
 
     @Test
@@ -114,7 +118,7 @@ public abstract class AbstractObjectTest extends BulkTest {
     @Test
     public void testObjectHashCodeEqualsSelfHashCode() {
         final Object obj = makeObject();
-        assertEquals("hashCode should be repeatable", obj.hashCode(), obj.hashCode());
+        assertEquals(obj.hashCode(), obj.hashCode(), "hashCode should be repeatable");
     }
 
     @Test
@@ -122,15 +126,15 @@ public abstract class AbstractObjectTest extends BulkTest {
         final Object obj1 = makeObject();
         if (obj1.equals(obj1)) {
             assertEquals(
-                "[1] When two objects are equal, their hashCodes should be also.",
-                obj1.hashCode(), obj1.hashCode());
+                    obj1.hashCode(), obj1.hashCode(),
+                    "[1] When two objects are equal, their hashCodes should be also.");
         }
         final Object obj2 = makeObject();
         if (obj1.equals(obj2)) {
             assertEquals(
-                "[2] When two objects are equal, their hashCodes should be also.",
-                obj1.hashCode(), obj2.hashCode());
-            assertEquals("When obj1.equals(obj2) is true, then obj2.equals(obj1) should also be true", obj2, obj1);
+                    obj1.hashCode(), obj2.hashCode(),
+                    "[2] When two objects are equal, their hashCodes should be also.");
+            assertEquals(obj2, obj1, "When obj1.equals(obj2) is true, then obj2.equals(obj1) should also be true");
         }
     }
 
@@ -153,7 +157,7 @@ public abstract class AbstractObjectTest extends BulkTest {
         if (obj instanceof Serializable && isTestSerialization()) {
             final Object dest = serializeDeserialize(obj);
             if (isEqualsCheckable()) {
-                assertEquals("obj != deserialize(serialize(obj))", obj, dest);
+                assertEquals(obj, dest, "obj != deserialize(serialize(obj))");
             }
         }
     }
@@ -186,8 +190,8 @@ public abstract class AbstractObjectTest extends BulkTest {
             if (object instanceof Serializable) {
                 final String name = getCanonicalEmptyCollectionName(object);
                 assertTrue(
-                    "Canonical empty collection (" + name + ") is not in SCM",
-                    new File(name).exists());
+                        new File(name).exists(),
+                        "Canonical empty collection (" + name + ") is not in SCM");
             }
         }
     }
@@ -203,8 +207,8 @@ public abstract class AbstractObjectTest extends BulkTest {
             if (object instanceof Serializable) {
                 final String name = getCanonicalFullCollectionName(object);
                 assertTrue(
-                    "Canonical full collection (" + name + ") is not in SCM",
-                    new File(name).exists());
+                        new File(name).exists(),
+                        "Canonical full collection (" + name + ") is not in SCM");
             }
         }
     }

--- a/src/test/java/org/apache/commons/collections4/AbstractTreeMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/AbstractTreeMapTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.TreeMap;
 
 import org.apache.commons.collections4.map.AbstractMapTest;
@@ -44,8 +47,8 @@ public abstract class AbstractTreeMapTest<K, V> extends AbstractMapTest<K, V> {
     @Test
     public void testNewMap() {
         final TreeMap<K, V> map = makeObject();
-        assertTrue("New map is empty", map.isEmpty());
-        assertEquals("New map has size zero", 0, map.size());
+        assertTrue(map.isEmpty(), "New map is empty");
+        assertEquals(0, map.size(), "New map has size zero");
     }
 
     @Test
@@ -54,10 +57,10 @@ public abstract class AbstractTreeMapTest<K, V> extends AbstractMapTest<K, V> {
         final TreeMap<K, V> map = makeObject();
         map.put((K) "first", (V) "First Item");
         map.put((K) "second", (V) "Second Item");
-        assertEquals("Top item is 'Second Item'",
-            "First Item", map.get("first"));
-        assertEquals("Next Item is 'First Item'",
-            "Second Item", map.get("second"));
+        assertEquals("First Item", map.get("first"),
+                "Top item is 'Second Item'");
+        assertEquals("Second Item", map.get("second"),
+                "Next Item is 'First Item'");
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/ArrayStackTest.java
+++ b/src/test/java/org/apache/commons/collections4/ArrayStackTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.EmptyStackException;
 
@@ -40,8 +43,8 @@ public class ArrayStackTest<E> extends AbstractArrayListTest<E> {
     @Test
     public void testNewStack() {
         final ArrayStack<E> stack = makeObject();
-        assertTrue("New stack is empty", stack.empty());
-        assertEquals("New stack has size zero", 0, stack.size());
+        assertTrue(stack.empty(), "New stack is empty");
+        assertEquals(0, stack.size(), "New stack has size zero");
 
         assertThrows(EmptyStackException.class, () -> stack.peek());
 
@@ -54,27 +57,27 @@ public class ArrayStackTest<E> extends AbstractArrayListTest<E> {
         final ArrayStack<E> stack = makeObject();
 
         stack.push((E) "First Item");
-        assertFalse("Stack is not empty", stack.empty());
-        assertEquals("Stack size is one", 1, stack.size());
-        assertEquals("Top item is 'First Item'",
-                     "First Item", (String) stack.peek());
-        assertEquals("Stack size is one", 1, stack.size());
+        assertFalse(stack.empty(), "Stack is not empty");
+        assertEquals(1, stack.size(), "Stack size is one");
+        assertEquals("First Item", (String) stack.peek(),
+                "Top item is 'First Item'");
+        assertEquals(1, stack.size(), "Stack size is one");
 
         stack.push((E) "Second Item");
-        assertEquals("Stack size is two", 2, stack.size());
-        assertEquals("Top item is 'Second Item'",
-                     "Second Item", (String) stack.peek());
-        assertEquals("Stack size is two", 2, stack.size());
+        assertEquals(2, stack.size(), "Stack size is two");
+        assertEquals("Second Item", (String) stack.peek(),
+                "Top item is 'Second Item'");
+        assertEquals(2, stack.size(), "Stack size is two");
 
-        assertEquals("Popped item is 'Second Item'",
-                     "Second Item", (String) stack.pop());
-        assertEquals("Top item is 'First Item'",
-                     "First Item", (String) stack.peek());
-        assertEquals("Stack size is one", 1, stack.size());
+        assertEquals("Second Item", (String) stack.pop(),
+                "Popped item is 'Second Item'");
+        assertEquals("First Item", (String) stack.peek(),
+                "Top item is 'First Item'");
+        assertEquals(1, stack.size(), "Stack size is one");
 
-        assertEquals("Popped item is 'First Item'",
-                     "First Item", (String) stack.pop());
-        assertEquals("Stack size is zero", 0, stack.size());
+        assertEquals("First Item", (String) stack.pop(),
+                "Popped item is 'First Item'");
+        assertEquals(0, stack.size(), "Stack size is zero");
     }
 
     @Test
@@ -85,12 +88,12 @@ public class ArrayStackTest<E> extends AbstractArrayListTest<E> {
 
         stack.push((E) "First Item");
         stack.push((E) "Second Item");
-        assertEquals("Top item is 'Second Item'",
-                     1, stack.search("Second Item"));
-        assertEquals("Next Item is 'First Item'",
-                     2, stack.search("First Item"));
-        assertEquals("Cannot find 'Missing Item'",
-                     -1, stack.search("Missing Item"));
+        assertEquals(1, stack.search("Second Item"),
+                "Top item is 'Second Item'");
+        assertEquals(2, stack.search("First Item"),
+                "Next Item is 'First Item'");
+        assertEquals(-1, stack.search("Missing Item"),
+                "Cannot find 'Missing Item'");
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/BulkTest.java
+++ b/src/test/java/org/apache/commons/collections4/BulkTest.java
@@ -128,7 +128,7 @@ import junit.framework.TestSuite;
  *  The ordinary {@link TestSuite} constructor doesn't know how to
  *  interpret bulk test methods.
  */
-public class BulkTest extends TestCase implements Cloneable {
+public class BulkTest implements Cloneable {
 
     // Note:  BulkTest is Cloneable to make it easier to construct
     // BulkTest instances for simple test methods that are defined in
@@ -153,14 +153,28 @@ public class BulkTest extends TestCase implements Cloneable {
     String verboseName;
 
     /**
+     *  the name of the simple test method
+     */
+    private String name;
+
+    /**
      *  Constructs a new {@code BulkTest} instance that will run the
      *  specified simple test.
      *
      *  @param name  the name of the simple test method to run
      */
     public BulkTest(final String name) {
-        super(name);
+        this.name = name;
         this.verboseName = getClass().getName();
+    }
+
+    /**
+     *  Returns the name of the simple test method of this {@code BulkTest}.
+     *
+     *  @return the name of the simple test method of this {@code BulkTest}
+     */
+    public String getName() {
+        return name;
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -141,11 +144,11 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
 
         final Bag<T> bag = makeObject();
         bag.add((T) "A");
-        assertTrue("Should contain 'A'", bag.contains("A"));
-        assertEquals("Should have count of 1", 1, bag.getCount("A"));
+        assertTrue(bag.contains("A"), "Should contain 'A'");
+        assertEquals(1, bag.getCount("A"), "Should have count of 1");
         bag.add((T) "A");
-        assertTrue("Should contain 'A'", bag.contains("A"));
-        assertEquals("Should have count of 2", 2, bag.getCount("A"));
+        assertTrue(bag.contains("A"), "Should contain 'A'");
+        assertEquals(2, bag.getCount("A"), "Should have count of 2");
         bag.add((T) "B");
         assertTrue(bag.contains("A"));
         assertTrue(bag.contains("B"));
@@ -178,20 +181,20 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
 
         final Bag<T> bag = makeObject();
         bag.add((T) "A");
-        assertEquals("Should have count of 1", 1, bag.getCount("A"));
+        assertEquals(1, bag.getCount("A"), "Should have count of 1");
         bag.remove("A");
-        assertEquals("Should have count of 0", 0, bag.getCount("A"));
+        assertEquals(0, bag.getCount("A"), "Should have count of 0");
         bag.add((T) "A");
         bag.add((T) "A");
         bag.add((T) "A");
         bag.add((T) "A");
-        assertEquals("Should have count of 4", 4, bag.getCount("A"));
+        assertEquals(4, bag.getCount("A"), "Should have count of 4");
         bag.remove("A", 0);
-        assertEquals("Should have count of 4", 4, bag.getCount("A"));
+        assertEquals(4, bag.getCount("A"), "Should have count of 4");
         bag.remove("A", 2);
-        assertEquals("Should have count of 2", 2, bag.getCount("A"));
+        assertEquals(2, bag.getCount("A"), "Should have count of 2");
         bag.remove("A");
-        assertEquals("Should have count of 0", 0, bag.getCount("A"));
+        assertEquals(0, bag.getCount("A"), "Should have count of 0");
     }
 
     @Test
@@ -203,18 +206,18 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
 
         final Bag<T> bag = makeObject();
         bag.add((T) "A", 2);
-        assertEquals("Should have count of 2", 2, bag.getCount("A"));
+        assertEquals(2, bag.getCount("A"), "Should have count of 2");
         bag.add((T) "B");
         bag.add((T) "C");
-        assertEquals("Should have count of 4", 4, bag.size());
+        assertEquals(4, bag.size(), "Should have count of 4");
         final List<String> delete = new ArrayList<>();
         delete.add("A");
         delete.add("B");
         bag.removeAll(delete);
-        assertEquals("Should have count of 1", 1, bag.getCount("A"));
-        assertEquals("Should have count of 0", 0, bag.getCount("B"));
-        assertEquals("Should have count of 1", 1, bag.getCount("C"));
-        assertEquals("Should have count of 2", 2, bag.size());
+        assertEquals(1, bag.getCount("A"), "Should have count of 1");
+        assertEquals(0, bag.getCount("B"), "Should have count of 0");
+        assertEquals(1, bag.getCount("C"), "Should have count of 1");
+        assertEquals(2, bag.size(), "Should have count of 2");
     }
 
     @Test
@@ -226,20 +229,20 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
 
         final Bag<T> bag = makeObject();
 
-        assertFalse("Bag does not have at least 1 'A'", bag.contains("A"));
-        assertFalse("Bag does not have at least 1 'B'", bag.contains("B"));
+        assertFalse(bag.contains("A"), "Bag does not have at least 1 'A'");
+        assertFalse(bag.contains("B"), "Bag does not have at least 1 'B'");
 
         bag.add((T) "A");  // bag 1A
-        assertTrue("Bag has at least 1 'A'", bag.contains("A"));
-        assertFalse("Bag does not have at least 1 'B'", bag.contains("B"));
+        assertTrue(bag.contains("A"), "Bag has at least 1 'A'");
+        assertFalse(bag.contains("B"), "Bag does not have at least 1 'B'");
 
         bag.add((T) "A");  // bag 2A
-        assertTrue("Bag has at least 1 'A'", bag.contains("A"));
-        assertFalse("Bag does not have at least 1 'B'", bag.contains("B"));
+        assertTrue(bag.contains("A"), "Bag has at least 1 'A'");
+        assertFalse(bag.contains("B"), "Bag does not have at least 1 'B'");
 
         bag.add((T) "B");  // bag 2A,1B
-        assertTrue("Bag has at least 1 'A'", bag.contains("A"));
-        assertTrue("Bag has at least 1 'B'", bag.contains("B"));
+        assertTrue(bag.contains("A"), "Bag has at least 1 'A'");
+        assertTrue(bag.contains("B"), "Bag has at least 1 'B'");
     }
 
     @Test
@@ -262,39 +265,39 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         known1A1B.add("A");
         known1A1B.add("B");
 
-        assertTrue("Bag containsAll of empty", bag.containsAll(known));
-        assertFalse("Bag does not containsAll of 1 'A'", bag.containsAll(known1A));
-        assertFalse("Bag does not containsAll of 2 'A'", bag.containsAll(known2A));
-        assertFalse("Bag does not containsAll of 1 'B'", bag.containsAll(known1B));
-        assertFalse("Bag does not containsAll of 1 'A' 1 'B'", bag.containsAll(known1A1B));
+        assertTrue(bag.containsAll(known), "Bag containsAll of empty");
+        assertFalse(bag.containsAll(known1A), "Bag does not containsAll of 1 'A'");
+        assertFalse(bag.containsAll(known2A), "Bag does not containsAll of 2 'A'");
+        assertFalse(bag.containsAll(known1B), "Bag does not containsAll of 1 'B'");
+        assertFalse(bag.containsAll(known1A1B), "Bag does not containsAll of 1 'A' 1 'B'");
 
         bag.add((T) "A");  // bag 1A
-        assertTrue("Bag containsAll of empty", bag.containsAll(known));
-        assertTrue("Bag containsAll of 1 'A'", bag.containsAll(known1A));
-        assertFalse("Bag does not containsAll of 2 'A'", bag.containsAll(known2A));
-        assertFalse("Bag does not containsAll of 1 'B'", bag.containsAll(known1B));
-        assertFalse("Bag does not containsAll of 1 'A' 1 'B'", bag.containsAll(known1A1B));
+        assertTrue(bag.containsAll(known), "Bag containsAll of empty");
+        assertTrue(bag.containsAll(known1A), "Bag containsAll of 1 'A'");
+        assertFalse(bag.containsAll(known2A), "Bag does not containsAll of 2 'A'");
+        assertFalse(bag.containsAll(known1B), "Bag does not containsAll of 1 'B'");
+        assertFalse(bag.containsAll(known1A1B), "Bag does not containsAll of 1 'A' 1 'B'");
 
         bag.add((T) "A");  // bag 2A
-        assertTrue("Bag containsAll of empty", bag.containsAll(known));
-        assertTrue("Bag containsAll of 1 'A'", bag.containsAll(known1A));
-        assertTrue("Bag containsAll of 2 'A'", bag.containsAll(known2A));
-        assertFalse("Bag does not containsAll of 1 'B'", bag.containsAll(known1B));
-        assertFalse("Bag does not containsAll of 1 'A' 1 'B'", bag.containsAll(known1A1B));
+        assertTrue(bag.containsAll(known), "Bag containsAll of empty");
+        assertTrue(bag.containsAll(known1A), "Bag containsAll of 1 'A'");
+        assertTrue(bag.containsAll(known2A), "Bag containsAll of 2 'A'");
+        assertFalse(bag.containsAll(known1B), "Bag does not containsAll of 1 'B'");
+        assertFalse(bag.containsAll(known1A1B), "Bag does not containsAll of 1 'A' 1 'B'");
 
         bag.add((T) "A");  // bag 3A
-        assertTrue("Bag containsAll of empty", bag.containsAll(known));
-        assertTrue("Bag containsAll of 1 'A'", bag.containsAll(known1A));
-        assertTrue("Bag containsAll of 2 'A'", bag.containsAll(known2A));
-        assertFalse("Bag does not containsAll of 1 'B'", bag.containsAll(known1B));
-        assertFalse("Bag does not containsAll of 1 'A' 1 'B'", bag.containsAll(known1A1B));
+        assertTrue(bag.containsAll(known), "Bag containsAll of empty");
+        assertTrue(bag.containsAll(known1A), "Bag containsAll of 1 'A'");
+        assertTrue(bag.containsAll(known2A), "Bag containsAll of 2 'A'");
+        assertFalse(bag.containsAll(known1B), "Bag does not containsAll of 1 'B'");
+        assertFalse(bag.containsAll(known1A1B), "Bag does not containsAll of 1 'A' 1 'B'");
 
         bag.add((T) "B");  // bag 3A1B
-        assertTrue("Bag containsAll of empty", bag.containsAll(known));
-        assertTrue("Bag containsAll of 1 'A'", bag.containsAll(known1A));
-        assertTrue("Bag containsAll of 2 'A'", bag.containsAll(known2A));
-        assertTrue("Bag containsAll of 1 'B'", bag.containsAll(known1B));
-        assertTrue("Bag containsAll of 1 'A' 1 'B'", bag.containsAll(known1A1B));
+        assertTrue(bag.containsAll(known), "Bag containsAll of empty");
+        assertTrue(bag.containsAll(known1A), "Bag containsAll of 1 'A'");
+        assertTrue(bag.containsAll(known2A), "Bag containsAll of 2 'A'");
+        assertTrue(bag.containsAll(known1B), "Bag containsAll of 1 'B'");
+        assertTrue(bag.containsAll(known1A1B), "Bag containsAll of 1 'A' 1 'B'");
     }
 
     @Test
@@ -305,22 +308,22 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         }
 
         final Bag<T> bag = makeObject();
-        assertEquals("Should have 0 total items", 0, bag.size());
+        assertEquals(0, bag.size(), "Should have 0 total items");
         bag.add((T) "A");
-        assertEquals("Should have 1 total items", 1, bag.size());
+        assertEquals(1, bag.size(), "Should have 1 total items");
         bag.add((T) "A");
-        assertEquals("Should have 2 total items", 2, bag.size());
+        assertEquals(2, bag.size(), "Should have 2 total items");
         bag.add((T) "A");
-        assertEquals("Should have 3 total items", 3, bag.size());
+        assertEquals(3, bag.size(), "Should have 3 total items");
         bag.add((T) "B");
-        assertEquals("Should have 4 total items", 4, bag.size());
+        assertEquals(4, bag.size(), "Should have 4 total items");
         bag.add((T) "B");
-        assertEquals("Should have 5 total items", 5, bag.size());
+        assertEquals(5, bag.size(), "Should have 5 total items");
         bag.remove("A", 2);
-        assertEquals("Should have 1 'A'", 1, bag.getCount("A"));
-        assertEquals("Should have 3 total items", 3, bag.size());
+        assertEquals(1, bag.getCount("A"), "Should have 1 'A'");
+        assertEquals(3, bag.size(), "Should have 3 total items");
         bag.remove("B");
-        assertEquals("Should have 1 total item", 1, bag.size());
+        assertEquals(1, bag.size(), "Should have 1 total item");
     }
 
     @Test
@@ -341,7 +344,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         retains.add("B");
         retains.add("C");
         bag.retainAll(retains);
-        assertEquals("Should have 2 total items", 2, bag.size());
+        assertEquals(2, bag.size(), "Should have 2 total items");
     }
 
     @Test
@@ -355,7 +358,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         bag.add((T) "A");
         bag.add((T) "A");
         bag.add((T) "B");
-        assertEquals("Bag should have 3 items", 3, bag.size());
+        assertEquals(3, bag.size(), "Bag should have 3 items");
         final Iterator<T> i = bag.iterator();
 
         boolean foundA = false;
@@ -371,9 +374,9 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
             }
         }
 
-        assertTrue("Bag should still contain 'A'", bag.contains("A"));
-        assertEquals("Bag should have 2 items", 2, bag.size());
-        assertEquals("Bag should have 1 'A'", 1, bag.getCount("A"));
+        assertTrue(bag.contains("A"), "Bag should still contain 'A'");
+        assertEquals(2, bag.size(), "Bag should have 2 items");
+        assertEquals(1, bag.getCount("A"), "Bag should have 1 'A'");
     }
 
     @Test
@@ -691,7 +694,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         final Bag<T> bag = makeObject();
         if (bag instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(bag));
-            assertTrue("Bag is empty", bag2.isEmpty());
+            assertTrue(bag2.isEmpty(), "Bag is empty");
             assertEquals(bag, bag2);
         }
     }
@@ -706,7 +709,7 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         final Bag<T> bag = makeFullCollection();
         if (bag instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalFullCollectionName(bag));
-            assertEquals("Bag is the right size", bag.size(), bag2.size());
+            assertEquals(bag.size(), bag2.size(), "Bag is the right size");
             assertEquals(bag, bag2);
         }
     }

--- a/src/test/java/org/apache/commons/collections4/bag/AbstractSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/AbstractSortedBagTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Iterator;
 
 import org.apache.commons.collections4.SortedBag;
@@ -54,13 +56,13 @@ public abstract class AbstractSortedBagTest<T> extends AbstractBagTest<T> {
             } else {
                 last = collIter.next();
             }
-            assertEquals("Element appears to be out of order.", last, confIter.next());
+            assertEquals(last, confIter.next(), "Element appears to be out of order.");
         }
         if (!getCollection().isEmpty()) {
-            assertEquals("Incorrect element returned by first().", first,
-                getCollection().first());
-            assertEquals("Incorrect element returned by last().", last,
-                getCollection().last());
+            assertEquals(first, getCollection().first(),
+                "Incorrect element returned by first().");
+            assertEquals(last, getCollection().last(),
+                "Incorrect element returned by last().");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/bag/CollectionBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/CollectionBagTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -99,7 +102,7 @@ public class CollectionBagTest<T> extends AbstractCollectionTest<T> {
         final Bag<T> bag = makeObject();
         if (bag instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(bag));
-            assertTrue("Bag is empty", bag2.isEmpty());
+            assertTrue(bag2.isEmpty(), "Bag is empty");
             assertEquals(bag, bag2);
         }
     }
@@ -114,7 +117,7 @@ public class CollectionBagTest<T> extends AbstractCollectionTest<T> {
         final Bag<T> bag = (Bag<T>) makeFullCollection();
         if (bag instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalFullCollectionName(bag));
-            assertEquals("Bag is the right size", bag.size(), bag2.size());
+            assertEquals(bag.size(), bag2.size(), "Bag is the right size");
             assertEquals(bag, bag2);
         }
     }

--- a/src/test/java/org/apache/commons/collections4/bag/CollectionSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/CollectionSortedBagTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -132,7 +134,7 @@ public class CollectionSortedBagTest<T> extends AbstractCollectionTest<T> {
         final Bag<T> bag = makeObject();
         if (bag instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             final Bag<?> bag2 = (Bag<?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(bag));
-            assertEquals("Bag is empty", 0, bag2.size());
+            assertEquals(0, bag2.size(), "Bag is empty");
             assertEquals(bag, bag2);
         }
     }
@@ -147,7 +149,7 @@ public class CollectionSortedBagTest<T> extends AbstractCollectionTest<T> {
         final SortedBag<T> bag = (SortedBag<T>) makeFullCollection();
         if (bag instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             final SortedBag<?> bag2 = (SortedBag<?>) readExternalFormFromDisk(getCanonicalFullCollectionName(bag));
-            assertEquals("Bag is the right size", bag.size(), bag2.size());
+            assertEquals(bag.size(), bag2.size(), "Bag is the right size");
             assertEquals(bag, bag2);
         }
     }

--- a/src/test/java/org/apache/commons/collections4/bag/PredicatedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/PredicatedBagTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 
@@ -73,10 +76,10 @@ public class PredicatedBagTest<T> extends AbstractBagTest<T> {
             assertTrue(bag.contains(els[i]));
         }
         Set<T> set = bag.uniqueSet();
-        assertTrue("Unique set contains the first element", set.contains(els[0]));
+        assertTrue(set.contains(els[0]), "Unique set contains the first element");
         assertTrue(bag.remove(els[0]));
         set = bag.uniqueSet();
-        assertFalse("Unique set now does not contain the first element", set.contains(els[0]));
+        assertFalse(set.contains(els[0]), "Unique set now does not contain the first element");
     }
 
     @Test
@@ -87,7 +90,7 @@ public class PredicatedBagTest<T> extends AbstractBagTest<T> {
 
         assertThrows(IllegalArgumentException.class, () -> bag.add((T) i));
 
-        assertFalse("Collection shouldn't contain illegal element", bag.contains(i));
+        assertFalse(bag.contains(i), "Collection shouldn't contain illegal element");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/bag/PredicatedSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/PredicatedSortedBagTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Comparator;
@@ -78,10 +80,10 @@ public class PredicatedSortedBagTest<T> extends AbstractSortedBagTest<T> {
         bag.add((T) one);
         bag.add((T) two);
         bag.add((T) three);
-        assertEquals("first element", bag.first(), one);
-        assertEquals("last element", bag.last(), two);
+        assertEquals(bag.first(), one, "first element");
+        assertEquals(bag.last(), two, "last element");
         final Comparator<? super T> c = bag.comparator();
-        assertNull("natural order, so comparator should be null", c);
+        assertNull(c, "natural order, so comparator should be null");
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/bag/TransformedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/TransformedBagTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.commons.collections4.Bag;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;

--- a/src/test/java/org/apache/commons/collections4/bag/TransformedSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/TransformedSortedBagTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.commons.collections4.SortedBag;
 import org.apache.commons.collections4.Transformer;
 import org.apache.commons.collections4.collection.TransformedCollectionTest;

--- a/src/test/java/org/apache/commons/collections4/bag/TreeBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/TreeBagTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.commons.collections4.Bag;
@@ -71,11 +72,11 @@ public class TreeBagTest<T> extends AbstractSortedBagTest<T> {
     @Test
     public void testOrdering() {
         final Bag<T> bag = setupBag();
-        assertEquals("Should get elements in correct order", "A", bag.toArray()[0]);
-        assertEquals("Should get elements in correct order", "B", bag.toArray()[1]);
-        assertEquals("Should get elements in correct order", "C", bag.toArray()[2]);
-        assertEquals("Should get first key", "A", ((SortedBag<T>) bag).first());
-        assertEquals("Should get last key", "D", ((SortedBag<T>) bag).last());
+        assertEquals("A", bag.toArray()[0], "Should get elements in correct order");
+        assertEquals("B", bag.toArray()[1], "Should get elements in correct order");
+        assertEquals("C", bag.toArray()[2], "Should get elements in correct order");
+        assertEquals("A", ((SortedBag<T>) bag).first(), "Should get first key");
+        assertEquals("D", ((SortedBag<T>) bag).last(), "Should get last key");
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/bag/UnmodifiableBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/UnmodifiableBagTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 

--- a/src/test/java/org/apache/commons/collections4/bag/UnmodifiableSortedBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/UnmodifiableSortedBagTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractBidiMapTest.java
@@ -16,7 +16,12 @@
  */
 package org.apache.commons.collections4.bidimap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -156,8 +161,8 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
     }
 
     private void doTestGetKey(final BidiMap<?, ?> map, final Object key, final Object value) {
-        assertEquals("Value not found for key.", value, map.get(key));
-        assertEquals("Key not found for value.", key, map.getKey(value));
+        assertEquals(value, map.get(key), "Value not found for key.");
+        assertEquals(key, map.getKey(value), "Key not found for value.");
     }
 
     // testInverse
@@ -167,19 +172,19 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
         final BidiMap<V, K> inverseMap = map.inverseBidiMap();
 
         assertSame(
-            "Inverse of inverse is not equal to original.",
-            map,
-            inverseMap.inverseBidiMap());
+                map,
+                inverseMap.inverseBidiMap(),
+                "Inverse of inverse is not equal to original.");
 
         assertEquals(
-            "Value not found for key.",
-            getSampleKeys()[0],
-            inverseMap.get(getSampleValues()[0]));
+                getSampleKeys()[0],
+                inverseMap.get(getSampleValues()[0]),
+                "Value not found for key.");
 
         assertEquals(
-            "Key not found for value.",
-            getSampleValues()[0],
-            inverseMap.getKey(getSampleKeys()[0]));
+                getSampleValues()[0],
+                inverseMap.getKey(getSampleKeys()[0]),
+                "Key not found for value.");
     }
 
     @Test
@@ -206,13 +211,13 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
         entry.setValue((T) newValue);
 
         assertEquals(
-            "Modifying entrySet did not affect underlying Map.",
             newValue,
-            map.get(key));
+            map.get(key),
+                "Modifying entrySet did not affect underlying Map.");
 
         assertNull(
-            "Modifying entrySet did not affect inverse Map.",
-            map.getKey(oldValue));
+            map.getKey(oldValue),
+                "Modifying entrySet did not affect inverse Map.");
     }
 
     @Test
@@ -224,14 +229,14 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
 
         BidiMap<?, ?> map = makeFullMap();
         map.clear();
-        assertTrue("Map was not cleared.", map.isEmpty());
-        assertTrue("Inverse map was not cleared.", map.inverseBidiMap().isEmpty());
+        assertTrue(map.isEmpty(), "Map was not cleared.");
+        assertTrue(map.inverseBidiMap().isEmpty(), "Inverse map was not cleared.");
 
         // Tests clear on inverse
         map = makeFullMap().inverseBidiMap();
         map.clear();
-        assertTrue("Map was not cleared.", map.isEmpty());
-        assertTrue("Inverse map was not cleared.", map.inverseBidiMap().isEmpty());
+        assertTrue(map.isEmpty(), "Map was not cleared.");
+        assertTrue(map.inverseBidiMap().isEmpty(), "Inverse map was not cleared.");
     }
 
     @Test
@@ -255,14 +260,14 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
 
     private void remove(final BidiMap<?, ?> map, final Object key) {
         final Object value = map.remove(key);
-        assertFalse("Key was not removed.", map.containsKey(key));
-        assertNull("Value was not removed.", map.getKey(value));
+        assertFalse(map.containsKey(key), "Key was not removed.");
+        assertNull(map.getKey(value), "Value was not removed.");
     }
 
     private void removeValue(final BidiMap<?, ?> map, final Object value) {
         final Object key = map.removeValue(value);
-        assertFalse("Key was not removed.", map.containsKey(key));
-        assertNull("Value was not removed.", map.getKey(value));
+        assertFalse(map.containsKey(key), "Key was not removed.");
+        assertNull(map.getKey(value), "Value was not removed.");
     }
 
     @Test
@@ -294,11 +299,11 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
     private void removeByKeySet(final BidiMap<?, ?> map, final Object key, final Object value) {
         map.remove(key);
 
-        assertFalse("Key was not removed.", map.containsKey(key));
-        assertFalse("Value was not removed.", map.containsValue(value));
+        assertFalse(map.containsKey(key), "Key was not removed.");
+        assertFalse(map.containsValue(value), "Value was not removed.");
 
-        assertFalse("Key was not removed from inverse map.", map.inverseBidiMap().containsValue(key));
-        assertFalse("Value was not removed from inverse map.", map.inverseBidiMap().containsKey(value));
+        assertFalse(map.inverseBidiMap().containsValue(key), "Key was not removed from inverse map.");
+        assertFalse(map.inverseBidiMap().containsKey(value), "Value was not removed from inverse map.");
     }
 
     @Test
@@ -316,11 +321,11 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
         temp.put(key, value);
         map.entrySet().remove(temp.entrySet().iterator().next());
 
-        assertFalse("Key was not removed.", map.containsKey(key));
-        assertFalse("Value was not removed.", map.containsValue(value));
+        assertFalse(map.containsKey(key), "Key was not removed.");
+        assertFalse(map.containsValue(value), "Value was not removed.");
 
-        assertFalse("Key was not removed from inverse map.", map.inverseBidiMap().containsValue(key));
-        assertFalse("Value was not removed from inverse map.", map.inverseBidiMap().containsKey(value));
+        assertFalse(map.inverseBidiMap().containsValue(key), "Key was not removed from inverse map.");
+        assertFalse(map.inverseBidiMap().containsKey(value), "Value was not removed from inverse map.");
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.bidimap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractSortedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractSortedBidiMapTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.bidimap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap2Test.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap2Test.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.bidimap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -133,9 +137,9 @@ public class DualTreeBidiMap2Test<K extends Comparable<K>, V extends Comparable<
         final Iterator<K> mapIter = sm.keySet().iterator();
         for (final K expectedKey : newSortedKeys) {
             final K mapKey = mapIter.next();
-            assertNotNull("key in sorted list may not be null", expectedKey);
-            assertNotNull("key in map may not be null", mapKey);
-            assertEquals("key from sorted list and map must be equal", expectedKey, mapKey);
+            assertNotNull(expectedKey, "key in sorted list may not be null");
+            assertNotNull(mapKey, "key in map may not be null");
+            assertEquals(expectedKey, mapKey, "key from sorted list and map must be equal");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableBidiMapTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.bidimap;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableOrderedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableOrderedBidiMapTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.bidimap;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.TreeMap;

--- a/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableSortedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/UnmodifiableSortedBidiMapTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.bidimap;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.SortedMap;
 import java.util.TreeMap;

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBitCountProducerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractBitCountProducerTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.util.Arrays;
@@ -27,7 +28,6 @@ import java.util.BitSet;
 
 import org.apache.commons.collections4.bag.TreeBag;
 import org.apache.commons.collections4.bloomfilter.BitCountProducer.BitCountConsumer;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public abstract class AbstractBitCountProducerTest extends AbstractIndexProducerTest {
@@ -93,7 +93,7 @@ public abstract class AbstractBitCountProducerTest extends AbstractIndexProducer
         final int ary[] = empty.asIndexArray();
         assertEquals(0, ary.length);
         assertTrue(empty.forEachCount((i, j) -> {
-            Assertions.fail("forEachCount consumer should not be called");
+            fail("forEachCount consumer should not be called");
             return false;
         }));
     }
@@ -111,7 +111,7 @@ public abstract class AbstractBitCountProducerTest extends AbstractIndexProducer
             bs2.set(i);
             return true;
         });
-        Assertions.assertEquals(bs1, bs2);
+        assertEquals(bs1, bs2);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractIndexProducerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/AbstractIndexProducerTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.bloomfilter;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -23,7 +25,6 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.function.IntPredicate;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -132,7 +133,7 @@ public abstract class AbstractIndexProducerTest {
             bs2.set(i);
             return true;
         });
-        Assertions.assertEquals(bs1, bs2);
+        assertEquals(bs1, bs2);
     }
 
     @Test
@@ -151,7 +152,7 @@ public abstract class AbstractIndexProducerTest {
     public final void testEmptyProducer() {
         final IndexProducer empty = createEmptyProducer();
         final int ary[] = empty.asIndexArray();
-        Assertions.assertEquals(0, ary.length);
+        assertEquals(0, ary.length);
         assertTrue(empty.forEachIndex(i -> {
             throw new AssertionError("forEach predictate should not be called");
         }));
@@ -170,7 +171,7 @@ public abstract class AbstractIndexProducerTest {
             bs2.set(i);
             return true;
         });
-        Assertions.assertEquals(bs1, bs2);
+        assertEquals(bs1, bs2);
     }
 
     /**
@@ -186,18 +187,18 @@ public abstract class AbstractIndexProducerTest {
         final int[] actual = createProducer().asIndexArray();
         if ((flags & ORDERED) != 0) {
             final int[] expected = Arrays.stream(actual).sorted().toArray();
-            Assertions.assertArrayEquals(expected, actual);
+            assertArrayEquals(expected, actual);
         }
         if ((flags & DISTINCT) != 0) {
             final long count = Arrays.stream(actual).distinct().count();
-            Assertions.assertEquals(count, actual.length);
+            assertEquals(count, actual.length);
         } else {
             // if the array is not distinct all expected elements must be generated
             // This is modified so use a copy
             final int[] expected = getExpectedIndices().clone();
             Arrays.sort(expected);
             Arrays.sort(actual);
-            Assertions.assertArrayEquals(expected, actual);
+            assertArrayEquals(expected, actual);
         }
     }
 
@@ -214,17 +215,17 @@ public abstract class AbstractIndexProducerTest {
         final int[] actual = list.toArray();
         if ((flags & ORDERED) != 0) {
             final int[] expected = Arrays.stream(actual).sorted().toArray();
-            Assertions.assertArrayEquals(expected, actual);
+            assertArrayEquals(expected, actual);
         }
         if ((flags & DISTINCT) != 0) {
             final long count = Arrays.stream(actual).distinct().count();
-            Assertions.assertEquals(count, actual.length);
+            assertEquals(count, actual.length);
         } else {
             // if forEach is not distinct all expected elements must be generated
             final int[] expected = getExpectedIndices().clone();
             Arrays.sort(expected);
             Arrays.sort(actual);
-            Assertions.assertArrayEquals(expected, actual);
+            assertArrayEquals(expected, actual);
         }
     }
 
@@ -235,13 +236,13 @@ public abstract class AbstractIndexProducerTest {
             passes[0]++;
             return false;
         }));
-        Assertions.assertEquals(1, passes[0]);
+        assertEquals(1, passes[0]);
 
         passes[0] = 0;
         assertTrue(createEmptyProducer().forEachIndex(i -> {
             passes[0]++;
             return false;
         }));
-        Assertions.assertEquals(0, passes[0]);
+        assertEquals(0, passes[0]);
     }
 }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/ShapeTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/ShapeTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -109,7 +108,7 @@ public class ShapeTest {
                 final int c = n;
                 // is sparse when number of bits stored as integers is less than 2 times the
                 // number of bitmaps
-                Assertions.assertEquals(n * Integer.SIZE <= Math.ceil((double) bits / Long.SIZE) * Long.SIZE,
+                assertEquals(n * Integer.SIZE <= Math.ceil((double) bits / Long.SIZE) * Long.SIZE,
                         shape.isSparse(n), () -> String.format("n=%d : bits=%d", c, bits));
             }
         }

--- a/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
@@ -16,7 +16,13 @@
  */
 package org.apache.commons.collections4.collection;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -40,7 +46,6 @@ import java.util.function.Predicate;
 
 import org.apache.commons.collections4.AbstractObjectTest;
 import org.apache.commons.lang3.ArrayUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -259,10 +264,10 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
      */
     public void verify() {
         final int confirmedSize = getConfirmed().size();
-        assertEquals("Collection size should match confirmed collection's", confirmedSize,
-                getCollection().size());
-        assertEquals("Collection isEmpty() result should match confirmed collection's",
-                getConfirmed().isEmpty(), getCollection().isEmpty());
+        assertEquals(confirmedSize, getCollection().size(),
+                "Collection size should match confirmed collection's");
+        assertEquals(getConfirmed().isEmpty(), getCollection().isEmpty(),
+                "Collection isEmpty() result should match confirmed collection's");
 
         // verify the collections are the same by attempting to match each
         // object in the collection and confirmed collection.  To account for
@@ -531,8 +536,8 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
             final boolean r = getCollection().add(element);
             getConfirmed().add(element);
             verify();
-            assertTrue("Empty collection changed after add", r);
-            assertEquals("Collection size is 1 after first add", 1, getCollection().size());
+            assertTrue(r, "Empty collection changed after add");
+            assertEquals(1, getCollection().size(), "Collection size is 1 after first add");
         }
 
         resetEmpty();
@@ -544,8 +549,8 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
             if (r) {
                 size++;
             }
-            assertEquals("Collection size should grow after add", size, getCollection().size());
-            assertTrue("Collection should contain added element", getCollection().contains(element));
+            assertEquals(size, getCollection().size(), "Collection size should grow after add");
+            assertTrue(getCollection().contains(element), "Collection should contain added element");
         }
     }
 
@@ -563,9 +568,9 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         boolean r = getCollection().addAll(Arrays.asList(elements));
         getConfirmed().addAll(Arrays.asList(elements));
         verify();
-        assertTrue("Empty collection should change after addAll", r);
+        assertTrue(r, "Empty collection should change after addAll");
         for (final E element : elements) {
-            assertTrue("Collection should contain added element", getCollection().contains(element));
+            assertTrue(getCollection().contains(element), "Collection should contain added element");
         }
 
         resetFull();
@@ -574,12 +579,12 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         r = getCollection().addAll(Arrays.asList(elements));
         getConfirmed().addAll(Arrays.asList(elements));
         verify();
-        assertTrue("Full collection should change after addAll", r);
+        assertTrue(r, "Full collection should change after addAll");
         for (final E element : elements) {
-            assertTrue("Full collection should contain added element",
-                    getCollection().contains(element));
+            assertTrue(getCollection().contains(element),
+                    "Full collection should contain added element");
         }
-        assertEquals("Size should increase after addAll", size + elements.length, getCollection().size());
+        assertEquals(size + elements.length, getCollection().size(), "Size should increase after addAll");
 
         resetFull();
         size = getCollection().size();
@@ -587,9 +592,9 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         getConfirmed().addAll(Arrays.asList(getFullElements()));
         verify();
         if (r) {
-            assertTrue("Size should increase if addAll returns true", size < getCollection().size());
+            assertTrue(size < getCollection().size(), "Size should increase if addAll returns true");
         } else {
-            assertEquals("Size should not change if addAll returns false", size, getCollection().size());
+            assertEquals(size, getCollection().size(), "Size should not change if addAll returns false");
         }
     }
 
@@ -659,14 +664,14 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         resetEmpty();
         elements = getFullElements();
         for (int i = 0; i < elements.length; i++) {
-            assertFalse("Empty collection shouldn't contain element[" + i + "]", getCollection().contains(elements[i]));
+            assertFalse(getCollection().contains(elements[i]), "Empty collection shouldn't contain element[" + i + "]");
         }
         // make sure calls to "contains" don't change anything
         verify();
 
         elements = getOtherElements();
         for (int i = 0; i < elements.length; i++) {
-            assertFalse("Empty collection shouldn't contain element[" + i + "]", getCollection().contains(elements[i]));
+            assertFalse(getCollection().contains(elements[i]), "Empty collection shouldn't contain element[" + i + "]");
         }
         // make sure calls to "contains" don't change anything
         verify();
@@ -674,8 +679,8 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         resetFull();
         elements = getFullElements();
         for (int i = 0; i < elements.length; i++) {
-            assertTrue("Full collection should contain element[" + i + "]",
-                    getCollection().contains(elements[i]));
+            assertTrue(getCollection().contains(elements[i]),
+                    "Full collection should contain element[" + i + "]");
         }
         // make sure calls to "contains" don't change anything
         verify();
@@ -683,7 +688,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         resetFull();
         elements = getOtherElements();
         for (final Object element : elements) {
-            assertFalse("Full collection shouldn't contain element", getCollection().contains(element));
+            assertFalse(getCollection().contains(element), "Full collection shouldn't contain element");
         }
     }
 
@@ -694,21 +699,21 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     public void testCollectionContainsAll() {
         resetEmpty();
         Collection<E> col = new HashSet<>();
-        assertTrue("Every Collection should contain all elements of an " +
-                "empty Collection.", getCollection().containsAll(col));
+        assertTrue(getCollection().containsAll(col),
+                "Every Collection should contain all elements of an " + "empty Collection.");
         col.addAll(Arrays.asList(getOtherElements()));
-        assertFalse("Empty Collection shouldn't contain all elements of " +
-                "a non-empty Collection.", getCollection().containsAll(col));
+        assertFalse(getCollection().containsAll(col),
+                "Empty Collection shouldn't contain all elements of " + "a non-empty Collection.");
         // make sure calls to "containsAll" don't change anything
         verify();
 
         resetFull();
-        assertFalse("Full collection shouldn't contain other elements", getCollection().containsAll(col));
+        assertFalse(getCollection().containsAll(col), "Full collection shouldn't contain other elements");
 
         col.clear();
         col.addAll(Arrays.asList(getFullElements()));
-        assertTrue("Full collection should containAll full elements",
-                getCollection().containsAll(col));
+        assertTrue(getCollection().containsAll(col),
+                "Full collection should containAll full elements");
         // make sure calls to "containsAll" don't change anything
         verify();
 
@@ -716,16 +721,17 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         final int max = getFullElements().length == 1 ? 1 :
                 getFullElements().length <= 5 ? getFullElements().length - 1 : 5;
         col = Arrays.asList(getFullElements()).subList(min, max);
-        assertTrue("Full collection should containAll partial full elements",
-                getCollection().containsAll(col));
-        assertTrue("Full collection should containAll itself", getCollection().containsAll(getCollection()));
+        assertTrue(getCollection().containsAll(col),
+                "Full collection should containAll partial full elements");
+        assertTrue(getCollection().containsAll(getCollection()),
+                "Full collection should containAll itself");
         // make sure calls to "containsAll" don't change anything
         verify();
 
         col = new ArrayList<>(Arrays.asList(getFullElements()));
         col.addAll(Arrays.asList(getFullElements()));
-        assertTrue("Full collection should containAll duplicate full elements",
-                getCollection().containsAll(col));
+        assertTrue(getCollection().containsAll(col),
+                "Full collection should containAll duplicate full elements");
 
         // make sure calls to "containsAll" don't change anything
         verify();
@@ -737,12 +743,12 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     @Test
     public void testCollectionIsEmpty() {
         resetEmpty();
-        assertTrue("New Collection should be empty.", getCollection().isEmpty());
+        assertTrue(getCollection().isEmpty(), "New Collection should be empty.");
         // make sure calls to "isEmpty() don't change anything
         verify();
 
         resetFull();
-        assertFalse("Full collection shouldn't be empty", getCollection().isEmpty());
+        assertFalse(getCollection().isEmpty(), "Full collection shouldn't be empty");
         // make sure calls to "isEmpty() don't change anything
         verify();
     }
@@ -754,7 +760,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     public void testCollectionIterator() {
         resetEmpty();
         Iterator<E> it1 = getCollection().iterator();
-        assertFalse("Iterator for empty Collection shouldn't have next.", it1.hasNext());
+        assertFalse(it1.hasNext(), "Iterator for empty Collection shouldn't have next.");
         final Iterator<E> finalIt1 = it1;
         assertThrows(NoSuchElementException.class, () -> finalIt1.next(),
                 "Iterator at end of Collection should throw NoSuchElementException when next is called.");
@@ -764,17 +770,17 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         resetFull();
         it1 = getCollection().iterator();
         for (final E element : getCollection()) {
-            assertTrue("Iterator for full collection should haveNext", it1.hasNext());
+            assertTrue(it1.hasNext(), "Iterator for full collection should haveNext");
             it1.next();
         }
-        assertFalse("Iterator should be finished", it1.hasNext());
+        assertFalse(it1.hasNext(), "Iterator should be finished");
 
         final ArrayList<E> list = new ArrayList<>();
         it1 = getCollection().iterator();
         for (int i = 0; i < getCollection().size(); i++) {
             final E next = it1.next();
-            assertTrue("Collection should contain element returned by its iterator",
-                    getCollection().contains(next));
+            assertTrue(getCollection().contains(next),
+                    "Collection should contain element returned by its iterator");
             list.add(next);
         }
         final Iterator<E> finalIt2 = it1;
@@ -831,10 +837,10 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
             }
 
             size--;
-            assertEquals("Collection should shrink by one after iterator.remove", size,
-                    getCollection().size());
+            assertEquals(size, getCollection().size(),
+                    "Collection should shrink by one after iterator.remove");
         }
-        assertTrue("Collection should be empty after iterator purge", getCollection().isEmpty());
+        assertTrue(getCollection().isEmpty(), "Collection should be empty after iterator purge");
 
         resetFull();
         iter = getCollection().iterator();
@@ -857,7 +863,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         resetEmpty();
         final E[] elements = getFullElements();
         for (final E element : elements) {
-            assertFalse("Shouldn't remove nonexistent element", getCollection().remove(element));
+            assertFalse(getCollection().remove(element), "Shouldn't remove nonexistent element");
             verify();
         }
 
@@ -865,15 +871,15 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
 
         resetFull();
         for (final E element : other) {
-            assertFalse("Shouldn't remove nonexistent other element", getCollection().remove(element));
+            assertFalse(getCollection().remove(element), "Shouldn't remove nonexistent other element");
             verify();
         }
 
         final int size = getCollection().size();
         for (final E element : elements) {
             resetFull();
-            assertTrue("Collection should remove extant element: " + element,
-                    getCollection().remove(element));
+            assertTrue(getCollection().remove(element),
+                    "Collection should remove extant element: " + element);
 
             // if the elements aren't distinguishable, we can just remove a
             // matching element from the confirmed collection and verify
@@ -888,7 +894,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
                 verify();
             }
 
-            assertEquals("Collection should shrink after remove", size - 1, getCollection().size());
+            assertEquals(size - 1, getCollection().size(), "Collection should shrink after remove");
         }
     }
 
@@ -902,21 +908,21 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         }
 
         resetEmpty();
-        assertFalse("Empty collection removeAll should return false for empty input", getCollection().removeAll(Collections.EMPTY_SET));
+        assertFalse(getCollection().removeAll(Collections.EMPTY_SET), "Empty collection removeAll should return false for empty input");
         verify();
 
-        assertFalse("Empty collection removeAll should return false for nonempty input", getCollection().removeAll(new ArrayList<>(getCollection())));
+        assertFalse(getCollection().removeAll(new ArrayList<>(getCollection())), "Empty collection removeAll should return false for nonempty input");
         verify();
 
         resetFull();
-        assertFalse("Full collection removeAll should return false for empty input", getCollection().removeAll(Collections.EMPTY_SET));
+        assertFalse(getCollection().removeAll(Collections.EMPTY_SET), "Full collection removeAll should return false for empty input");
         verify();
 
-        assertFalse("Full collection removeAll should return false for other elements", getCollection().removeAll(Arrays.asList(getOtherElements())));
+        assertFalse(getCollection().removeAll(Arrays.asList(getOtherElements())), "Full collection removeAll should return false for other elements");
         verify();
 
-        assertTrue("Full collection removeAll should return true for full elements",
-                getCollection().removeAll(new HashSet<>(getCollection())));
+        assertTrue(getCollection().removeAll(new HashSet<>(getCollection())),
+                "Full collection removeAll should return true for full elements");
         getConfirmed().removeAll(new HashSet<>(getConfirmed()));
         verify();
 
@@ -926,13 +932,13 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         final int max = getFullElements().length == 1 ? 1 :
                 getFullElements().length <= 5 ? getFullElements().length - 1 : 5;
         final Collection<E> all = Arrays.asList(getFullElements()).subList(min, max);
-        assertTrue("Full collection removeAll should work", getCollection().removeAll(all));
+        assertTrue(getCollection().removeAll(all), "Full collection removeAll should work");
         getConfirmed().removeAll(all);
         verify();
 
-        assertTrue("Collection should shrink after removeAll", getCollection().size() < size);
+        assertTrue(getCollection().size() < size, "Collection should shrink after removeAll");
         for (final E element : all) {
-            assertFalse("Collection shouldn't contain removed element", getCollection().contains(element));
+            assertFalse(getCollection().contains(element), "Collection shouldn't contain removed element");
         }
     }
 
@@ -947,18 +953,17 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         }
 
         resetEmpty();
-        assertFalse("Empty collection removeIf should return false for a predicate that returns only false", getCollection().removeIf(e -> false));
+        assertFalse(getCollection().removeIf(e -> false), "Empty collection removeIf should return false for a predicate that returns only false");
         verify();
 
-        assertFalse("Empty collection removeIf should return false for a predicate that returns only true", getCollection().removeIf(e -> true));
+        assertFalse(getCollection().removeIf(e -> true), "Empty collection removeIf should return false for a predicate that returns only true");
         verify();
 
         resetFull();
-        assertFalse("Full collection removeIf should return false for a predicate that returns only false", getCollection().removeIf(e -> false));
+        assertFalse(getCollection().removeIf(e -> false), "Full collection removeIf should return false for a predicate that returns only false");
         verify();
 
-        assertTrue("Full collection removeIf should return true for a predicate that returns only true",
-                getCollection().removeIf(e -> true));
+        assertTrue(getCollection().removeIf(e -> true), "Full collection removeIf should return true for a predicate that returns only true");
         getConfirmed().removeIf(e -> true);
         verify();
 
@@ -973,12 +978,12 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
 
         final Predicate<E> filter = target::equals;
 
-        assertTrue("Full collection removeIf should work", getCollection().removeIf(filter));
+        assertTrue(getCollection().removeIf(filter), "Full collection removeIf should work");
         getConfirmed().removeIf(filter);
         verify();
 
-        assertEquals("Collection should shrink after removeIf", getCollection().size(), size - targetCount);
-        assertFalse("Collection shouldn't contain removed element", getCollection().contains(target));
+        assertEquals(getCollection().size(), size - targetCount, "Collection should shrink after removeIf");
+        assertFalse(getCollection().contains(target), "Collection shouldn't contain removed element");
     }
 
     /**
@@ -994,52 +999,52 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         final List<E> elements = Arrays.asList(getFullElements());
         final List<E> other = Arrays.asList(getOtherElements());
 
-        assertFalse("Empty retainAll() should return false", getCollection().retainAll(Collections.EMPTY_SET));
+        assertFalse(getCollection().retainAll(Collections.EMPTY_SET), "Empty retainAll() should return false");
         verify();
 
-        assertFalse("Empty retainAll() should return false", getCollection().retainAll(elements));
+        assertFalse(getCollection().retainAll(elements), "Empty retainAll() should return false");
         verify();
 
         resetFull();
-        assertTrue("Collection should change from retainAll empty",
-                getCollection().retainAll(Collections.EMPTY_SET));
+        assertTrue(getCollection().retainAll(Collections.EMPTY_SET),
+                "Collection should change from retainAll empty");
         getConfirmed().retainAll(Collections.EMPTY_SET);
         verify();
 
         resetFull();
-        assertTrue("Collection changed from retainAll other", getCollection().retainAll(other));
+        assertTrue(getCollection().retainAll(other), "Collection changed from retainAll other");
         getConfirmed().retainAll(other);
         verify();
 
         resetFull();
         int size = getCollection().size();
-        assertFalse("Collection shouldn't change from retainAll elements", getCollection().retainAll(elements));
+        assertFalse(getCollection().retainAll(elements), "Collection shouldn't change from retainAll elements");
         verify();
-        assertEquals("Collection size shouldn't change", size, getCollection().size());
+        assertEquals(size, getCollection().size(), "Collection size shouldn't change");
 
         if (getFullElements().length > 1) {
             resetFull();
             size = getCollection().size();
             final int min = getFullElements().length < 4 ? 0 : 2;
             final int max = getFullElements().length <= 5 ? getFullElements().length - 1 : 5;
-            assertTrue("Collection should changed by partial retainAll",
-                    getCollection().retainAll(elements.subList(min, max)));
+            assertTrue(getCollection().retainAll(elements.subList(min, max)),
+                    "Collection should changed by partial retainAll");
             getConfirmed().retainAll(elements.subList(min, max));
             verify();
 
             for (final E element : getCollection()) {
-                assertTrue("Collection only contains retained element", elements.subList(min, max).contains(element));
+                assertTrue(elements.subList(min, max).contains(element), "Collection only contains retained element");
             }
         }
 
         resetFull();
         final HashSet<E> set = new HashSet<>(elements);
         size = getCollection().size();
-        assertFalse("Collection shouldn't change from retainAll without " +
-                "duplicate elements", getCollection().retainAll(set));
+        assertFalse(getCollection().retainAll(set),
+                "Collection shouldn't change from retainAll without " + "duplicate elements");
         verify();
-        assertEquals("Collection size didn't change from nonduplicate " +
-                     "retainAll", size, getCollection().size());
+        assertEquals(size, getCollection().size(),
+                "Collection size didn't change from nonduplicate " + "retainAll");
     }
 
     /**
@@ -1048,10 +1053,10 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     @Test
     public void testCollectionSize() {
         resetEmpty();
-        assertEquals("Size of new Collection is 0.", 0, getCollection().size());
+        assertEquals(0, getCollection().size(), "Size of new Collection is 0.");
 
         resetFull();
-        assertFalse("Size of full collection should be greater than zero", getCollection().isEmpty());
+        assertFalse(getCollection().isEmpty(), "Size of full collection should be greater than zero");
     }
 
     /**
@@ -1060,21 +1065,21 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     @Test
     public void testCollectionToArray() {
         resetEmpty();
-        assertEquals("Empty Collection should return empty array for toArray",
-                     0, getCollection().toArray().length);
+        assertEquals(0, getCollection().toArray().length,
+                "Empty Collection should return empty array for toArray");
 
         resetFull();
         final Object[] array = getCollection().toArray();
-        assertEquals("Full collection toArray should be same size as collection",
-                array.length, getCollection().size());
+        assertEquals(array.length, getCollection().size(),
+                "Full collection toArray should be same size as collection");
         final Object[] confirmedArray = getConfirmed().toArray();
-        assertEquals("length of array from confirmed collection should "
-                + "match the length of the collection's array", confirmedArray.length, array.length);
+        assertEquals(confirmedArray.length, array.length, "length of array from confirmed collection should "
+                + "match the length of the collection's array");
         final boolean[] matched = new boolean[array.length];
 
         for (int i = 0; i < array.length; i++) {
-            assertTrue("Collection should contain element in toArray",
-                    getCollection().contains(array[i]));
+            assertTrue(getCollection().contains(array[i]),
+                    "Collection should contain element in toArray");
 
             boolean match = false;
             // find a match in the confirmed array
@@ -1095,7 +1100,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
             }
         }
         for (final boolean element : matched) {
-            assertTrue("Collection should return all its elements in " + "toArray", element);
+            assertTrue(element, "Collection should return all its elements in " + "toArray");
         }
     }
 
@@ -1107,8 +1112,8 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         resetEmpty();
         Object[] a = { new Object(), null, null };
         Object[] array = getCollection().toArray(a);
-        assertEquals("Given array shouldn't shrink", array, a);
-        assertNull("Last element should be set to null", a[0]);
+        assertEquals(array, a, "Given array shouldn't shrink");
+        assertNull(a[0], "Last element should be set to null");
         verify();
 
         resetFull();
@@ -1127,7 +1132,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         if ((getIterationBehaviour() & UNORDERED) != 0) {
             assertUnorderedArrayEquals(array, a, "toArray(Object[]) and toArray()");
         } else {
-            assertEquals("toArrays should be equal", Arrays.asList(array), Arrays.asList(a));
+            assertEquals(Arrays.asList(array), Arrays.asList(a), "toArrays should be equal");
         }
         // Figure out if they're all the same class
         // TODO: It'd be nicer to detect a common superclass
@@ -1145,15 +1150,15 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
         }
         a = (Object[]) Array.newInstance(cl, 0);
         array = getCollection().toArray(a);
-        assertEquals("toArray(Object[]) should return correct array type",
-                a.getClass(), array.getClass());
+        assertEquals(a.getClass(), array.getClass(),
+                "toArray(Object[]) should return correct array type");
 
         if ((getIterationBehaviour() & UNORDERED) != 0) {
             assertUnorderedArrayEquals(array, getCollection().toArray(), "type-specific toArray(T[]) and toArray()");
         } else {
-            assertEquals("type-specific toArrays should be equal",
-                    Arrays.asList(array),
-                    Arrays.asList(getCollection().toArray()));
+            assertEquals(Arrays.asList(array),
+                    Arrays.asList(getCollection().toArray()),
+                    "type-specific toArrays should be equal");
         }
         verify();
     }
@@ -1169,7 +1174,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
      * @param msg Failure message prefix
      */
     private static void assertUnorderedArrayEquals(final Object[] a1, final Object[] a2, final String msg) {
-        Assertions.assertEquals(a1.length, a2.length, () -> msg + ": length");
+        assertEquals(a1.length, a2.length, () -> msg + ": length");
         final int size = a1.length;
         // Track values that have been matched once (and only once)
         final boolean[] matched = new boolean[size];
@@ -1197,10 +1202,10 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
     @Test
     public void testCollectionToString() {
         resetEmpty();
-        assertNotNull("toString shouldn't return null", getCollection().toString());
+        assertNotNull(getCollection().toString(), "toString shouldn't return null");
 
         resetFull();
-        assertNotNull("toString shouldn't return null", getCollection().toString());
+        assertNotNull(getCollection().toString(), "toString shouldn't return null");
     }
 
     /**
@@ -1327,7 +1332,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
             final Object dest = in.readObject();
             in.close();
             if (isEqualsCheckable()) {
-                assertEquals("obj != deserialize(serialize(obj)) - EMPTY Collection", obj, dest);
+                assertEquals(obj, dest, "obj != deserialize(serialize(obj)) - EMPTY Collection");
             }
         }
         obj = makeFullCollection();
@@ -1341,7 +1346,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
             final Object dest = in.readObject();
             in.close();
             if (isEqualsCheckable()) {
-                assertEquals("obj != deserialize(serialize(obj)) - FULL Collection", obj, dest);
+                assertEquals(obj, dest, "obj != deserialize(serialize(obj)) - FULL Collection");
             }
         }
     }

--- a/src/test/java/org/apache/commons/collections4/collection/CompositeCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/CompositeCollectionTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.collection;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,7 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Predicate;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -258,7 +260,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         final ArrayList<String> nullList = null;
         final CompositeCollection<String> cc = new CompositeCollection<>();
         cc.addComposited(nullList);
-        Assertions.assertEquals(0, cc.size());
+        assertEquals(0, cc.size());
     }
 
     @Test
@@ -266,7 +268,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         final ArrayList<String> nullList = null;
         final CompositeCollection<String> cc = new CompositeCollection<>();
         cc.addComposited(nullList, nullList);
-        Assertions.assertEquals(0, cc.size());
+        assertEquals(0, cc.size());
     }
 
     @Test
@@ -274,7 +276,7 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         final ArrayList<String> nullList = null;
         final CompositeCollection<String> cc = new CompositeCollection<>();
         cc.addComposited(nullList, nullList, nullList);
-        Assertions.assertEquals(0, cc.size());
+        assertEquals(0, cc.size());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
@@ -17,6 +17,8 @@
 package org.apache.commons.collections4.collection;
 
 import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.Serializable;

--- a/src/test/java/org/apache/commons/collections4/collection/PredicatedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/PredicatedCollectionTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.collections4.collection;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
@@ -88,7 +89,7 @@ public class PredicatedCollectionTest<E> extends AbstractCollectionTest<E> {
 
         assertThrows(IllegalArgumentException.class, () -> c.add((E) i), "Integer should fail string predicate.");
 
-        assertFalse("Collection shouldn't contain illegal element", c.contains(i));
+        assertFalse(c.contains(i), "Collection shouldn't contain illegal element");
     }
 
     @Test
@@ -103,10 +104,10 @@ public class PredicatedCollectionTest<E> extends AbstractCollectionTest<E> {
 
         assertThrows(IllegalArgumentException.class, () -> c.addAll(elements), "Integer should fail string predicate.");
 
-        assertFalse("Collection shouldn't contain illegal element", c.contains("one"));
-        assertFalse("Collection shouldn't contain illegal element", c.contains("two"));
-        assertFalse("Collection shouldn't contain illegal element", c.contains(3));
-        assertFalse("Collection shouldn't contain illegal element", c.contains("four"));
+        assertFalse(c.contains("one"), "Collection shouldn't contain illegal element");
+        assertFalse(c.contains("two"), "Collection shouldn't contain illegal element");
+        assertFalse(c.contains(3), "Collection shouldn't contain illegal element");
+        assertFalse(c.contains("four"), "Collection shouldn't contain illegal element");
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/collection/TransformedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/TransformedCollectionTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.collection;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/org/apache/commons/collections4/collection/UnmodifiableBoundedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/UnmodifiableBoundedCollectionTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.collection;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/apache/commons/collections4/collection/UnmodifiableCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/UnmodifiableCollectionTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.collection;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/apache/commons/collections4/comparators/AbstractComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/AbstractComparatorTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.comparators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
@@ -107,7 +111,7 @@ public abstract class AbstractComparatorTest<T> extends AbstractObjectTest {
 
         final List<T> list2 = new LinkedList<>();
 
-        assertEquals("Comparator cannot sort empty lists", list2, list);
+        assertEquals(list2, list, "Comparator cannot sort empty lists");
     }
 
     /**
@@ -123,7 +127,7 @@ public abstract class AbstractComparatorTest<T> extends AbstractObjectTest {
 
         final List<T> orderedList = getComparableObjectsOrdered();
 
-        assertEquals("Comparator did not reorder the List correctly", orderedList, randomList);
+        assertEquals(orderedList, randomList, "Comparator did not reorder the List correctly");
     }
 
     /**
@@ -146,7 +150,7 @@ public abstract class AbstractComparatorTest<T> extends AbstractObjectTest {
         }
         */
 
-        assertEquals("Comparator did not reorder the List correctly", orderedList, randomList);
+        assertEquals(orderedList, randomList, "Comparator did not reorder the List correctly");
     }
 
     /**
@@ -155,8 +159,8 @@ public abstract class AbstractComparatorTest<T> extends AbstractObjectTest {
     @Test
     public void testComparatorIsSerializable() {
         final Comparator<T> comparator = makeObject();
-        assertTrue("This comparator should be Serializable.",
-                   comparator instanceof Serializable);
+        assertTrue(comparator instanceof Serializable,
+                   "This comparator should be Serializable.");
     }
 
     public String getCanonicalComparatorName(final Object object) {
@@ -209,7 +213,7 @@ public abstract class AbstractComparatorTest<T> extends AbstractObjectTest {
 
             final List<T> orderedList = getComparableObjectsOrdered();
 
-            assertEquals("Comparator did not reorder the List correctly", orderedList, randomList);
+            assertEquals(orderedList, randomList, "Comparator did not reorder the List correctly");
         }
     }
 }

--- a/src/test/java/org/apache/commons/collections4/comparators/BooleanComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/BooleanComparatorTest.java
@@ -17,8 +17,12 @@
 package org.apache.commons.collections4.comparators;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/apache/commons/collections4/comparators/ComparatorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/ComparatorChainTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.comparators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -60,7 +62,7 @@ public class ComparatorChainTest extends AbstractComparatorTest<ComparatorChainT
         chain.addComparator(new ComparableComparator<>());
 
         final int correctValue = i1.compareTo(i2);
-        assertEquals("Comparison returns the right order", chain.compare(i1, i2), correctValue);
+        assertEquals(chain.compare(i1, i2), correctValue, "Comparison returns the right order");
     }
 
     @Test
@@ -81,7 +83,7 @@ public class ComparatorChainTest extends AbstractComparatorTest<ComparatorChainT
         final Integer i2 = 6;
 
         final int correctValue = i1.compareTo(i2);
-        assertEquals("Comparison returns the right order", chain.compare(i1, i2), correctValue);
+        assertEquals(chain.compare(i1, i2), correctValue, "Comparison returns the right order");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/comparators/FixedOrderComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/FixedOrderComparatorTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.comparators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Comparator;

--- a/src/test/java/org/apache/commons/collections4/comparators/ReverseComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/ReverseComparatorTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.comparators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
@@ -89,7 +91,7 @@ public class ReverseComparatorTest extends AbstractComparatorTest<Integer> {
         final ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(buffer.toByteArray()));
         final Object dest = in.readObject();
         in.close();
-        assertEquals("obj != deserialize(serialize(obj))", comp, dest);
+        assertEquals(comp, dest, "obj != deserialize(serialize(obj))");
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/comparators/TransformingComparatorTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/TransformingComparatorTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.comparators;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
@@ -67,12 +69,12 @@ public class TransformingComparatorTest extends AbstractComparatorTest<Integer> 
         final TransformingComparator<String, String> comp2 = new TransformingComparator<>(t1, comp1);
 
         // Checks the contract: equals-hashcode on comp1 and comp2
-        assertTrue("Contract failed: equals-hashcode",
-                comp1.equals(comp2) ? comp1.hashCode() == comp2.hashCode() : true);
+        assertTrue(comp1.equals(comp2) ? comp1.hashCode() == comp2.hashCode() : true,
+                "Contract failed: equals-hashcode");
 
         // Checks the contract: equals-hashcode on comp1 and comp2
-        assertTrue("Contract failed: equals-hashcode",
-                comp2.equals(comp1) ? comp2.hashCode() == comp1.hashCode() : true);
+        assertTrue(comp2.equals(comp1) ? comp2.hashCode() == comp1.hashCode() : true,
+                "Contract failed: equals-hashcode");
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/functors/AbstractCompositePredicateTest.java
+++ b/src/test/java/org/apache/commons/collections4/functors/AbstractCompositePredicateTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.collections4.functors;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
@@ -24,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.collections4.Predicate;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -84,7 +84,7 @@ public abstract class AbstractCompositePredicateTest<T> extends AbstractMockPred
     public void singleElementArrayToGetInstance() {
         final Predicate<T> predicate = createMockPredicate(null);
         final Predicate<T> allPredicate = getPredicateInstance(predicate);
-        Assertions.assertSame(predicate, allPredicate, "expected argument to be returned by getInstance()");
+        assertSame(predicate, allPredicate, "expected argument to be returned by getInstance()");
     }
 
     /**
@@ -95,7 +95,7 @@ public abstract class AbstractCompositePredicateTest<T> extends AbstractMockPred
         final Predicate<T> predicate = createMockPredicate(null);
         final Predicate<T> allPredicate = getPredicateInstance(
                 Collections.<Predicate<T>>singleton(predicate));
-        Assertions.assertSame(predicate, allPredicate, "expected argument to be returned by getInstance()");
+        assertSame(predicate, allPredicate, "expected argument to be returned by getInstance()");
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/functors/AbstractPredicateTest.java
+++ b/src/test/java/org/apache/commons/collections4/functors/AbstractPredicateTest.java
@@ -16,8 +16,11 @@
  */
 package org.apache.commons.collections4.functors;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.apache.commons.collections4.Predicate;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +40,7 @@ public abstract class AbstractPredicateTest {
     @Test
     public void predicateSanityTests() throws Exception {
         final Predicate<?> predicate = generatePredicate();
-        Assertions.assertNotNull(predicate);
+        assertNotNull(predicate);
     }
 
     /**
@@ -46,11 +49,11 @@ public abstract class AbstractPredicateTest {
     protected abstract Predicate<?> generatePredicate();
 
     protected <T> void assertPredicateFalse(final Predicate<T> predicate, final T testObject) {
-        Assertions.assertFalse(predicate.evaluate(testObject));
+        assertFalse(predicate.evaluate(testObject));
     }
 
     protected <T> void assertPredicateTrue(final Predicate<T> predicate, final T testObject) {
-        Assertions.assertTrue(predicate.evaluate(testObject));
+        assertTrue(predicate.evaluate(testObject));
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractIteratorTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -109,7 +113,7 @@ public abstract class AbstractIteratorTest<E> extends AbstractObjectTest {
         final Iterator<E> it = makeEmptyIterator();
 
         // hasNext() should return false
-        assertFalse("hasNext() should return false for empty iterators", it.hasNext());
+        assertFalse(it.hasNext(), "hasNext() should return false for empty iterators");
 
         // next() should throw a NoSuchElementException
         assertThrows(NoSuchElementException.class, () -> it.next(),
@@ -131,7 +135,7 @@ public abstract class AbstractIteratorTest<E> extends AbstractObjectTest {
         final Iterator<E> it = makeObject();
 
         // hasNext() must be true (ensure makeFullIterator is correct!)
-        assertTrue("hasNext() should return true for at least one element", it.hasNext());
+        assertTrue(it.hasNext(), "hasNext() should return true for at least one element");
 
         // next() must not throw exception (ensure makeFullIterator is correct!)
         try {

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractListIteratorTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.ListIterator;

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractMapIteratorTest.java
@@ -16,7 +16,12 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.Map;
@@ -161,16 +166,16 @@ public abstract class AbstractMapIteratorTest<K, V> extends AbstractIteratorTest
         while (it.hasNext()) {
             // getKey
             final K key = it.next();
-            assertSame("it.next() should equals getKey()", key, it.getKey());
-            assertTrue("Key must be in map",  map.containsKey(key));
-            assertTrue("Key must be unique", set.add(key));
+            assertSame(key, it.getKey(), "it.next() should equals getKey()");
+            assertTrue(map.containsKey(key),  "Key must be in map");
+            assertTrue(set.add(key), "Key must be unique");
 
             // getValue
             final V value = it.getValue();
             if (!isGetStructuralModify()) {
-                assertSame("Value must be mapped to key", map.get(key), value);
+                assertSame(map.get(key), value, "Value must be mapped to key");
             }
-            assertTrue("Value must be in map",  map.containsValue(value));
+            assertTrue(map.containsValue(value),  "Value must be in map");
 
             verify();
         }
@@ -197,26 +202,26 @@ public abstract class AbstractMapIteratorTest<K, V> extends AbstractIteratorTest
         }
         final V old = it.setValue(newValue);
         confirmed.put(key, newValue);
-        assertSame("Key must not change after setValue", key, it.getKey());
-        assertSame("Value must be changed after setValue", newValue, it.getValue());
-        assertSame("setValue must return old value", value, old);
-        assertTrue("Map must contain key", map.containsKey(key));
+        assertSame(key, it.getKey(), "Key must not change after setValue");
+        assertSame(newValue, it.getValue(), "Value must be changed after setValue");
+        assertSame(value, old, "setValue must return old value");
+        assertTrue(map.containsKey(key), "Map must contain key");
         // test against confirmed, as map may contain value twice
-        assertEquals("Map must not contain old value",
-            confirmed.containsValue(old), map.containsValue(old));
-        assertTrue("Map must contain new value", map.containsValue(newValue));
+        assertEquals(confirmed.containsValue(old), map.containsValue(old),
+            "Map must not contain old value");
+        assertTrue(map.containsValue(newValue), "Map must contain new value");
         verify();
 
         it.setValue(newValue);  // same value - should be OK
         confirmed.put(key, newValue);
-        assertSame("Key must not change after setValue", key, it.getKey());
-        assertSame("Value must be changed after setValue", newValue, it.getValue());
+        assertSame(key, it.getKey(), "Key must not change after setValue");
+        assertSame(newValue, it.getValue(), "Value must be changed after setValue");
         verify();
 
         it.setValue(newValue2);  // new value
         confirmed.put(key, newValue2);
-        assertSame("Key must not change after setValue", key, it.getKey());
-        assertSame("Value must be changed after setValue", newValue2, it.getValue());
+        assertSame(key, it.getKey(), "Key must not change after setValue");
+        assertSame(newValue2, it.getValue(), "Value must be changed after setValue");
         verify();
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractOrderedMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractOrderedMapIteratorTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -95,16 +99,16 @@ public abstract class AbstractOrderedMapIteratorTest<K, V> extends AbstractMapIt
         while (it.hasNext()) {
             // getKey
             final K key = it.next();
-            assertSame("it.next() should equals getKey()", key, it.getKey());
-            assertTrue("Key must be in map",  map.containsKey(key));
-            assertTrue("Key must be unique", set.add(key));
+            assertSame(key, it.getKey(), "it.next() should equals getKey()");
+            assertTrue(map.containsKey(key),  "Key must be in map");
+            assertTrue(set.add(key), "Key must be unique");
 
             // getValue
             final V value = it.getValue();
             if (!isGetStructuralModify()) {
-                assertSame("Value must be mapped to key", map.get(key), value);
+                assertSame(map.get(key), value, "Value must be mapped to key");
             }
-            assertTrue("Value must be in map",  map.containsValue(value));
+            assertTrue(map.containsValue(value),  "Value must be in map");
 
             assertTrue(it.hasPrevious());
 
@@ -113,16 +117,16 @@ public abstract class AbstractOrderedMapIteratorTest<K, V> extends AbstractMapIt
         while (it.hasPrevious()) {
             // getKey
             final Object key = it.previous();
-            assertSame("it.previous() should equals getKey()", key, it.getKey());
-            assertTrue("Key must be in map",  map.containsKey(key));
-            assertTrue("Key must be unique", set.remove(key));
+            assertSame(key, it.getKey(), "it.previous() should equals getKey()");
+            assertTrue(map.containsKey(key),  "Key must be in map");
+            assertTrue(set.remove(key), "Key must be unique");
 
             // getValue
             final Object value = it.getValue();
             if (!isGetStructuralModify()) {
-                assertSame("Value must be mapped to key", map.get(key), value);
+                assertSame(map.get(key), value, "Value must be mapped to key");
             }
-            assertTrue("Value must be in map",  map.containsValue(value));
+            assertTrue(map.containsValue(value),  "Value must be in map");
 
             assertTrue(it.hasNext());
 
@@ -142,7 +146,7 @@ public abstract class AbstractOrderedMapIteratorTest<K, V> extends AbstractMapIt
         final OrderedMapIterator<K, V> it = makeObject();
         final Map<K, V> map = getMap();
 
-        assertEquals("keySet() not consistent", new ArrayList<>(map.keySet()), new ArrayList<>(map.keySet()));
+        assertEquals(new ArrayList<>(map.keySet()), new ArrayList<>(map.keySet()), "keySet() not consistent");
 
         final Iterator<K> it2 = map.keySet().iterator();
         assertTrue(it.hasNext());

--- a/src/test/java/org/apache/commons/collections4/iterators/ArrayIterator2Test.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ArrayIterator2Test.java
@@ -17,7 +17,10 @@
 package org.apache.commons.collections4.iterators;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -69,15 +72,15 @@ public class ArrayIterator2Test<E> extends AbstractIteratorTest<E> {
             final Integer testValue = Integer.valueOf(element);
             final Number iterValue = (Number) iter.next();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
-        assertFalse("Iterator should now be empty", iter.hasNext());
+        assertFalse(iter.hasNext(), "Iterator should now be empty");
 
         try {
             iter.next();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
     }
 
@@ -90,7 +93,7 @@ public class ArrayIterator2Test<E> extends AbstractIteratorTest<E> {
             iter.next();
         }
 
-        assertEquals("the count should be right using ArrayIterator(Object,2) ", count, testArray.length - 2);
+        assertEquals(count, testArray.length - 2, "the count should be right using ArrayIterator(Object,2) ");
 
         iter = makeArrayIterator(testArray, 1, testArray.length - 1);
         count = 0;
@@ -100,9 +103,9 @@ public class ArrayIterator2Test<E> extends AbstractIteratorTest<E> {
         }
 
         assertEquals(
-            "the count should be right using ArrayIterator(Object,1," + (testArray.length - 1) + ") ",
-            count,
-            testArray.length - 2);
+                count,
+                testArray.length - 2,
+                "the count should be right using ArrayIterator(Object,1," + (testArray.length - 1) + ") ");
         assertAll(
                 () -> assertThrows(ArrayIndexOutOfBoundsException.class, () -> makeArrayIterator(testArray, -1),
                         "new ArrayIterator(Object,-1) should throw an ArrayIndexOutOfBoundsException"),

--- a/src/test/java/org/apache/commons/collections4/iterators/ArrayIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ArrayIteratorTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Iterator;
@@ -57,10 +59,10 @@ public class ArrayIteratorTest<E> extends AbstractIteratorTest<E> {
         for (final String testValue : testArray) {
             final E iterValue = iter.next();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
-        assertFalse("Iterator should now be empty", iter.hasNext());
+        assertFalse(iter.hasNext(), "Iterator should now be empty");
 
         assertThrows(NoSuchElementException.class, iter::next, "NoSuchElementException must be thrown");
     }

--- a/src/test/java/org/apache/commons/collections4/iterators/ArrayListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ArrayListIteratorTest.java
@@ -17,6 +17,8 @@
 package org.apache.commons.collections4.iterators;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ListIterator;
@@ -71,15 +73,15 @@ public class ArrayListIteratorTest<E> extends ArrayIteratorTest<E> {
             final Object testValue = testArray[x];
             final Object iterValue = iter.previous();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
-        assertFalse("Iterator should now be empty", iter.hasPrevious());
+        assertFalse(iter.hasPrevious(), "Iterator should now be empty");
 
         try {
             iter.previous();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
 
     }

--- a/src/test/java/org/apache/commons/collections4/iterators/BoundedIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/BoundedIteratorTest.java
@@ -20,7 +20,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -48,12 +51,10 @@ public class BoundedIteratorTest<E> extends AbstractIteratorTest<E> {
         super(BoundedIteratorTest.class.getSimpleName());
     }
 
-    @Override
     @SuppressWarnings("unchecked")
     @BeforeEach
     public void setUp()
         throws Exception {
-        super.setUp();
         testList = Arrays.asList((E[]) testArray);
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/CollatingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/CollatingIteratorTest.java
@@ -16,6 +16,12 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -44,10 +50,8 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
     private ArrayList<Integer> odds = null;
     private ArrayList<Integer> fib = null;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         comparator = new ComparableComparator<>();
         evens = new ArrayList<>();
         odds = new ArrayList<>();
@@ -264,9 +268,9 @@ public class CollatingIteratorTest extends AbstractIteratorTest<Integer> {
         collatingIterator2.setComparator(new ComparableComparator<Integer>());
         for ( ; collatingIterator2.hasNext(); i++ ) {
             final Integer n = collatingIterator2.next();
-            assertEquals("wrong order", (int) n, i + 1);
+            assertEquals((int) n, i + 1, "wrong order");
         }
-        assertEquals("wrong size", i, l1.size() + l2.size());
+        assertEquals(i, l1.size() + l2.size(), "wrong size");
     }
 }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/FilterIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/FilterIteratorTest.java
@@ -17,7 +17,10 @@
 package org.apache.commons.collections4.iterators;
 
 import static org.apache.commons.collections4.functors.TruePredicate.truePredicate;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +32,7 @@ import java.util.NoSuchElementException;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.collections4.functors.NotNullPredicate;
 import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -49,7 +53,6 @@ public class FilterIteratorTest<E> extends AbstractIteratorTest<E> {
     /**
      * Set up instance variables required by this test case.
      */
-    @Override
     @BeforeEach
     public void setUp() {
         array = new String[] { "a", "b", "c" };
@@ -59,7 +62,7 @@ public class FilterIteratorTest<E> extends AbstractIteratorTest<E> {
     /**
      * Tear down instance variables required by this test case.
      */
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         iterator = null;
     }
@@ -183,7 +186,7 @@ public class FilterIteratorTest<E> extends AbstractIteratorTest<E> {
         if (iterator.hasNext()) {
             final Object last = iterator.next();
             iterator.remove();
-            assertFalse("Base of FilterIterator still contains removed element.", list.contains(last));
+            assertFalse(list.contains(last), "Base of FilterIterator still contains removed element.");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
@@ -17,7 +17,10 @@
 package org.apache.commons.collections4.iterators;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -46,7 +49,6 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         super(IteratorChainTest.class.getSimpleName());
     }
 
-    @Override
     @BeforeEach
     public void setUp() {
         list1 = new ArrayList<>();
@@ -82,15 +84,15 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         for (final String testValue : testArray) {
             final Object iterValue = iter.next();
 
-            assertEquals( "Iteration value is correct", testValue, iterValue );
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
-        assertFalse("Iterator should now be empty", iter.hasNext());
+        assertFalse(iter.hasNext(), "Iterator should now be empty");
 
         try {
             iter.next();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
     }
 
@@ -130,16 +132,16 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         for (final String testValue : testArray) {
             final String iterValue = iter.next();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
 
             if (!iterValue.equals("Four")) {
                 iter.remove();
             }
         }
 
-        assertTrue("List is empty", list1.isEmpty());
-        assertEquals("List is empty", 1, list2.size());
-        assertTrue("List is empty", list3.isEmpty());
+        assertTrue(list1.isEmpty(), "List is empty");
+        assertEquals(1, list2.size(), "List is empty");
+        assertTrue(list3.isEmpty(), "List is empty");
     }
 
     @Test
@@ -152,13 +154,13 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         final IteratorChain<String> chain = new IteratorChain<>();
         chain.addIterator(empty.iterator());
         chain.addIterator(notEmpty.iterator());
-        assertTrue("should have next", chain.hasNext());
+        assertTrue(chain.hasNext(), "should have next");
         assertEquals("A", chain.next());
-        assertTrue("should have next", chain.hasNext());
+        assertTrue(chain.hasNext(), "should have next");
         assertEquals("B", chain.next());
-        assertTrue("should have next", chain.hasNext());
+        assertTrue(chain.hasNext(), "should have next");
         assertEquals("C", chain.next());
-        assertFalse("should not have next", chain.hasNext());
+        assertFalse(chain.hasNext(), "should not have next");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorIterableTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorIterableTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;

--- a/src/test/java/org/apache/commons/collections4/iterators/LazyIteratorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/LazyIteratorChainTest.java
@@ -17,7 +17,10 @@
 package org.apache.commons.collections4.iterators;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -46,7 +49,6 @@ public class LazyIteratorChainTest extends AbstractIteratorTest<String> {
         super(LazyIteratorChainTest.class.getSimpleName());
     }
 
-    @Override
     @BeforeEach
     public void setUp() {
         list1 = new ArrayList<>();
@@ -96,15 +98,15 @@ public class LazyIteratorChainTest extends AbstractIteratorTest<String> {
         for (final String testValue : testArray) {
             final Object iterValue = iter.next();
 
-            assertEquals( "Iteration value is correct", testValue, iterValue );
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
-        assertFalse("Iterator should now be empty", iter.hasNext());
+        assertFalse(iter.hasNext(), "Iterator should now be empty");
 
         try {
             iter.next();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
     }
 
@@ -144,16 +146,16 @@ public class LazyIteratorChainTest extends AbstractIteratorTest<String> {
         for (final String testValue : testArray) {
             final String iterValue = iter.next();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
 
             if (!iterValue.equals("Four")) {
                 iter.remove();
             }
         }
 
-        assertTrue("List is empty", list1.isEmpty());
-        assertEquals("List is empty", 1, list2.size());
-        assertTrue("List is empty", list3.isEmpty());
+        assertTrue(list1.isEmpty(), "List is empty");
+        assertEquals(1, list2.size(), "List is empty");
+        assertTrue(list3.isEmpty(), "List is empty");
     }
 
     @Test
@@ -175,13 +177,13 @@ public class LazyIteratorChainTest extends AbstractIteratorTest<String> {
                 return null;
             }
         };
-        assertTrue("should have next", chain.hasNext());
+        assertTrue(chain.hasNext(), "should have next");
         assertEquals("A", chain.next());
-        assertTrue("should have next", chain.hasNext());
+        assertTrue(chain.hasNext(), "should have next");
         assertEquals("B", chain.next());
-        assertTrue("should have next", chain.hasNext());
+        assertTrue(chain.hasNext(), "should have next");
         assertEquals("C", chain.next());
-        assertFalse("should not have next", chain.hasNext());
+        assertFalse(chain.hasNext(), "should not have next");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapper2Test.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapper2Test.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
@@ -42,7 +44,6 @@ public class ListIteratorWrapper2Test<E> extends AbstractIteratorTest<E> {
         super(ListIteratorWrapper2Test.class.getSimpleName());
     }
 
-    @Override
     @BeforeEach
     @SuppressWarnings("unchecked")
     public void setUp() {
@@ -72,15 +73,15 @@ public class ListIteratorWrapper2Test<E> extends AbstractIteratorTest<E> {
         for (final String testValue : testArray) {
             final Object iterValue = iter.next();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
-        assertFalse("Iterator should now be empty", iter.hasNext());
+        assertFalse(iter.hasNext(), "Iterator should now be empty");
 
         try {
             iter.next();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
 
         // now, read it backwards
@@ -88,20 +89,20 @@ public class ListIteratorWrapper2Test<E> extends AbstractIteratorTest<E> {
             final Object testValue = testArray[i];
             final E iterValue = iter.previous();
 
-            assertEquals( "Iteration value is correct", testValue, iterValue );
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
         try {
             iter.previous();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
 
         // now, read it forwards again
         for (final String testValue : testArray) {
             final Object iterValue = iter.next();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
     }
@@ -185,18 +186,18 @@ public class ListIteratorWrapper2Test<E> extends AbstractIteratorTest<E> {
         iter.reset();
 
         // after reset, there shouldn't be any previous elements
-        assertFalse("No previous elements after reset()", iter.hasPrevious());
+        assertFalse(iter.hasPrevious(), "No previous elements after reset()");
 
         // after reset, the results should be the same as before
-        assertEquals("First element should be the same", first, iter.next());
-        assertEquals("Second element should be the same", second, iter.next());
+        assertEquals(first, iter.next(), "First element should be the same");
+        assertEquals(second, iter.next(), "Second element should be the same");
 
         // after passing the point, where we reset, continuation should work as expected
         for (int i = 2; i < testArray.length; i++) {
             final Object testValue = testArray[i];
             final E iterValue = iter.next();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapperTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ListIteratorWrapperTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
@@ -43,7 +45,6 @@ public class ListIteratorWrapperTest<E> extends AbstractIteratorTest<E> {
         super(ListIteratorWrapperTest.class.getSimpleName());
     }
 
-    @Override
     @BeforeEach
     @SuppressWarnings("unchecked")
     public void setUp() {
@@ -73,15 +74,15 @@ public class ListIteratorWrapperTest<E> extends AbstractIteratorTest<E> {
         for (final String testValue : testArray) {
             final Object iterValue = iter.next();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
-        assertFalse("Iterator should now be empty", iter.hasNext());
+        assertFalse(iter.hasNext(), "Iterator should now be empty");
 
         try {
             iter.next();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
 
         // now, read it backwards
@@ -89,20 +90,20 @@ public class ListIteratorWrapperTest<E> extends AbstractIteratorTest<E> {
             final Object testValue = testArray[i];
             final E iterValue = iter.previous();
 
-            assertEquals( "Iteration value is correct", testValue, iterValue );
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
         try {
             iter.previous();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
 
         // now, read it forwards again
         for (final String testValue : testArray) {
             final Object iterValue = iter.next();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
     }
@@ -207,18 +208,18 @@ public class ListIteratorWrapperTest<E> extends AbstractIteratorTest<E> {
         iter.reset();
 
         // after reset, there shouldn't be any previous elements
-        assertFalse("No previous elements after reset()", iter.hasPrevious());
+        assertFalse(iter.hasPrevious(), "No previous elements after reset()");
 
         // after reset, the results should be the same as before
-        assertEquals("First element should be the same", first, iter.next());
-        assertEquals("Second element should be the same", second, iter.next());
+        assertEquals(first, iter.next(), "First element should be the same");
+        assertEquals(second, iter.next(), "Second element should be the same");
 
         // after passing the point, where we reset, continuation should work as expected
         for (int i = 2; i < testArray.length; i++) {
             final Object testValue = testArray[i];
             final E iterValue = iter.next();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/NodeListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/NodeListIteratorTest.java
@@ -49,10 +49,8 @@ public class NodeListIteratorTest extends AbstractIteratorTest<Node> {
         super(NodeListIteratorTest.class.getSimpleName());
     }
 
-    @Override
     @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
 
         // Default: use standard constr.
         createIteratorWithStandardConstr = true;

--- a/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayIteratorTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Iterator;
@@ -74,15 +76,15 @@ public class ObjectArrayIteratorTest<E> extends AbstractIteratorTest<E> {
         for (final String testValue : testArray) {
             final E iterValue = iter.next();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
-        assertFalse("Iterator should now be empty", iter.hasNext());
+        assertFalse(iter.hasNext(), "Iterator should now be empty");
 
         try {
             iter.next();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ObjectArrayListIteratorTest.java
@@ -17,6 +17,8 @@
 package org.apache.commons.collections4.iterators;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ListIterator;
@@ -68,15 +70,15 @@ public class ObjectArrayListIteratorTest<E> extends ObjectArrayIteratorTest<E> {
             final Object testValue = testArray[x];
             final Object iterValue = iter.previous();
 
-            assertEquals("Iteration value is correct", testValue, iterValue);
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
-        assertFalse("Iterator should now be empty", iter.hasPrevious());
+        assertFalse(iter.hasPrevious(), "Iterator should now be empty");
 
         try {
             iter.previous();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
 
     }

--- a/src/test/java/org/apache/commons/collections4/iterators/ObjectGraphIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ObjectGraphIteratorTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -44,7 +48,6 @@ public class ObjectGraphIteratorTest extends AbstractIteratorTest<Object> {
         super(ObjectGraphIteratorTest.class.getSimpleName());
     }
 
-    @Override
     @BeforeEach
     public void setUp() {
         list1 = new ArrayList<>();

--- a/src/test/java/org/apache/commons/collections4/iterators/PeekingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/PeekingIteratorTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,11 +48,9 @@ public class PeekingIteratorTest<E> extends AbstractIteratorTest<E> {
     /**
      * {@inheritDoc}
      */
-    @Override
     @SuppressWarnings("unchecked")
     @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         testList = new ArrayList<>(Arrays.asList((E[]) testArray));
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/PermutationIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/PermutationIteratorTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,7 +47,6 @@ public class PermutationIteratorTest extends AbstractIteratorTest<List<Character
         super(PermutationIteratorTest.class.getSimpleName());
     }
 
-    @Override
     @BeforeEach
     public void setUp() {
         testList = new ArrayList<>();

--- a/src/test/java/org/apache/commons/collections4/iterators/PushbackIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/PushbackIteratorTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,11 +45,9 @@ public class PushbackIteratorTest<E> extends AbstractIteratorTest<E> {
     /**
      * {@inheritDoc}
      */
-    @Override
     @SuppressWarnings("unchecked")
     @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         testList = new ArrayList<>(Arrays.asList((E[]) testArray));
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/ReverseListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ReverseListIteratorTest.java
@@ -17,7 +17,10 @@
 package org.apache.commons.collections4.iterators;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -96,7 +99,7 @@ public class ReverseListIteratorTest<E> extends AbstractListIteratorTest<E> {
 
         // loop back through comparing
         for (int i = list.size() - 1; i >= 0; i--) {
-            assertEquals("" + i, list.size() - i - 2, it.nextIndex());  // reversed index
+            assertEquals(list.size() - i - 2, it.nextIndex(), "" + i);  // reversed index
             assertEquals(list.size() - i - 1, it.previousIndex());  // reversed index
 
             final Object obj = list.get(i);

--- a/src/test/java/org/apache/commons/collections4/iterators/SingletonIterator2Test.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/SingletonIterator2Test.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -63,17 +67,17 @@ public class SingletonIterator2Test<E> extends AbstractIteratorTest<E> {
     @Test
     public void testIterator() {
         final Iterator<E> iter = makeObject();
-        assertTrue("Iterator has a first item", iter.hasNext());
+        assertTrue(iter.hasNext(), "Iterator has a first item");
 
         final E iterValue = iter.next();
-        assertEquals("Iteration value is correct", testValue, iterValue);
+        assertEquals(testValue, iterValue, "Iteration value is correct");
 
-        assertFalse("Iterator should now be empty", iter.hasNext());
+        assertFalse(iter.hasNext(), "Iterator should now be empty");
 
         try {
             iter.next();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/SingletonIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/SingletonIteratorTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -66,17 +70,17 @@ public class SingletonIteratorTest<E> extends AbstractIteratorTest<E> {
     @Test
     public void testIterator() {
         final Iterator<E> iter = makeObject();
-        assertTrue("Iterator has a first item", iter.hasNext());
+        assertTrue(iter.hasNext(), "Iterator has a first item");
 
         final E iterValue = iter.next();
-        assertEquals("Iteration value is correct", testValue, iterValue);
+        assertEquals(testValue, iterValue, "Iteration value is correct");
 
-        assertFalse("Iterator should now be empty", iter.hasNext());
+        assertFalse(iter.hasNext(), "Iterator should now be empty");
 
         try {
             iter.next();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/SingletonListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/SingletonListIteratorTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 
@@ -70,45 +74,45 @@ public class SingletonListIteratorTest<E> extends AbstractListIteratorTest<E> {
     @Test
     public void testIterator() {
         final ListIterator<E> iter = makeObject();
-        assertTrue( "Iterator should have next item", iter.hasNext() );
-        assertFalse("Iterator should have no previous item", iter.hasPrevious());
-        assertEquals( "Iteration next index", 0, iter.nextIndex() );
-        assertEquals( "Iteration previous index", -1, iter.previousIndex() );
+        assertTrue(iter.hasNext(), "Iterator should have next item");
+        assertFalse(iter.hasPrevious(), "Iterator should have no previous item");
+        assertEquals(0, iter.nextIndex(), "Iteration next index");
+        assertEquals(-1, iter.previousIndex(), "Iteration previous index");
 
         Object iterValue = iter.next();
-        assertEquals( "Iteration value is correct", testValue, iterValue );
+        assertEquals(testValue, iterValue, "Iteration value is correct");
 
-        assertFalse("Iterator should have no next item", iter.hasNext());
-        assertTrue( "Iterator should have previous item", iter.hasPrevious() );
-        assertEquals( "Iteration next index", 1, iter.nextIndex() );
-        assertEquals( "Iteration previous index", 0, iter.previousIndex() );
+        assertFalse(iter.hasNext(), "Iterator should have no next item");
+        assertTrue(iter.hasPrevious(), "Iterator should have previous item");
+        assertEquals(1, iter.nextIndex(), "Iteration next index");
+        assertEquals(0, iter.previousIndex(), "Iteration previous index");
 
         iterValue = iter.previous();
-        assertEquals( "Iteration value is correct", testValue, iterValue );
+        assertEquals(testValue, iterValue, "Iteration value is correct");
 
-        assertTrue( "Iterator should have next item", iter.hasNext() );
-        assertFalse("Iterator should have no previous item", iter.hasPrevious());
-        assertEquals( "Iteration next index", 0, iter.nextIndex() );
-        assertEquals( "Iteration previous index", -1, iter.previousIndex() );
+        assertTrue(iter.hasNext(), "Iterator should have next item");
+        assertFalse(iter.hasPrevious(), "Iterator should have no previous item");
+        assertEquals(0, iter.nextIndex(), "Iteration next index");
+        assertEquals(-1, iter.previousIndex(), "Iteration previous index");
 
         iterValue = iter.next();
-        assertEquals( "Iteration value is correct", testValue, iterValue );
+        assertEquals(testValue, iterValue, "Iteration value is correct");
 
-        assertFalse("Iterator should have no next item", iter.hasNext());
-        assertTrue( "Iterator should have previous item", iter.hasPrevious() );
-        assertEquals( "Iteration next index", 1, iter.nextIndex() );
-        assertEquals( "Iteration previous index", 0, iter.previousIndex() );
+        assertFalse(iter.hasNext(), "Iterator should have no next item");
+        assertTrue(iter.hasPrevious(), "Iterator should have previous item");
+        assertEquals(1, iter.nextIndex(), "Iteration next index");
+        assertEquals(0, iter.previousIndex(), "Iteration previous index");
 
         try {
             iter.next();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
         iter.previous();
         try {
             iter.previous();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/SkippingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/SkippingIteratorTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,12 +47,10 @@ public class SkippingIteratorTest<E> extends AbstractIteratorTest<E> {
         super(SkippingIteratorTest.class.getSimpleName());
     }
 
-    @Override
     @SuppressWarnings("unchecked")
     @BeforeEach
     public void setUp()
         throws Exception {
-        super.setUp();
         testList = Arrays.asList((E[]) testArray);
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/UniqueFilterIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UniqueFilterIteratorTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -39,7 +42,6 @@ public class UniqueFilterIteratorTest<E> extends AbstractIteratorTest<E> {
         super(UniqueFilterIteratorTest.class.getSimpleName());
     }
 
-    @Override
     @BeforeEach
     @SuppressWarnings("unchecked")
     public void setUp() {
@@ -74,15 +76,15 @@ public class UniqueFilterIteratorTest<E> extends AbstractIteratorTest<E> {
         for (final String testValue : testArray) {
             final E iterValue = iter.next();
 
-            assertEquals( "Iteration value is correct", testValue, iterValue );
+            assertEquals(testValue, iterValue, "Iteration value is correct");
         }
 
-        assertFalse("Iterator should now be empty", iter.hasNext());
+        assertFalse(iter.hasNext(), "Iterator should now be empty");
 
         try {
             iter.next();
         } catch (final Exception e) {
-            assertEquals("NoSuchElementException must be thrown", e.getClass(), new NoSuchElementException().getClass());
+            assertEquals(e.getClass(), new NoSuchElementException().getClass(), "NoSuchElementException must be thrown");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableIteratorTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,11 +46,9 @@ public class UnmodifiableIteratorTest<E> extends AbstractIteratorTest<E> {
     /**
      * {@inheritDoc}
      */
-    @Override
     @SuppressWarnings("unchecked")
     @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         testList = new ArrayList<>(Arrays.asList((E[]) testArray));
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableListIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableListIteratorTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,11 +46,9 @@ public class UnmodifiableListIteratorTest<E> extends AbstractListIteratorTest<E>
     /**
      * {@inheritDoc}
      */
-    @Override
     @SuppressWarnings("unchecked")
     @BeforeEach
     protected void setUp() throws Exception {
-        super.setUp();
         testList = new ArrayList<>(Arrays.asList((E[]) testArray));
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableMapIteratorTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableOrderedMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableOrderedMapIteratorTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/org/apache/commons/collections4/iterators/ZippingIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/ZippingIteratorTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.iterators;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 
 import org.apache.commons.collections4.IteratorUtils;
@@ -40,10 +44,8 @@ public class ZippingIteratorTest extends AbstractIteratorTest<Integer> {
     private ArrayList<Integer> odds = null;
     private ArrayList<Integer> fib = null;
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         evens = new ArrayList<>();
         odds = new ArrayList<>();
         for (int i = 0; i < 20; i++) {

--- a/src/test/java/org/apache/commons/collections4/list/AbstractLinkedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/AbstractLinkedListTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.collections4.list;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;

--- a/src/test/java/org/apache/commons/collections4/list/AbstractListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/AbstractListTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.list;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -36,7 +39,6 @@ import java.util.NoSuchElementException;
 import org.apache.commons.collections4.BulkTest;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.iterators.AbstractListIteratorTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -84,22 +86,22 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         final List<E> list1 = getCollection();
         final List<E> list2 = getConfirmed();
 
-        assertEquals("List should equal confirmed", list1, list2);
-        assertEquals("Confirmed should equal list", list2, list1);
+        assertEquals(list1, list2, "List should equal confirmed");
+        assertEquals(list2, list1, "Confirmed should equal list");
 
-        assertEquals("Hash codes should be equal", list1.hashCode(), list2.hashCode());
+        assertEquals(list1.hashCode(), list2.hashCode(), "Hash codes should be equal");
 
         int i = 0;
         final Iterator<E> iterator1 = list1.iterator();
         final E[] array = (E[]) list1.toArray();
         for (Object o2 : list2) {
-            assertTrue("List iterator should have next", iterator1.hasNext());
+            assertTrue(iterator1.hasNext(), "List iterator should have next");
             final Object o1 = iterator1.next();
-            assertEquals("Iterator elements should be equal", o1, o2);
+            assertEquals(o1, o2, "Iterator elements should be equal");
             o2 = list1.get(i);
-            assertEquals("get should return correct element", o1, o2);
+            assertEquals(o1, o2, "get should return correct element");
             o2 = array[i];
-            assertEquals("toArray should have correct element", o1, o2);
+            assertEquals(o1, o2, "toArray should have correct element");
             i++;
         }
     }
@@ -253,32 +255,32 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     public void testListEquals() {
         resetEmpty();
         List<E> list = getCollection();
-        assertTrue("Empty lists should be equal", list.equals(getConfirmed()));
+        assertTrue(list.equals(getConfirmed()), "Empty lists should be equal");
         verify();
-        assertTrue("Empty list should equal self", list.equals(list));
+        assertTrue(list.equals(list), "Empty list should equal self");
         verify();
 
         List<E> list2 = Arrays.asList(getFullElements());
-        assertFalse("Empty list shouldn't equal full", list.equals(list2));
+        assertFalse(list.equals(list2), "Empty list shouldn't equal full");
         verify();
 
         list2 = Arrays.asList(getOtherElements());
-        assertFalse("Empty list shouldn't equal other", list.equals(list2));
+        assertFalse(list.equals(list2), "Empty list shouldn't equal other");
         verify();
 
         resetFull();
         list = getCollection();
-        assertTrue("Full lists should be equal", list.equals(getConfirmed()));
+        assertTrue(list.equals(getConfirmed()), "Full lists should be equal");
         verify();
-        assertTrue("Full list should equal self", list.equals(list));
+        assertTrue(list.equals(list), "Full list should equal self");
         verify();
 
         list2 = makeObject();
-        assertFalse("Full list shouldn't equal empty", list.equals(list2));
+        assertFalse(list.equals(list2), "Full list shouldn't equal empty");
         verify();
 
         list2 = Arrays.asList(getOtherElements());
-        assertFalse("Full list shouldn't equal other", list.equals(list2));
+        assertFalse(list.equals(list2), "Full list shouldn't equal other");
         verify();
 
         list2 = Arrays.asList(getFullElements());
@@ -291,13 +293,13 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         }
         if (list2.size() > 1) {
             Collections.reverse(list2);
-            assertFalse("Full list shouldn't equal full list with same elements but different order", list.equals(list2));
+            assertFalse(list.equals(list2), "Full list shouldn't equal full list with same elements but different order");
             verify();
         }
 
         resetFull();
         list = getCollection();
-        assertFalse("List shouldn't equal String", list.equals(""));
+        assertFalse(list.equals(""), "List shouldn't equal String");
         verify();
 
         final List<E> listForC = Arrays.asList(getFullElements());
@@ -313,7 +315,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
             }
         };
 
-        assertFalse("List shouldn't equal nonlist with same elements in same order", list.equals(c));
+        assertFalse(list.equals(c), "List shouldn't equal nonlist with same elements in same order");
         verify();
     }
 
@@ -325,13 +327,13 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         resetEmpty();
         int hash1 = getCollection().hashCode();
         int hash2 = getConfirmed().hashCode();
-        assertEquals("Empty lists should have equal hashCodes", hash1, hash2);
+        assertEquals(hash1, hash2, "Empty lists should have equal hashCodes");
         verify();
 
         resetFull();
         hash1 = getCollection().hashCode();
         hash2 = getConfirmed().hashCode();
-        assertEquals("Full lists should have equal hashCodes", hash1, hash2);
+        assertEquals(hash1, hash2, "Full lists should have equal hashCodes");
         verify();
     }
 
@@ -344,7 +346,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         final List<E> list = getCollection();
         final E[] elements = getFullElements();
         for (int i = 0; i < elements.length; i++) {
-            assertEquals("List should contain correct elements", elements[i], list.get(i));
+            assertEquals(elements[i], list.get(i), "List should contain correct elements");
             verify();
         }
     }
@@ -404,15 +406,15 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         final List<E> list2 = getConfirmed();
 
         for (final E element : list2) {
-            assertEquals("indexOf should return correct result",
-                    list1.indexOf(element), list2.indexOf(element));
+            assertEquals(list1.indexOf(element),
+                    list2.indexOf(element), "indexOf should return correct result");
             verify();
         }
 
         final E[] other = getOtherElements();
         for (final E element : other) {
-            assertEquals("indexOf should return -1 for nonexistent element",
-                -1, list1.indexOf(element));
+            assertEquals(-1, list1.indexOf(element),
+                    "indexOf should return -1 for nonexistent element");
             verify();
         }
     }
@@ -427,15 +429,15 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         final List<E> list2 = getConfirmed();
 
         for (final E element : list2) {
-            assertEquals("lastIndexOf should return correct result",
-                list1.lastIndexOf(element), list2.lastIndexOf(element));
+            assertEquals(list1.lastIndexOf(element), list2.lastIndexOf(element),
+                    "lastIndexOf should return correct result");
             verify();
         }
 
         final E[] other = getOtherElements();
         for (final E element : other) {
-            assertEquals("lastIndexOf should return -1 for nonexistent " +
-                "element", -1, list1.lastIndexOf(element));
+            assertEquals(-1, list1.lastIndexOf(element),
+                    "lastIndexOf should return -1 for nonexistent " + "element");
             verify();
         }
     }
@@ -511,7 +513,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         for (int i = 0; i < elements.length; i++) {
             final E n = other[i % other.length];
             final E v = getCollection().set(i, n);
-            assertEquals("Set should return correct element", elements[i], v);
+            assertEquals(elements[i], v, "Set should return correct element");
             getConfirmed().set(i, n);
             verify();
         }
@@ -602,7 +604,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
             resetFull();
             final E o1 = getCollection().remove(i);
             final E o2 = getConfirmed().remove(i);
-            assertEquals("remove should return correct element", o1, o2);
+            assertEquals(o1, o2, "remove should return correct element");
             verify();
         }
     }
@@ -777,19 +779,19 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         final int max = getFullElements().length;
 
         while (i < max) {
-            assertTrue("Iterator should have next", iter.hasNext());
-            assertEquals("Iterator.nextIndex should work",
-                i, iter.nextIndex());
-            assertEquals("Iterator.previousIndex should work",
-                i - 1, iter.previousIndex());
+            assertTrue(iter.hasNext(), "Iterator should have next");
+            assertEquals(i, iter.nextIndex(),
+                "Iterator.nextIndex should work");
+            assertEquals(i - 1, iter.previousIndex(),
+                "Iterator.previousIndex should work");
             final Object o = iter.next();
-            assertEquals("Iterator returned correct element", list.get(i), o);
+            assertEquals(list.get(i), o, "Iterator returned correct element");
             i++;
         }
 
-        assertFalse("Iterator shouldn't have next", iter.hasNext());
-        assertEquals("nextIndex should be size", max, iter.nextIndex());
-        assertEquals("previousIndex should be size - 1", max - 1, iter.previousIndex());
+        assertFalse(iter.hasNext(), "Iterator shouldn't have next");
+        assertEquals(max, iter.nextIndex(), "nextIndex should be size");
+        assertEquals(max - 1, iter.previousIndex(), "previousIndex should be size - 1");
 
         assertThrows(NoSuchElementException.class, () -> iter.next(),
                 "Exhausted iterator should raise NoSuchElement");
@@ -805,23 +807,23 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         final List<E> list = getCollection();
 
         while (i > 0) {
-            assertTrue("Iterator should have previous, i:" + i,
-                iter.hasPrevious());
-            assertEquals("Iterator.nextIndex should work, i:" + i,
-                i, iter.nextIndex());
-            assertEquals("Iterator.previousIndex should work, i:" + i,
-                i - 1, iter.previousIndex());
+            assertTrue(iter.hasPrevious(),
+                "Iterator should have previous, i:" + i);
+            assertEquals(i, iter.nextIndex(),
+                "Iterator.nextIndex should work, i:" + i);
+            assertEquals(i - 1, iter.previousIndex(),
+                "Iterator.previousIndex should work, i:" + i);
             final E o = iter.previous();
-            assertEquals("Iterator returned correct element",
-                list.get(i - 1), o);
+            assertEquals(list.get(i - 1), o,
+                "Iterator returned correct element");
             i--;
         }
 
-        assertFalse("Iterator shouldn't have previous", iter.hasPrevious());
+        assertFalse(iter.hasPrevious(), "Iterator shouldn't have previous");
         final int nextIndex = iter.nextIndex();
-        assertEquals("nextIndex should be 0", 0, nextIndex);
+        assertEquals(0, nextIndex, "nextIndex should be 0");
         final int prevIndex = iter.previousIndex();
-        assertEquals("previousIndex should be -1", -1, prevIndex);
+        assertEquals(-1, prevIndex, "previousIndex should be -1");
 
         assertThrows(NoSuchElementException.class, () -> iter.previous(),
                 "Exhausted iterator should raise NoSuchElement");
@@ -899,8 +901,8 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         final byte[] object = writeExternalFormToBytes((Serializable) list);
         final List<E> list2 = (List<E>) readExternalFormFromBytes(object);
 
-        assertEquals("Both lists are empty", 0, list.size());
-        assertEquals("Both lists are empty", 0, list2.size());
+        assertEquals(0, list.size(), "Both lists are empty");
+        assertEquals(0, list2.size(), "Both lists are empty");
     }
 
     @Test
@@ -915,8 +917,8 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         final byte[] object = writeExternalFormToBytes((Serializable) list);
         final List<E> list2 = (List<E>) readExternalFormFromBytes(object);
 
-        assertEquals("Both lists are same size", size, list.size());
-        assertEquals("Both lists are same size", size, list2.size());
+        assertEquals(size, list.size(), "Both lists are same size");
+        assertEquals(size, list2.size(), "Both lists are same size");
     }
 
     /**
@@ -939,7 +941,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
         if (list instanceof Serializable && !skipSerializedCanonicalTests()
                 && isTestSerialization()) {
             final List<E> list2 = (List<E>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(list));
-            assertEquals("List is empty", 0, list2.size());
+            assertEquals(0, list2.size(), "List is empty");
             assertEquals(list, list2);
         }
     }
@@ -967,7 +969,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
                 // old serialized tests
                 return;
             }
-            assertEquals("List is the right size", list.size(), list2.size());
+            assertEquals(list.size(), list2.size(), "List is the right size");
             assertEquals(list, list2);
         }
     }
@@ -1185,7 +1187,7 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
 
         final InvocationTargetException thrown = assertThrows(InvocationTargetException.class, () -> m.invoke(list, params),
                 m.getName() + " should raise ConcurrentModification");
-        Assertions.assertTrue(thrown.getTargetException() instanceof ConcurrentModificationException,
+        assertTrue(thrown.getTargetException() instanceof ConcurrentModificationException,
                 m.getName() + " raised unexpected " + thrown.getTargetException());
     }
 

--- a/src/test/java/org/apache/commons/collections4/list/Collections701Test.java
+++ b/src/test/java/org/apache/commons/collections4/list/Collections701Test.java
@@ -16,12 +16,13 @@
  */
 package org.apache.commons.collections4.list;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -33,16 +34,16 @@ public class Collections701Test {
     public void testArrayList() {
         final List<Object> list = new ArrayList<>();
         list.add(list);
-        Assertions.assertEquals(1, list.size());
-        Assertions.assertEquals(list, list.get(0));
+        assertEquals(1, list.size());
+        assertEquals(list, list.get(0));
     }
 
     @Test
     public void testHashSet() {
         final Set<Object> set = new HashSet<>();
         set.add(set);
-        Assertions.assertEquals(1, set.size());
-        Assertions.assertEquals(set, set.iterator().next());
+        assertEquals(1, set.size());
+        assertEquals(set, set.iterator().next());
     }
 
     @Test
@@ -50,8 +51,8 @@ public class Collections701Test {
         final List<Object> source = new ArrayList<>();
         final List<Object> list = SetUniqueList.setUniqueList(source);
         list.add(list);
-        Assertions.assertEquals(1, list.size());
-        Assertions.assertEquals(list, list.get(0));
+        assertEquals(1, list.size());
+        assertEquals(list, list.get(0));
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/list/CursorableLinkedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/CursorableLinkedListTest.java
@@ -17,7 +17,13 @@
 package org.apache.commons.collections4.list;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
@@ -42,7 +48,6 @@ public class CursorableLinkedListTest<E> extends AbstractLinkedListTest<E> {
     }
     private CursorableLinkedList<E> list;
 
-    @Override
     @BeforeEach
     public void setUp() {
         list = new CursorableLinkedList<>();

--- a/src/test/java/org/apache/commons/collections4/list/FixedSizeListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/FixedSizeListTest.java
@@ -16,13 +16,15 @@
  */
 package org.apache.commons.collections4.list;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -81,9 +83,9 @@ public class FixedSizeListTest<E> extends AbstractListTest<E> {
         final int sizeBefore = fixedSizeList.size();
         //
         final boolean changed = decoratedList.add("New Value");
-        Assertions.assertTrue(changed);
+        assertTrue(changed);
         //
-        Assertions.assertEquals(sizeBefore + 1, fixedSizeList.size(),
+        assertEquals(sizeBefore + 1, fixedSizeList.size(),
                 "Modifying an the underlying list is allowed");
     }
 
@@ -125,22 +127,22 @@ public class FixedSizeListTest<E> extends AbstractListTest<E> {
         final FixedSizeList<String> fixedSizeList = initFixedSizeList();
 
         final List<String> subFixedSizeList = fixedSizeList.subList(1, 1);
-        Assertions.assertNotNull(subFixedSizeList);
-        Assertions.assertEquals(0, subFixedSizeList.size());
+        assertNotNull(subFixedSizeList);
+        assertEquals(0, subFixedSizeList.size());
     }
 
     @Test
     public void testIsFull() {
         final FixedSizeList<String> fixedSizeList = initFixedSizeList();
 
-        Assertions.assertTrue(fixedSizeList.isFull());
+        assertTrue(fixedSizeList.isFull());
     }
 
     @Test
     public void testMaxSize() {
         final FixedSizeList<String> fixedSizeList = initFixedSizeList();
 
-        Assertions.assertEquals(2, fixedSizeList.maxSize());
+        assertEquals(2, fixedSizeList.maxSize());
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/list/GrowthListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/GrowthListTest.java
@@ -19,6 +19,8 @@ package org.apache.commons.collections4.list;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;

--- a/src/test/java/org/apache/commons/collections4/list/LazyListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/LazyListTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections4.list;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/test/java/org/apache/commons/collections4/list/PredicatedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/PredicatedListTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.collections4.list;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -70,7 +74,7 @@ public class PredicatedListTest<E> extends AbstractListTest<E> {
         assertThrows(IllegalArgumentException.class, () -> list.add((E) i),
                 "Integer should fail string predicate.");
 
-        assertFalse("Collection shouldn't contain illegal element", list.contains(i));
+        assertFalse(list.contains(i), "Collection shouldn't contain illegal element");
     }
 
     @Test
@@ -86,10 +90,10 @@ public class PredicatedListTest<E> extends AbstractListTest<E> {
         assertThrows(IllegalArgumentException.class, () -> list.addAll(0, elements),
                 "Integer should fail string predicate.");
 
-        assertFalse("List shouldn't contain illegal element", list.contains("one"));
-        assertFalse("List shouldn't contain illegal element", list.contains("two"));
-        assertFalse("List shouldn't contain illegal element", list.contains(Integer.valueOf(3)));
-        assertFalse("List shouldn't contain illegal element", list.contains("four"));
+        assertFalse(list.contains("one"), "List shouldn't contain illegal element");
+        assertFalse(list.contains("two"), "List shouldn't contain illegal element");
+        assertFalse(list.contains(Integer.valueOf(3)), "List shouldn't contain illegal element");
+        assertFalse(list.contains("four"), "List shouldn't contain illegal element");
     }
 
     @Test
@@ -110,10 +114,10 @@ public class PredicatedListTest<E> extends AbstractListTest<E> {
         elements.add((E) "two");
         elements.add((E) "three");
         list.addAll(1, elements);
-        assertTrue("List should contain legal element", list.contains("zero"));
-        assertTrue("List should contain legal element", list.contains("one"));
-        assertTrue("List should contain legal element", list.contains("two"));
-        assertTrue("List should contain legal element", list.contains("three"));
+        assertTrue(list.contains("zero"), "List should contain legal element");
+        assertTrue(list.contains("one"), "List should contain legal element");
+        assertTrue(list.contains("two"), "List should contain legal element");
+        assertTrue(list.contains("three"), "List should contain legal element");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.collections4.list;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -99,11 +103,11 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         final E obj = (E) Integer.valueOf(1);
         lset.add(obj);
         lset.add(obj);
-        assertEquals("Duplicate element was added.", 1, lset.size());
+        assertEquals(1, lset.size(), "Duplicate element was added.");
 
         // Unique element
         lset.add((E) Integer.valueOf(2));
-        assertEquals("Unique element was not added.", 2, lset.size());
+        assertEquals(2, lset.size(), "Unique element was not added.");
     }
 
     @Test
@@ -114,7 +118,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         lset.addAll(
             Arrays.asList((E[]) new Integer[] { Integer.valueOf(1), Integer.valueOf(1)}));
 
-        assertEquals("Duplicate element was added.", 1, lset.size());
+        assertEquals(1, lset.size(), "Duplicate element was added.");
     }
 
     @Test
@@ -126,10 +130,10 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         boolean r = getCollection().addAll(Arrays.asList(elements));
         getConfirmed().addAll(Arrays.asList(elements));
         verify();
-        assertTrue("Empty collection should change after addAll", r);
+        assertTrue(r, "Empty collection should change after addAll");
         for (final E element : elements) {
-            assertTrue("Collection should contain added element",
-                    getCollection().contains(element));
+            assertTrue(getCollection().contains(element),
+                    "Collection should contain added element");
         }
 
         resetFull();
@@ -138,13 +142,13 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         r = getCollection().addAll(Arrays.asList(elements));
         getConfirmed().addAll(Arrays.asList(elements));
         verify();
-        assertTrue("Full collection should change after addAll", r);
+        assertTrue(r, "Full collection should change after addAll");
         for (int i = 0; i < elements.length; i++) {
-            assertTrue("Full collection should contain added element " + i,
-                    getCollection().contains(elements[i]));
+            assertTrue(getCollection().contains(elements[i]),
+                    "Full collection should contain added element " + i);
         }
-        assertEquals("Size should increase after addAll",
-                size + elements.length, getCollection().size());
+        assertEquals(size + elements.length, getCollection().size(),
+                "Size should increase after addAll");
     }
 
     @Test
@@ -255,7 +259,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         final ArrayList<Integer> list = new ArrayList<>(Arrays.asList(array));
         final SetUniqueList<Integer> lset = SetUniqueList.setUniqueList(list);
 
-        assertEquals("Duplicate element was added.", 2, lset.size());
+        assertEquals(2, lset.size(), "Duplicate element was added.");
         assertEquals(Integer.valueOf(1), lset.get(0));
         assertEquals(Integer.valueOf(2), lset.get(1));
         assertEquals(Integer.valueOf(1), list.get(0));
@@ -274,18 +278,18 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         final Integer secondNewElement = Integer.valueOf(3);
         Collection<Integer> collection = Arrays.asList(firstNewElement, secondNewElement);
         list.addAll(0, collection);
-        assertEquals("Unique elements should be added.", 3, list.size());
-        assertEquals("First new element should be at index 0", firstNewElement, list.get(0));
-        assertEquals("Second new element should be at index 1", secondNewElement, list.get(1));
-        assertEquals("Existing element should shift to index 2", existingElement, list.get(2));
+        assertEquals(3, list.size(), "Unique elements should be added.");
+        assertEquals(firstNewElement, list.get(0), "First new element should be at index 0");
+        assertEquals(secondNewElement, list.get(1), "Second new element should be at index 1");
+        assertEquals(existingElement, list.get(2), "Existing element should shift to index 2");
 
         // add a duplicate element and a unique element at index 0
         final Integer thirdNewElement = Integer.valueOf(4);
         collection = Arrays.asList(existingElement, thirdNewElement);
         list.addAll(0, collection);
-        assertEquals("Duplicate element should not be added, unique element should be added.",
-            4, list.size());
-        assertEquals("Third new element should be at index 0", thirdNewElement, list.get(0));
+        assertEquals(4, list.size(),
+                "Duplicate element should not be added, unique element should be added.");
+        assertEquals(thirdNewElement, list.get(0), "Third new element should be at index 0");
     }
 
     @Test
@@ -308,7 +312,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
             }
         }
 
-        assertEquals("Duplicate element was added", 2, lset.size());
+        assertEquals(2, lset.size(), "Duplicate element was added");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/list/TransformedListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/TransformedListTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections4.list;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/test/java/org/apache/commons/collections4/list/TreeListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/TreeListTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.list;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;

--- a/src/test/java/org/apache/commons/collections4/list/UnmodifiableListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/UnmodifiableListTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4.list;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;

--- a/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
@@ -16,7 +16,14 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -37,6 +44,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.collection.AbstractCollectionTest;
 import org.apache.commons.collections4.keyvalue.DefaultMapEntry;
 import org.apache.commons.collections4.set.AbstractSetTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -410,23 +418,23 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
             try {
                 m.put(keys[i], values[i]);
             } catch (final NullPointerException exception) {
-                assertTrue("NullPointerException only allowed to be thrown " +
-                           "if either the key or value is null.",
-                           keys[i] == null || values[i] == null);
+                assertTrue(keys[i] == null || values[i] == null,
+                        "NullPointerException only allowed to be thrown " +
+                                "if either the key or value is null.");
 
-                assertTrue("NullPointerException on null key, but " +
-                           "isAllowNullKey is not overridden to return false.",
-                           keys[i] == null || !isAllowNullKey());
+                assertTrue(keys[i] == null || !isAllowNullKey(),
+                        "NullPointerException on null key, but " +
+                                "isAllowNullKey is not overridden to return false.");
 
-                assertTrue("NullPointerException on null value, but " +
-                           "isAllowNullValue is not overridden to return false.",
-                           values[i] == null || !isAllowNullValue());
+                assertTrue(values[i] == null || !isAllowNullValue(),
+                        "NullPointerException on null value, but " +
+                                "isAllowNullValue is not overridden to return false.");
 
                 fail("Unknown reason for NullPointer.");
             }
         }
-        assertEquals("size must reflect number of mappings added.",
-                     keys.length, m.size());
+        assertEquals(keys.length, m.size(),
+                "size must reflect number of mappings added.");
     }
 
     /**
@@ -494,40 +502,36 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         final Object[] values = getSampleValues();
         final Object[] newValues = getNewSampleValues();
 
-        assertNotNull("failure in test: Must have keys returned from " +
-                 "getSampleKeys.", keys);
+        assertNotNull(keys, "failure in test: Must have keys returned from " +
+                "getSampleKeys.");
 
-        assertNotNull("failure in test: Must have values returned from " +
-                 "getSampleValues.", values);
+        assertNotNull(values, "failure in test: Must have values returned from " +
+                "getSampleValues.");
 
         // verify keys and values have equivalent lengths (in case getSampleX are
         // overridden)
-        assertEquals("failure in test: not the same number of sample " +
-                   "keys and values.",  keys.length, values.length);
+        assertEquals(keys.length, values.length, "failure in test: not the same number of sample " +
+                "keys and values.");
 
-        assertEquals("failure in test: not the same number of values and new values.",
-                   values.length, newValues.length);
+        assertEquals(values.length, newValues.length,
+                "failure in test: not the same number of values and new values.");
 
         // verify there aren't duplicate keys, and check values
         for (int i = 0; i < keys.length - 1; i++) {
             for (int j = i + 1; j < keys.length; j++) {
-                assertTrue("failure in test: duplicate null keys.",
-                        keys[i] != null || keys[j] != null);
-                assertTrue(
-                        "failure in test: duplicate non-null key.",
-                        keys[i] == null || keys[j] == null || !keys[i].equals(keys[j]) && !keys[j]
-                                .equals(keys[i]));
+                assertTrue(keys[i] != null || keys[j] != null,
+                        "failure in test: duplicate null keys.");
+                assertTrue(keys[i] == null || keys[j] == null || !keys[i].equals(keys[j]) && !keys[j].equals(keys[i]),
+                        "failure in test: duplicate non-null key.");
             }
-            assertTrue("failure in test: found null key, but isNullKeySupported " + "is false.",
-                    keys[i] != null || isAllowNullKey());
-            assertTrue(
-                    "failure in test: found null value, but isNullValueSupported " + "is false.",
-                    values[i] != null || isAllowNullValue());
-            assertTrue("failure in test: found null new value, but isNullValueSupported "
-                    + "is false.", newValues[i] != null || isAllowNullValue());
-            assertTrue("failure in test: values should not be the same as new value",
-                    values[i] != newValues[i]
-                            && (values[i] == null || !values[i].equals(newValues[i])));
+            assertTrue(keys[i] != null || isAllowNullKey(),
+                    "failure in test: found null key, but isNullKeySupported " + "is false.");
+            assertTrue(values[i] != null || isAllowNullValue(),
+                    "failure in test: found null value, but isNullValueSupported " + "is false.");
+            assertTrue(newValues[i] != null || isAllowNullValue(),
+                    "failure in test: found null new value, but isNullValueSupported " + "is false.");
+            assertTrue(values[i] != newValues[i] && (values[i] == null || !values[i].equals(newValues[i])),
+                    "failure in test: values should not be the same as new value");
         }
     }
 
@@ -555,22 +559,22 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     @Test
     public void testMakeMap() {
         final Map<K, V> em = makeObject();
-        assertNotNull("failure in test: makeEmptyMap must return a non-null map.", em);
+        assertNotNull(em, "failure in test: makeEmptyMap must return a non-null map.");
 
         final Map<K, V> em2 = makeObject();
-        assertNotNull("failure in test: makeEmptyMap must return a non-null map.", em);
+        assertNotNull(em, "failure in test: makeEmptyMap must return a non-null map.");
 
-        assertNotSame("failure in test: makeEmptyMap must return a new map " +
-                "with each invocation.", em, em2);
+        assertNotSame(em, em2, "failure in test: makeEmptyMap must return a new map " +
+                "with each invocation.");
 
         final Map<K, V> fm = makeFullMap();
-        assertNotNull("failure in test: makeFullMap must return a non-null map.", fm);
+        assertNotNull(fm, "failure in test: makeFullMap must return a non-null map.");
 
         final Map<K, V> fm2 = makeFullMap();
-        assertNotNull("failure in test: makeFullMap must return a non-null map.", fm);
+        assertNotNull(fm2, "failure in test: makeFullMap must return a non-null map.");
 
-        assertNotSame("failure in test: makeFullMap must return a new map " +
-                "with each invocation.", fm, fm2);
+        assertNotSame(fm, fm2, "failure in test: makeFullMap must return a new map " +
+                "with each invocation.");
     }
 
     /**
@@ -579,11 +583,11 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     @Test
     public void testMapIsEmpty() {
         resetEmpty();
-        assertTrue("Map.isEmpty() should return true with an empty map", getMap().isEmpty());
+        assertTrue(getMap().isEmpty(), "Map.isEmpty() should return true with an empty map");
         verify();
 
         resetFull();
-        assertFalse("Map.isEmpty() should return false with a non-empty map", getMap().isEmpty());
+        assertFalse(getMap().isEmpty(), "Map.isEmpty() should return false with a non-empty map");
         verify();
     }
 
@@ -593,13 +597,13 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     @Test
     public void testMapSize() {
         resetEmpty();
-        assertEquals("Map.size() should be 0 with an empty map",
-                     0, getMap().size());
+        assertEquals(0, getMap().size(),
+                "Map.size() should be 0 with an empty map");
         verify();
 
         resetFull();
-        assertEquals("Map.size() should equal the number of entries " +
-                     "in the map", getSampleKeys().length, getMap().size());
+        assertEquals(getSampleKeys().length, getMap().size(),
+                "Map.size() should equal the number of entries " + "in the map");
         verify();
     }
 
@@ -642,14 +646,14 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
 
         resetEmpty();
         for (final Object key : keys) {
-            assertFalse("Map must not contain key when map is empty", getMap().containsKey(key));
+            assertFalse(getMap().containsKey(key), "Map must not contain key when map is empty");
         }
         verify();
 
         resetFull();
         for (final Object key : keys) {
-            assertTrue("Map must contain key for a mapping in the map. " +
-                       "Missing: " + key, getMap().containsKey(key));
+            assertTrue(getMap().containsKey(key), "Map must contain key for a mapping in the map. " +
+                    "Missing: " + key);
         }
         verify();
     }
@@ -665,14 +669,14 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
 
         resetEmpty();
         for (final Object value : values) {
-            assertFalse("Empty map must not contain value", getMap().containsValue(value));
+            assertFalse(getMap().containsValue(value), "Empty map must not contain value");
         }
         verify();
 
         resetFull();
         for (final Object value : values) {
-            assertTrue("Map must contain value for a mapping in the map.",
-                    getMap().containsValue(value));
+            assertTrue(getMap().containsValue(value),
+                    "Map must contain value for a mapping in the map.");
         }
         verify();
     }
@@ -684,11 +688,11 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     @Test
     public void testMapEquals() {
         resetEmpty();
-        assertEquals("Empty maps unequal.", getMap(), confirmed);
+        assertEquals(getMap(), confirmed, "Empty maps unequal.");
         verify();
 
         resetFull();
-        assertEquals("Full maps unequal.", getMap(), confirmed);
+        assertEquals(getMap(), confirmed, "Full maps unequal.");
         verify();
 
         resetFull();
@@ -697,11 +701,11 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         final Iterator<K> iter = confirmed.keySet().iterator();
         iter.next();
         iter.remove();
-        assertFalse("Different maps equal.", getMap().equals(confirmed));
+        assertFalse(getMap().equals(confirmed), "Different maps equal.");
 
         resetFull();
-        assertFalse("equals(null) returned true.", getMap().equals(null));
-        assertFalse("equals(new Object()) returned true.", getMap().equals(new Object()));
+        assertFalse(getMap().equals(null), "equals(null) returned true.");
+        assertFalse(getMap().equals(new Object()), "equals(new Object()) returned true.");
         verify();
     }
 
@@ -716,14 +720,14 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         final Object[] values = getSampleValues();
 
         for (final Object key : keys) {
-            assertNull("Empty map.get() should return null.", getMap().get(key));
+            assertNull(getMap().get(key), "Empty map.get() should return null.");
         }
         verify();
 
         resetFull();
         for (int i = 0; i < keys.length; i++) {
-            assertEquals("Full map.get() should return value from mapping.",
-                         values[i], getMap().get(keys[i]));
+            assertEquals(values[i], getMap().get(keys[i]),
+                    "Full map.get() should return value from mapping.");
         }
     }
 
@@ -733,10 +737,10 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     @Test
     public void testMapHashCode() {
         resetEmpty();
-        assertEquals("Empty maps have different hashCodes.", getMap().hashCode(), confirmed.hashCode());
+        assertEquals(getMap().hashCode(), confirmed.hashCode(), "Empty maps have different hashCodes.");
 
         resetFull();
-        assertEquals("Equal maps have different hashCodes.", getMap().hashCode(), confirmed.hashCode());
+        assertEquals(getMap().hashCode(), confirmed.hashCode(), "Equal maps have different hashCodes.");
     }
 
     /**
@@ -751,11 +755,11 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     @Test
     public void testMapToString() {
         resetEmpty();
-        assertNotNull("Empty map toString() should not return null", getMap().toString());
+        assertNotNull(getMap().toString(), "Empty map toString() should not return null");
         verify();
 
         resetFull();
-        assertNotNull("Empty map toString() should not return null", getMap().toString());
+        assertNotNull(getMap().toString(), "Empty map toString() should not return null");
         verify();
     }
 
@@ -778,7 +782,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         if (map instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             @SuppressWarnings("unchecked")
             final Map<K, V> map2 = (Map<K, V>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(map));
-            assertEquals("Map is empty", 0, map2.size());
+            assertEquals(0, map2.size(), "Map is empty");
         }
     }
 
@@ -801,7 +805,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         if (map instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             @SuppressWarnings("unchecked")
             final Map<K, V> map2 = (Map<K, V>) readExternalFormFromDisk(getCanonicalFullCollectionName(map));
-            assertEquals("Map is the right size", getSampleKeys().length, map2.size());
+            assertEquals(getSampleKeys().length, map2.size(), "Map is the right size");
         }
     }
 
@@ -820,27 +824,27 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
                 final Object o = getMap().put(keys[i], values[i]);
                 getConfirmed().put(keys[i], values[i]);
                 verify();
-                assertNull("First map.put should return null", o);
-                assertTrue("Map should contain key after put",
-                        getMap().containsKey(keys[i]));
-                assertTrue("Map should contain value after put",
-                        getMap().containsValue(values[i]));
+                assertNull(o, "First map.put should return null");
+                assertTrue(getMap().containsKey(keys[i]),
+                        "Map should contain key after put");
+                assertTrue(getMap().containsValue(values[i]),
+                        "Map should contain value after put");
             }
             if (isPutChangeSupported()) {
                 for (int i = 0; i < keys.length; i++) {
                     final Object o = getMap().put(keys[i], newValues[i]);
                     getConfirmed().put(keys[i], newValues[i]);
                     verify();
-                    assertEquals("Map.put should return previous value when changed", values[i], o);
-                    assertTrue("Map should still contain key after put when changed",
-                            getMap().containsKey(keys[i]));
-                    assertTrue("Map should contain new value after put when changed",
-                            getMap().containsValue(newValues[i]));
+                    assertEquals(values[i], o, "Map.put should return previous value when changed");
+                    assertTrue(getMap().containsKey(keys[i]),
+                            "Map should still contain key after put when changed");
+                    assertTrue(getMap().containsValue(newValues[i]),
+                            "Map should contain new value after put when changed");
 
                     // if duplicates are allowed, we're not guaranteed that the value
                     // no longer exists, so don't try checking that.
                     if (!isAllowDuplicateValues()) {
-                        assertFalse("Map should not contain old value after put when changed", getMap().containsValue(values[i]));
+                        assertFalse(getMap().containsValue(values[i]), "Map should not contain old value after put when changed");
                     }
                 }
             } else {
@@ -869,16 +873,16 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
                 final V o = getMap().put(key, newValues[i]);
                 final V value = getConfirmed().put(key, newValues[i]);
                 verify();
-                assertEquals("Map.put should return previous value when changed", value, o);
-                assertTrue("Map should still contain key after put when changed", getMap()
-                        .containsKey(key));
-                assertTrue("Map should contain new value after put when changed", getMap()
-                        .containsValue(newValues[i]));
+                assertEquals(value, o, "Map.put should return previous value when changed");
+                assertTrue(getMap().containsKey(key),
+                        "Map should still contain key after put when changed");
+                assertTrue(getMap().containsValue(newValues[i]),
+                        "Map should contain new value after put when changed");
 
                 // if duplicates are allowed, we're not guaranteed that the value
                 // no longer exists, so don't try checking that.
                 if (!isAllowDuplicateValues()) {
-                    assertFalse("Map should not contain old value after put when changed", getMap().containsValue(values[i]));
+                    assertFalse(getMap().containsValue(values[i]), "Map should not contain old value after put when changed");
                 }
             }
         } else {
@@ -1005,7 +1009,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         final Object[] values = getSampleValues();
         for (final Object key : keys) {
             final Object o = getMap().remove(key);
-            assertNull("First map.remove should return null", o);
+            assertNull(o, "First map.remove should return null");
         }
         verify();
 
@@ -1016,8 +1020,8 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
             getConfirmed().remove(keys[i]);
             verify();
 
-            assertEquals("map.remove with valid key should return value",
-                         values[i], o);
+            assertEquals(values[i], o,
+                    "map.remove with valid key should return value");
         }
 
         final Object[] other = getOtherKeys();
@@ -1026,9 +1030,9 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
         final int size = getMap().size();
         for (final Object element : other) {
             final Object o = getMap().remove(element);
-            assertNull("map.remove for nonexistent key should return null", o);
-            assertEquals("map.remove for nonexistent key should not " +
-                         "shrink map", size, getMap().size());
+            assertNull(o, "map.remove for nonexistent key should return null");
+            assertEquals(size, getMap().size(),
+                    "map.remove for nonexistent key should not " + "shrink map");
         }
         verify();
     }
@@ -1234,8 +1238,8 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
                     }
                     j++;
                 }
-                assertTrue("values().remove(obj) is broken", j < 10000);
-                assertFalse("Value should have been removed from the underlying map.", getMap().containsValue(sampleValue));
+                assertTrue(j < 10000, "values().remove(obj) is broken");
+                assertFalse(getMap().containsValue(sampleValue), "Value should have been removed from the underlying map.");
             }
         }
     }
@@ -1321,7 +1325,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
             final StringBuilder msg = new StringBuilder("Value should ");
             msg.append(expected ? "yet " : "no longer ");
             msg.append("be present in the underlying map");
-            assertEquals(msg.toString(), expected, getMap().containsValue(value));
+            assertEquals(expected, getMap().containsValue(value), msg.toString());
         }
         assertTrue(getMap().isEmpty());
     }
@@ -1343,7 +1347,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
                 // if key.remove is unsupported, just skip this test
                 return;
             }
-            assertFalse("Key should have been removed from the underlying map.", getMap().containsKey(sampleKey));
+            assertFalse(getMap().containsKey(sampleKey), "Key should have been removed from the underlying map.");
         }
     }
 
@@ -1432,7 +1436,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
                 // if entrySet removal is unsupported, just skip this test
                 return;
             }
-            assertFalse("Entry should have been removed from the underlying map.", getMap().containsKey(sampleKeys[i]));
+            assertFalse(getMap().containsKey(sampleKeys[i]), "Entry should have been removed from the underlying map.");
         }
     }
 
@@ -1725,7 +1729,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
                     break;
                 }
             }
-            assertNotNull("No matching entry in map for key '" + key + "'", entry);
+            assertNotNull(entry, "No matching entry in map for key '" + key + "'");
             return entry;
         }
 
@@ -1994,54 +1998,54 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
     public void verifyMap() {
         final int size = getConfirmed().size();
         final boolean empty = getConfirmed().isEmpty();
-        assertEquals("Map should be same size as HashMap", size, getMap().size());
-        assertEquals("Map should be empty if HashMap is", empty, getMap().isEmpty());
-        assertEquals("hashCodes should be the same", getConfirmed().hashCode(), getMap().hashCode());
+        assertEquals(size, getMap().size(), "Map should be same size as HashMap");
+        assertEquals(empty, getMap().isEmpty(), "Map should be empty if HashMap is");
+        assertEquals(getConfirmed().hashCode(), getMap().hashCode(), "hashCodes should be the same");
         // changing the order of the assertion below fails for LRUMap because confirmed is
         // another collection (e.g. treemap) and confirmed.equals() creates a normal iterator (not
         // #mapIterator()), which modifies the parent expected modCount of the map object, causing
         // concurrent modification exceptions.
         // Because of this we have assertEquals(map, confirmed), and not the other way around.
-        assertEquals("Map should still equal HashMap", map, confirmed);
-        assertEquals("Map should still equal HashMap", getMap(), getConfirmed());
+        assertEquals(map, confirmed, "Map should still equal HashMap");
+        assertEquals(getMap(), getConfirmed(), "Map should still equal HashMap");
     }
 
     public void verifyEntrySet() {
         final int size = getConfirmed().size();
         final boolean empty = getConfirmed().isEmpty();
-        assertEquals("entrySet should be same size as HashMap's" +
-                     "\nTest: " + entrySet + "\nReal: " + getConfirmed().entrySet(),
-                     size, entrySet.size());
-        assertEquals("entrySet should be empty if HashMap is" +
-                     "\nTest: " + entrySet + "\nReal: " + getConfirmed().entrySet(),
-                     empty, entrySet.isEmpty());
-        assertTrue("entrySet should contain all HashMap's elements" +
-                   "\nTest: " + entrySet + "\nReal: " + getConfirmed().entrySet(),
-                   entrySet.containsAll(getConfirmed().entrySet()));
-        assertEquals("entrySet hashCodes should be the same" +
-                     "\nTest: " + entrySet + "\nReal: " + getConfirmed().entrySet(),
-                     getConfirmed().entrySet().hashCode(), entrySet.hashCode());
-        assertEquals("Map's entry set should still equal HashMap's",
-                     getConfirmed().entrySet(), entrySet);
+        assertEquals(size, entrySet.size(),
+                "entrySet should be same size as HashMap's" +
+                        "\nTest: " + entrySet + "\nReal: " + getConfirmed().entrySet());
+        assertEquals(empty, entrySet.isEmpty(),
+                "entrySet should be empty if HashMap is" +
+                        "\nTest: " + entrySet + "\nReal: " + getConfirmed().entrySet());
+        assertTrue(entrySet.containsAll(getConfirmed().entrySet()),
+                "entrySet should contain all HashMap's elements" +
+                        "\nTest: " + entrySet + "\nReal: " + getConfirmed().entrySet());
+        assertEquals(getConfirmed().entrySet().hashCode(), entrySet.hashCode(),
+                "entrySet hashCodes should be the same" +
+                        "\nTest: " + entrySet + "\nReal: " + getConfirmed().entrySet());
+        assertEquals(getConfirmed().entrySet(), entrySet,
+                "Map's entry set should still equal HashMap's");
     }
 
     public void verifyKeySet() {
         final int size = getConfirmed().size();
         final boolean empty = getConfirmed().isEmpty();
-        assertEquals("keySet should be same size as HashMap's" +
-                     "\nTest: " + keySet + "\nReal: " + getConfirmed().keySet(),
-                     size, keySet.size());
-        assertEquals("keySet should be empty if HashMap is" +
-                     "\nTest: " + keySet + "\nReal: " + getConfirmed().keySet(),
-                     empty, keySet.isEmpty());
-        assertTrue("keySet should contain all HashMap's elements" +
-                   "\nTest: " + keySet + "\nReal: " + getConfirmed().keySet(),
-                   keySet.containsAll(getConfirmed().keySet()));
-        assertEquals("keySet hashCodes should be the same" +
-                     "\nTest: " + keySet + "\nReal: " + getConfirmed().keySet(),
-                     getConfirmed().keySet().hashCode(), keySet.hashCode());
-        assertEquals("Map's key set should still equal HashMap's",
-                getConfirmed().keySet(), keySet);
+        assertEquals(size, keySet.size(),
+                "keySet should be same size as HashMap's" +
+                        "\nTest: " + keySet + "\nReal: " + getConfirmed().keySet());
+        assertEquals(empty, keySet.isEmpty(),
+                "keySet should be empty if HashMap is" +
+                        "\nTest: " + keySet + "\nReal: " + getConfirmed().keySet());
+        assertTrue(keySet.containsAll(getConfirmed().keySet()),
+                "keySet should contain all HashMap's elements" +
+                        "\nTest: " + keySet + "\nReal: " + getConfirmed().keySet());
+        assertEquals(getConfirmed().keySet().hashCode(), keySet.hashCode(),
+                "keySet hashCodes should be the same" +
+                        "\nTest: " + keySet + "\nReal: " + getConfirmed().keySet());
+        assertEquals(getConfirmed().keySet(), keySet,
+                "Map's key set should still equal HashMap's");
     }
 
     public void verifyValues() {
@@ -2053,30 +2057,30 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
 
         final int size = getConfirmed().size();
         final boolean empty = getConfirmed().isEmpty();
-        assertEquals("values should be same size as HashMap's" +
-                     "\nTest: " + test + "\nReal: " + known,
-                     size, values.size());
-        assertEquals("values should be empty if HashMap is" +
-                     "\nTest: " + test + "\nReal: " + known,
-                     empty, values.isEmpty());
-        assertTrue("values should contain all HashMap's elements" +
-                   "\nTest: " + test + "\nReal: " + known,
-                    test.containsAll(known));
-        assertTrue("values should contain all HashMap's elements" +
-                   "\nTest: " + test + "\nReal: " + known,
-                   known.containsAll(test));
+        assertEquals(size, values.size(),
+                "values should be same size as HashMap's" +
+                        "\nTest: " + test + "\nReal: " + known);
+        assertEquals(empty, values.isEmpty(),
+                "values should be empty if HashMap is" +
+                        "\nTest: " + test + "\nReal: " + known);
+        assertTrue(test.containsAll(known),
+                "values should contain all HashMap's elements" +
+                        "\nTest: " + test + "\nReal: " + known);
+        assertTrue(known.containsAll(test),
+                "values should contain all HashMap's elements" +
+                        "\nTest: " + test + "\nReal: " + known);
         // originally coded to use a HashBag, but now separate jar so...
         for (final V v : known) {
             final boolean removed = test.remove(v);
-            assertTrue("Map's values should still equal HashMap's", removed);
+            assertTrue(removed, "Map's values should still equal HashMap's");
         }
-        assertTrue("Map's values should still equal HashMap's", test.isEmpty());
+        assertTrue(test.isEmpty(), "Map's values should still equal HashMap's");
     }
 
     /**
      * Erases any leftover instance variables by setting them to null.
      */
-    @Override
+    @AfterEach
     public void tearDown() throws Exception {
         map = null;
         keySet = null;

--- a/src/test/java/org/apache/commons/collections4/map/AbstractOrderedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractOrderedMapTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;

--- a/src/test/java/org/apache/commons/collections4/map/AbstractSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractSortedMapTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;

--- a/src/test/java/org/apache/commons/collections4/map/CaseInsensitiveMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/CaseInsensitiveMapTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -91,10 +95,10 @@ public class CaseInsensitiveMapTest<K, V> extends AbstractIterableMapTest<K, V> 
             for (final Locale locale : locales) {
                 Locale.setDefault(locale);
                 for (int j = 0; j < data.length; j++) {
-                    assertTrue("Test data corrupt: " + j, data[j][0].equalsIgnoreCase(data[j][1]));
+                    assertTrue(data[j][0].equalsIgnoreCase(data[j][1]), "Test data corrupt: " + j);
                     final CaseInsensitiveMap<String, String> map = new CaseInsensitiveMap<>();
                     map.put(data[j][0], "value");
-                    assertEquals(Locale.getDefault() + ": " + j, "value", map.get(data[j][1]));
+                    assertEquals("value", map.get(data[j][1]), Locale.getDefault() + ": " + j);
                 }
             }
         } finally {

--- a/src/test/java/org/apache/commons/collections4/map/CompositeMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/CompositeMapTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -40,10 +43,8 @@ public class CompositeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         super(CompositeMapTest.class.getSimpleName());
     }
 
-    @Override
     @BeforeEach
     public void setUp() throws Exception {
-        super.setUp();
         this.pass = false;
     }
 

--- a/src/test/java/org/apache/commons/collections4/map/DefaultedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/DefaultedMapTest.java
@@ -17,7 +17,10 @@
 package org.apache.commons.collections4.map;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
@@ -16,6 +16,14 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;

--- a/src/test/java/org/apache/commons/collections4/map/HashedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/HashedMapTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import org.junit.jupiter.api.Test;
 
 /**

--- a/src/test/java/org/apache/commons/collections4/map/LRUMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LRUMapTest.java
@@ -17,7 +17,14 @@
 package org.apache.commons.collections4.map;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -649,9 +656,9 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
             }
         }
 
-        assertEquals("Exceptions have been thrown: " + exceptions, 0, exceptions.size());
-        assertTrue("Each thread should have put at least 1 element into the map, but only "
-                + counter[0] + " did succeed", counter[0] >= threads.length);
+        assertEquals(0, exceptions.size(), "Exceptions have been thrown: " + exceptions);
+        assertTrue(counter[0] >= threads.length,
+                "Each thread should have put at least 1 element into the map, but only " + counter[0] + " did succeed");
     }
 
     @Test
@@ -728,9 +735,9 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
             }
         }
 
-        assertEquals("Exceptions have been thrown: " + exceptions, 0, exceptions.size());
-        assertTrue("Each thread should have put at least 1 element into the map, but only "
-                + counter[0] + " did succeed", counter[0] >= threads.length);
+        assertEquals(0, exceptions.size(), "Exceptions have been thrown: " + exceptions);
+        assertTrue(counter[0] >= threads.length,
+                "Each thread should have put at least 1 element into the map, but only " + counter[0] + " did succeed");
     }
 
     @Test
@@ -812,9 +819,9 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
             }
         }
 
-        assertEquals("Exceptions have been thrown: " + exceptions, 0, exceptions.size());
-        assertTrue("Each thread should have put at least 1 element into the map, but only "
-                + counter[0] + " did succeed", counter[0] >= threads.length);
+        assertEquals(0, exceptions.size(), "Exceptions have been thrown: " + exceptions);
+        assertTrue(counter[0] >= threads.length,
+                "Each thread should have put at least 1 element into the map, but only " + counter[0] + " did succeed");
     }
 
     @Test
@@ -891,9 +898,9 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
             }
         }
 
-        assertEquals("Exceptions have been thrown: " + exceptions, 0, exceptions.size());
-        assertTrue("Each thread should have put at least 1 element into the map, but only "
-                + counter[0] + " did succeed", counter[0] >= threads.length);
+        assertEquals(0, exceptions.size(), "Exceptions have been thrown: " + exceptions);
+        assertTrue(counter[0] >= threads.length,
+                "Each thread should have put at least 1 element into the map, but only " + counter[0] + " did succeed");
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/map/LazyMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LazyMapTest.java
@@ -17,6 +17,9 @@
 package org.apache.commons.collections4.map;
 
 import static org.apache.commons.collections4.map.LazyMap.lazyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/org/apache/commons/collections4/map/LazySortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LazySortedMapTest.java
@@ -18,7 +18,11 @@ package org.apache.commons.collections4.map;
 
 import static org.apache.commons.collections4.map.LazySortedMap.lazySortedMap;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Comparator;
 import java.util.Map;
@@ -96,36 +100,36 @@ public class LazySortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
         map.put("A",  5);
         map.get("B"); // Entry with value "One" created
         map.put("C", 8);
-        assertEquals("First key should be A", "A", map.firstKey());
-        assertEquals("Last key should be C", "C", map.lastKey());
-        assertEquals("First key in tail map should be B",
-            "B", map.tailMap("B").firstKey());
-        assertEquals("Last key in head map should be B",
-            "B", map.headMap("C").lastKey());
-        assertEquals("Last key in submap should be B",
-            "B", map.subMap("A", "C").lastKey());
+        assertEquals("A", map.firstKey(), "First key should be A");
+        assertEquals("C", map.lastKey(), "Last key should be C");
+        assertEquals("B", map.tailMap("B").firstKey(),
+                "First key in tail map should be B");
+        assertEquals("B", map.headMap("C").lastKey(),
+                "Last key in head map should be B");
+        assertEquals("B", map.subMap("A", "C").lastKey(),
+                "Last key in submap should be B");
 
         final Comparator<?> c = map.comparator();
-        assertNull("natural order, so comparator should be null", c);
+        assertNull(c, "natural order, so comparator should be null");
     }
 
     @Test
     public void testReverseSortOrder() {
         final SortedMap<String, Number> map = lazySortedMap(new ConcurrentSkipListMap<String, Number>(reverseStringComparator), oneFactory);
-        map.put("A",  5);
+        map.put("A", 5);
         map.get("B"); // Entry with value "One" created
         map.put("C", 8);
-        assertEquals("Last key should be A", "A", map.lastKey());
-        assertEquals("First key should be C", "C", map.firstKey());
-        assertEquals("First key in tail map should be B",
-            "B", map.tailMap("B").firstKey());
-        assertEquals("Last key in head map should be B",
-            "B", map.headMap("A").lastKey());
-        assertEquals("Last key in submap should be B",
-            "B", map.subMap("C", "A").lastKey());
+        assertEquals("A", map.lastKey(), "Last key should be A");
+        assertEquals("C", map.firstKey(), "First key should be C");
+        assertEquals("B", map.tailMap("B").firstKey(),
+                "First key in tail map should be B");
+        assertEquals("B", map.headMap("A").lastKey(),
+                "Last key in head map should be B");
+        assertEquals("B", map.subMap("C", "A").lastKey(),
+                "Last key in submap should be B");
 
         final Comparator<?> c = map.comparator();
-        assertSame("natural order, so comparator should be null", c, reverseStringComparator);
+        assertSame(c, reverseStringComparator, "natural order, so comparator should be null");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/map/LinkedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LinkedMapTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;

--- a/src/test/java/org/apache/commons/collections4/map/ListOrderedMap2Test.java
+++ b/src/test/java/org/apache/commons/collections4/map/ListOrderedMap2Test.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/test/java/org/apache/commons/collections4/map/ListOrderedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ListOrderedMapTest.java
@@ -17,6 +17,9 @@
 package org.apache.commons.collections4.map;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
@@ -398,11 +401,11 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         final HashMap<Object, Object> hmap = new HashMap<>();
         hmap.put(key1, null);
         hmap.put(key2, null);
-        assertEquals("Should have two elements", 2, hmap.size());
+        assertEquals(2, hmap.size(), "Should have two elements");
         final ListOrderedMap<Object, Object> listMap = new ListOrderedMap<>();
         listMap.put(key1, null);
         listMap.put(key2, null);
-        assertEquals("Should have two elements", 2, listMap.size());
+        assertEquals(2, listMap.size(), "Should have two elements");
         listMap.putAll(2, hmap);
     }
 
@@ -413,11 +416,11 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         final HashMap<Object, Object> hmap = new HashMap<>();
         hmap.put(key1, "1");
         hmap.put(key2, "2");
-        assertEquals("Should have two elements", 2, hmap.size());
+        assertEquals(2, hmap.size(), "Should have two elements");
         final ListOrderedMap<Object, Object> listMap = new ListOrderedMap<>();
         listMap.put(key1, "3");
         listMap.put(key2, "4");
-        assertEquals("Should have two elements", 2, listMap.size());
+        assertEquals(2, listMap.size(), "Should have two elements");
         listMap.putAll(2, hmap);
     }
 

--- a/src/test/java/org/apache/commons/collections4/map/MultiKeyMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/MultiKeyMapTest.java
@@ -16,7 +16,13 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Map;
 

--- a/src/test/java/org/apache/commons/collections4/map/MultiValueMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/MultiValueMapTest.java
@@ -16,7 +16,12 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -478,19 +483,19 @@ public class MultiValueMapTest<K, V> extends AbstractObjectTest {
     public void testEmptyMapCompatibility() throws Exception {
         final Map<?, ?> map = makeEmptyMap();
         final Map<?, ?> map2 = (Map<?, ?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(map));
-        assertEquals("Map is empty", 0, map2.size());
+        assertEquals(0, map2.size(), "Map is empty");
     }
 
     @Test
     public void testFullMapCompatibility() throws Exception {
         final Map<?, ?> map = (Map<?, ?>) makeObject();
         final Map<?, ?> map2 = (Map<?, ?>) readExternalFormFromDisk(getCanonicalFullCollectionName(map));
-        assertEquals("Map is the right size", map.size(), map2.size());
+        assertEquals(map.size(), map2.size(), "Map is the right size");
         for (final Object key : map.keySet()) {
-            assertEquals( "Map had unequal elements", map.get(key), map2.get(key) );
+            assertEquals(map.get(key), map2.get(key), "Map had unequal elements");
             map2.remove(key);
         }
-        assertEquals("Map had extra values", 0, map2.size());
+        assertEquals(0, map2.size(), "Map had extra values");
     }
 
 //    public void testCreate() throws Exception {

--- a/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PassiveExpiringMapTest.java
@@ -17,7 +17,13 @@
 package org.apache.commons.collections4.map;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/org/apache/commons/collections4/map/PredicatedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PredicatedMapTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
@@ -61,10 +64,10 @@ public class PredicatedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
     @SuppressWarnings("unchecked")
     public void testEntrySet() {
         Map<K, V> map = makeTestMap();
-        assertNotNull("returned entryset should not be null", map.entrySet());
+        assertNotNull(map.entrySet(), "returned entryset should not be null");
         map = decorateMap(new HashMap<K, V>(), null, null);
         map.put((K) "oneKey", (V) "oneValue");
-        assertEquals("returned entryset should contain one entry", 1, map.entrySet().size());
+        assertEquals(1, map.entrySet().size(), "returned entryset should contain one entry");
         map = decorateMap(map, null, null);
     }
 

--- a/src/test/java/org/apache/commons/collections4/map/PredicatedSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PredicatedSortedMapTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Comparator;
@@ -89,10 +94,10 @@ public class PredicatedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
     @SuppressWarnings("unchecked")
     public void testEntrySet() {
         SortedMap<K, V> map = makeTestMap();
-        assertNotNull("returned entryset should not be null", map.entrySet());
+        assertNotNull(map.entrySet(), "returned entryset should not be null");
         map = decorateMap(new TreeMap<K, V>(), null, null);
         map.put((K) "oneKey", (V) "oneValue");
-        assertEquals("returned entryset should contain one entry", 1, map.entrySet().size());
+        assertEquals(1, map.entrySet().size(), "returned entryset should contain one entry");
         map = decorateMap(map, null, null);
     }
 
@@ -136,24 +141,24 @@ public class PredicatedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
     @SuppressWarnings("unchecked")
     public void testSortOrder() {
         final SortedMap<K, V> map = makeTestMap();
-        map.put((K) "A",  (V) "a");
+        map.put((K) "A", (V) "a");
         map.put((K) "B", (V) "b");
         assertThrows(IllegalArgumentException.class, () -> map.put(null, (V) "c"),
                 "Null key should raise IllegalArgument");
         map.put((K) "C", (V) "c");
         assertThrows(IllegalArgumentException.class, () -> map.put((K) "D", null),
                 "Null value should raise IllegalArgument");
-        assertEquals("First key should be A", "A", map.firstKey());
-        assertEquals("Last key should be C", "C", map.lastKey());
-        assertEquals("First key in tail map should be B",
-            "B", map.tailMap((K) "B").firstKey());
-        assertEquals("Last key in head map should be B",
-            "B", map.headMap((K) "C").lastKey());
-        assertEquals("Last key in submap should be B",
-            "B", map.subMap((K) "A", (K) "C").lastKey());
+        assertEquals("A", map.firstKey(), "First key should be A");
+        assertEquals("C", map.lastKey(), "Last key should be C");
+        assertEquals("B", map.tailMap((K) "B").firstKey(),
+                "First key in tail map should be B");
+        assertEquals("B", map.headMap((K) "C").lastKey(),
+                "Last key in head map should be B");
+        assertEquals("B", map.subMap((K) "A", (K) "C").lastKey(),
+                "Last key in submap should be B");
 
         final Comparator<? super K> c = map.comparator();
-        assertNull("natural order, so comparator should be null", c);
+        assertNull(c, "natural order, so comparator should be null");
     }
 
     @Test
@@ -167,17 +172,17 @@ public class PredicatedSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
         map.put((K) "C", (V) "c");
         assertThrows(IllegalArgumentException.class, () -> map.put((K) "D", null),
                 "Null value should raise IllegalArgument");
-        assertEquals("Last key should be A", "A", map.lastKey());
-        assertEquals("First key should be C", "C", map.firstKey());
-        assertEquals("First key in tail map should be B",
-            "B", map.tailMap((K) "B").firstKey());
-        assertEquals("Last key in head map should be B",
-            "B", map.headMap((K) "A").lastKey());
-        assertEquals("Last key in submap should be B",
-            "B", map.subMap((K) "C", (K) "A").lastKey());
+        assertEquals("A", map.lastKey(), "Last key should be A");
+        assertEquals("C", map.firstKey(), "First key should be C");
+        assertEquals("B", map.tailMap((K) "B").firstKey(),
+                "First key in tail map should be B");
+        assertEquals("B", map.headMap((K) "A").lastKey(),
+                "Last key in head map should be B");
+        assertEquals("B", map.subMap((K) "C", (K) "A").lastKey(),
+                "Last key in submap should be B");
 
         final Comparator<? super K> c = map.comparator();
-        assertSame("reverse order, so comparator should be reverseStringComparator", c, reverseStringComparator);
+        assertSame(c, reverseStringComparator, "reverse order, so comparator should be reverseStringComparator");
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/map/ReferenceIdentityMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ReferenceIdentityMapTest.java
@@ -16,7 +16,14 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.ref.WeakReference;
 import java.util.Iterator;
@@ -66,9 +73,9 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
         final Map<K, V> testMap = new ReferenceIdentityMap<>(ReferenceStrength.WEAK, ReferenceStrength.HARD, true);
         testMap.put(key, value);
 
-        assertEquals("In map", value, testMap.get(key));
-        assertNotNull("Weak reference released early (1)", keyReference.get());
-        assertNotNull("Weak reference released early (2)", valueReference.get());
+        assertEquals(value, testMap.get(key), "In map");
+        assertNotNull(keyReference.get(), "Weak reference released early (1)");
+        assertNotNull(valueReference.get(), "Weak reference released early (2)");
         return testMap;
     }
 

--- a/src/test/java/org/apache/commons/collections4/map/ReferenceMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ReferenceMapTest.java
@@ -16,7 +16,13 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -219,9 +225,9 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         final Map<K, V> testMap = new ReferenceMap<>(ReferenceStrength.WEAK, ReferenceStrength.HARD, true);
         testMap.put(key, value);
 
-        assertEquals("In map", value, testMap.get(key));
-        assertNotNull("Weak reference released early (1)", keyReference.get());
-        assertNotNull("Weak reference released early (2)", valueReference.get());
+        assertEquals(value, testMap.get(key), "In map");
+        assertNotNull(keyReference.get(), "Weak reference released early (1)");
+        assertNotNull(valueReference.get(), "Weak reference released early (2)");
         return testMap;
     }
 
@@ -282,7 +288,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
             final byte[] b = new byte[bytz];
             bytz = bytz * 2;
         }
-        assertFalse("Value should be stored", expiredValues.isEmpty());
+        assertFalse(expiredValues.isEmpty(), "Value should be stored");
     }
 
     /**
@@ -326,7 +332,7 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         // below line should not affect remove
         assertFalse(iter.hasNext());
         iter.remove();
-        assertTrue("Expect empty but have entry: " + map, map.isEmpty());
+        assertTrue(map.isEmpty(), "Expect empty but have entry: " + map);
     }
 
     @SuppressWarnings("unused")

--- a/src/test/java/org/apache/commons/collections4/map/SingletonMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/SingletonMapTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.HashMap;
 
 import org.apache.commons.collections4.BoundedMap;

--- a/src/test/java/org/apache/commons/collections4/map/StaticBucketMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/StaticBucketMapTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
 /**
@@ -62,7 +67,7 @@ public class StaticBucketMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         // loop so we find a string that is in the same bucket as the null
         for (int i = 'A'; i <= 'Z'; i++) {
             final String str = String.valueOf((char) i);
-            assertNull("String: " + str, map.get(str));
+            assertNull(map.get(str), "String: " + str);
         }
     }
 
@@ -75,7 +80,7 @@ public class StaticBucketMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         // loop so we find a string that is in the same bucket as the null
         for (int i = 'A'; i <= 'Z'; i++) {
             final String str = String.valueOf((char) i);
-            assertFalse("String: " + str, map.containsKey(str));
+            assertFalse(map.containsKey(str), "String: " + str);
         }
     }
 
@@ -88,7 +93,7 @@ public class StaticBucketMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         // loop so we find a string that is in the same bucket as the null
         for (int i = 'A'; i <= 'Z'; i++) {
             final String str = String.valueOf((char) i);
-            assertFalse("String: " + str, map.containsValue(str));
+            assertFalse(map.containsValue(str), "String: " + str);
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/map/TransformedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/TransformedMapTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;

--- a/src/test/java/org/apache/commons/collections4/map/TransformedSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/TransformedSortedMapTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
 import java.util.Set;

--- a/src/test/java/org/apache/commons/collections4/map/UnmodifiableMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/UnmodifiableMapTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/org/apache/commons/collections4/map/UnmodifiableOrderedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/UnmodifiableOrderedMapTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 

--- a/src/test/java/org/apache/commons/collections4/map/UnmodifiableSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/UnmodifiableSortedMapTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.SortedMap;
 import java.util.TreeMap;

--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -16,7 +16,12 @@
  */
 package org.apache.commons.collections4.multimap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -861,7 +866,7 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         final MultiValuedMap<?, ?> map = makeObject();
         final MultiValuedMap<?, ?> map2 =
                 (MultiValuedMap<?, ?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(map));
-        assertEquals("Map is empty", 0, map2.size());
+        assertEquals(0, map2.size(), "Map is empty");
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -870,16 +875,16 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         final MultiValuedMap map = makeFullMap();
         final MultiValuedMap map2 =
                 (MultiValuedMap) readExternalFormFromDisk(getCanonicalFullCollectionName(map));
-        assertEquals("Map is the right size", map.size(), map2.size());
+        assertEquals(map.size(), map2.size(), "Map is the right size");
         for (final Object key : map.keySet()) {
-            assertTrue("Map had inequal elements",
-                       CollectionUtils.isEqualCollection(map.get(key), map2.get(key)));
+            assertTrue(CollectionUtils.isEqualCollection(map.get(key), map2.get(key)),
+                    "Map had inequal elements");
             if (isRemoveSupported()) {
                 map2.remove(key);
             }
         }
         if (isRemoveSupported()) {
-            assertEquals("Map had extra values", 0, map2.size());
+            assertEquals(0, map2.size(), "Map had extra values");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/multimap/ArrayListValuedHashMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/ArrayListValuedHashMapTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections4.multimap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/test/java/org/apache/commons/collections4/multimap/HashSetValuedHashMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/HashSetValuedHashMapTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections4.multimap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;

--- a/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections4.multimap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Collection;
 
 import org.apache.commons.collections4.MultiValuedMap;

--- a/src/test/java/org/apache/commons/collections4/multimap/UnmodifiableMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/UnmodifiableMultiValuedMapTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.multimap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.multiset;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -139,11 +142,11 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
 
         final MultiSet<T> multiset = makeObject();
         multiset.add((T) "A");
-        assertTrue("Should contain 'A'", multiset.contains("A"));
-        assertEquals("Should have count of 1", 1, multiset.getCount("A"));
+        assertTrue(multiset.contains("A"), "Should contain 'A'");
+        assertEquals(1, multiset.getCount("A"), "Should have count of 1");
         multiset.add((T) "A");
-        assertTrue("Should contain 'A'", multiset.contains("A"));
-        assertEquals("Should have count of 2", 2, multiset.getCount("A"));
+        assertTrue(multiset.contains("A"), "Should contain 'A'");
+        assertEquals(2, multiset.getCount("A"), "Should have count of 2");
         multiset.add((T) "B");
         assertTrue(multiset.contains("A"));
         assertTrue(multiset.contains("B"));
@@ -176,20 +179,20 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
 
         final MultiSet<T> multiset = makeObject();
         multiset.add((T) "A");
-        assertEquals("Should have count of 1", 1, multiset.getCount("A"));
+        assertEquals(1, multiset.getCount("A"), "Should have count of 1");
         multiset.remove("A");
-        assertEquals("Should have count of 0", 0, multiset.getCount("A"));
+        assertEquals(0, multiset.getCount("A"), "Should have count of 0");
         multiset.add((T) "A");
         multiset.add((T) "A");
         multiset.add((T) "A");
         multiset.add((T) "A");
-        assertEquals("Should have count of 4", 4, multiset.getCount("A"));
+        assertEquals(4, multiset.getCount("A"), "Should have count of 4");
         multiset.remove("A", 0);
-        assertEquals("Should have count of 4", 4, multiset.getCount("A"));
+        assertEquals(4, multiset.getCount("A"), "Should have count of 4");
         multiset.remove("A", 2);
-        assertEquals("Should have count of 2", 2, multiset.getCount("A"));
+        assertEquals(2, multiset.getCount("A"), "Should have count of 2");
         multiset.remove("A");
-        assertEquals("Should have count of 1", 1, multiset.getCount("A"));
+        assertEquals(1, multiset.getCount("A"), "Should have count of 1");
     }
 
     @Test
@@ -201,18 +204,18 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
 
         final MultiSet<T> multiset = makeObject();
         multiset.add((T) "A", 2);
-        assertEquals("Should have count of 2", 2, multiset.getCount("A"));
+        assertEquals(2, multiset.getCount("A"), "Should have count of 2");
         multiset.add((T) "B");
         multiset.add((T) "C");
-        assertEquals("Should have count of 4", 4, multiset.size());
+        assertEquals(4, multiset.size(), "Should have count of 4");
         final List<String> delete = new ArrayList<>();
         delete.add("A");
         delete.add("B");
         multiset.removeAll(delete);
-        assertEquals("Should have count of 0", 0, multiset.getCount("A"));
-        assertEquals("Should have count of 0", 0, multiset.getCount("B"));
-        assertEquals("Should have count of 1", 1, multiset.getCount("C"));
-        assertEquals("Should have count of 1", 1, multiset.size());
+        assertEquals(0, multiset.getCount("A"), "Should have count of 0");
+        assertEquals(0, multiset.getCount("B"), "Should have count of 0");
+        assertEquals(1, multiset.getCount("C"), "Should have count of 1");
+        assertEquals(1, multiset.size(), "Should have count of 1");
     }
 
     @Test
@@ -224,20 +227,20 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
 
         final MultiSet<T> multiset = makeObject();
 
-        assertFalse("MultiSet does not have at least 1 'A'", multiset.contains("A"));
-        assertFalse("MultiSet does not have at least 1 'B'", multiset.contains("B"));
+        assertFalse(multiset.contains("A"), "MultiSet does not have at least 1 'A'");
+        assertFalse(multiset.contains("B"), "MultiSet does not have at least 1 'B'");
 
         multiset.add((T) "A");  // multiset 1A
-        assertTrue("MultiSet has at least 1 'A'", multiset.contains("A"));
-        assertFalse("MultiSet does not have at least 1 'B'", multiset.contains("B"));
+        assertTrue(multiset.contains("A"), "MultiSet has at least 1 'A'");
+        assertFalse(multiset.contains("B"), "MultiSet does not have at least 1 'B'");
 
         multiset.add((T) "A");  // multiset 2A
-        assertTrue("MultiSet has at least 1 'A'", multiset.contains("A"));
-        assertFalse("MultiSet does not have at least 1 'B'", multiset.contains("B"));
+        assertTrue(multiset.contains("A"), "MultiSet has at least 1 'A'");
+        assertFalse(multiset.contains("B"), "MultiSet does not have at least 1 'B'");
 
         multiset.add((T) "B");  // multiset 2A,1B
-        assertTrue("MultiSet has at least 1 'A'", multiset.contains("A"));
-        assertTrue("MultiSet has at least 1 'B'", multiset.contains("B"));
+        assertTrue(multiset.contains("A"), "MultiSet has at least 1 'A'");
+        assertTrue(multiset.contains("B"), "MultiSet has at least 1 'B'");
     }
 
     @Test
@@ -260,39 +263,39 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         known1A1B.add("A");
         known1A1B.add("B");
 
-        assertTrue("MultiSet containsAll of empty", multiset.containsAll(known));
-        assertFalse("MultiSet does not containsAll of 1 'A'", multiset.containsAll(known1A));
-        assertFalse("MultiSet does not containsAll of 2 'A'", multiset.containsAll(known2A));
-        assertFalse("MultiSet does not containsAll of 1 'B'", multiset.containsAll(known1B));
-        assertFalse("MultiSet does not containsAll of 1 'A' 1 'B'", multiset.containsAll(known1A1B));
+        assertTrue(multiset.containsAll(known), "MultiSet containsAll of empty");
+        assertFalse(multiset.containsAll(known1A), "MultiSet does not containsAll of 1 'A'");
+        assertFalse(multiset.containsAll(known2A), "MultiSet does not containsAll of 2 'A'");
+        assertFalse(multiset.containsAll(known1B), "MultiSet does not containsAll of 1 'B'");
+        assertFalse(multiset.containsAll(known1A1B), "MultiSet does not containsAll of 1 'A' 1 'B'");
 
         multiset.add((T) "A");  // multiset 1A
-        assertTrue("MultiSet containsAll of empty", multiset.containsAll(known));
-        assertTrue("MultiSet containsAll of 1 'A'", multiset.containsAll(known1A));
-        assertTrue("MultiSet does not containsAll 'A'", multiset.containsAll(known2A));
-        assertFalse("MultiSet does not containsAll of 1 'B'", multiset.containsAll(known1B));
-        assertFalse("MultiSet does not containsAll of 1 'A' 1 'B'", multiset.containsAll(known1A1B));
+        assertTrue(multiset.containsAll(known), "MultiSet containsAll of empty");
+        assertTrue(multiset.containsAll(known1A), "MultiSet containsAll of 1 'A'");
+        assertTrue(multiset.containsAll(known2A), "MultiSet does not containsAll 'A'");
+        assertFalse(multiset.containsAll(known1B), "MultiSet does not containsAll of 1 'B'");
+        assertFalse(multiset.containsAll(known1A1B), "MultiSet does not containsAll of 1 'A' 1 'B'");
 
         multiset.add((T) "A");  // multiset 2A
-        assertTrue("MultiSet containsAll of empty", multiset.containsAll(known));
-        assertTrue("MultiSet containsAll of 1 'A'", multiset.containsAll(known1A));
-        assertTrue("MultiSet containsAll of 2 'A'", multiset.containsAll(known2A));
-        assertFalse("MultiSet does not containsAll of 1 'B'", multiset.containsAll(known1B));
-        assertFalse("MultiSet does not containsAll of 1 'A' 1 'B'", multiset.containsAll(known1A1B));
+        assertTrue(multiset.containsAll(known), "MultiSet containsAll of empty");
+        assertTrue(multiset.containsAll(known1A), "MultiSet containsAll of 1 'A'");
+        assertTrue(multiset.containsAll(known2A), "MultiSet containsAll of 2 'A'");
+        assertFalse(multiset.containsAll(known1B), "MultiSet does not containsAll of 1 'B'");
+        assertFalse(multiset.containsAll(known1A1B), "MultiSet does not containsAll of 1 'A' 1 'B'");
 
         multiset.add((T) "A");  // multiset 3A
-        assertTrue("MultiSet containsAll of empty", multiset.containsAll(known));
-        assertTrue("MultiSet containsAll of 1 'A'", multiset.containsAll(known1A));
-        assertTrue("MultiSet containsAll of 2 'A'", multiset.containsAll(known2A));
-        assertFalse("MultiSet does not containsAll of 1 'B'", multiset.containsAll(known1B));
-        assertFalse("MultiSet does not containsAll of 1 'A' 1 'B'", multiset.containsAll(known1A1B));
+        assertTrue(multiset.containsAll(known), "MultiSet containsAll of empty");
+        assertTrue(multiset.containsAll(known1A), "MultiSet containsAll of 1 'A'");
+        assertTrue(multiset.containsAll(known2A), "MultiSet containsAll of 2 'A'");
+        assertFalse(multiset.containsAll(known1B), "MultiSet does not containsAll of 1 'B'");
+        assertFalse(multiset.containsAll(known1A1B), "MultiSet does not containsAll of 1 'A' 1 'B'");
 
         multiset.add((T) "B");  // multiset 3A1B
-        assertTrue("MultiSet containsAll of empty", multiset.containsAll(known));
-        assertTrue("MultiSet containsAll of 1 'A'", multiset.containsAll(known1A));
-        assertTrue("MultiSet containsAll of 2 'A'", multiset.containsAll(known2A));
-        assertTrue("MultiSet containsAll of 1 'B'", multiset.containsAll(known1B));
-        assertTrue("MultiSet containsAll of 1 'A' 1 'B'", multiset.containsAll(known1A1B));
+        assertTrue(multiset.containsAll(known), "MultiSet containsAll of empty");
+        assertTrue(multiset.containsAll(known1A), "MultiSet containsAll of 1 'A'");
+        assertTrue(multiset.containsAll(known2A), "MultiSet containsAll of 2 'A'");
+        assertTrue(multiset.containsAll(known1B), "MultiSet containsAll of 1 'B'");
+        assertTrue(multiset.containsAll(known1A1B), "MultiSet containsAll of 1 'A' 1 'B'");
     }
 
     @Test
@@ -303,22 +306,22 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         }
 
         final MultiSet<T> multiset = makeObject();
-        assertEquals("Should have 0 total items", 0, multiset.size());
+        assertEquals(0, multiset.size(), "Should have 0 total items");
         multiset.add((T) "A");
-        assertEquals("Should have 1 total items", 1, multiset.size());
+        assertEquals(1, multiset.size(), "Should have 1 total items");
         multiset.add((T) "A");
-        assertEquals("Should have 2 total items", 2, multiset.size());
+        assertEquals(2, multiset.size(), "Should have 2 total items");
         multiset.add((T) "A");
-        assertEquals("Should have 3 total items", 3, multiset.size());
+        assertEquals(3, multiset.size(), "Should have 3 total items");
         multiset.add((T) "B");
-        assertEquals("Should have 4 total items", 4, multiset.size());
+        assertEquals(4, multiset.size(), "Should have 4 total items");
         multiset.add((T) "B");
-        assertEquals("Should have 5 total items", 5, multiset.size());
+        assertEquals(5, multiset.size(), "Should have 5 total items");
         multiset.remove("A", 2);
-        assertEquals("Should have 1 'A'", 1, multiset.getCount("A"));
-        assertEquals("Should have 3 total items", 3, multiset.size());
+        assertEquals(1, multiset.getCount("A"), "Should have 1 'A'");
+        assertEquals(3, multiset.size(), "Should have 3 total items");
         multiset.remove("B");
-        assertEquals("Should have 2 total item", 2, multiset.size());
+        assertEquals(2, multiset.size(), "Should have 2 total item");
     }
 
     @Test
@@ -339,7 +342,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         retains.add("B");
         retains.add("C");
         multiset.retainAll(retains);
-        assertEquals("Should have 3 total items", 3, multiset.size());
+        assertEquals(3, multiset.size(), "Should have 3 total items");
     }
 
     @Test
@@ -353,7 +356,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         multiset.add((T) "A");
         multiset.add((T) "A");
         multiset.add((T) "B");
-        assertEquals("MultiSet should have 3 items", 3, multiset.size());
+        assertEquals(3, multiset.size(), "MultiSet should have 3 items");
         final Iterator<T> i = multiset.iterator();
 
         boolean foundA = false;
@@ -369,9 +372,9 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
             }
         }
 
-        assertTrue("MultiSet should still contain 'A'", multiset.contains("A"));
-        assertEquals("MultiSet should have 2 items", 2, multiset.size());
-        assertEquals("MultiSet should have 1 'A'", 1, multiset.getCount("A"));
+        assertTrue(multiset.contains("A"), "MultiSet should still contain 'A'");
+        assertEquals(2, multiset.size(), "MultiSet should have 2 items");
+        assertEquals(1, multiset.getCount("A"), "MultiSet should have 1 'A'");
     }
 
     @Test
@@ -706,7 +709,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         final MultiSet<T> multiset = makeObject();
         if (multiset instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             final MultiSet<?> multiset2 = (MultiSet<?>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(multiset));
-            assertTrue("MultiSet is empty", multiset2.isEmpty());
+            assertTrue(multiset2.isEmpty(), "MultiSet is empty");
             assertEquals(multiset, multiset2);
         }
     }
@@ -721,7 +724,7 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
         final MultiSet<T> multiset = makeFullCollection();
         if (multiset instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             final MultiSet<?> multiset2 = (MultiSet<?>) readExternalFormFromDisk(getCanonicalFullCollectionName(multiset));
-            assertEquals("MultiSet is the right size", multiset.size(), multiset2.size());
+            assertEquals(multiset.size(), multiset2.size(), "MultiSet is the right size");
             assertEquals(multiset, multiset2);
         }
     }

--- a/src/test/java/org/apache/commons/collections4/multiset/PredicatedMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/PredicatedMultiSetTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.multiset;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Set;
 
@@ -73,11 +76,11 @@ public class PredicatedMultiSetTest<T> extends AbstractMultiSetTest<T> {
             assertTrue(multiset.contains(els[i]));
         }
         Set<T> set = ((PredicatedMultiSet<T>) multiset).uniqueSet();
-        assertTrue("Unique set contains the first element", set.contains(els[0]));
+        assertTrue(set.contains(els[0]), "Unique set contains the first element");
         assertTrue(multiset.remove(els[0]));
         set = ((PredicatedMultiSet<T>) multiset).uniqueSet();
-        assertTrue("Unique set does not contain anymore the first element",
-            set.contains(els[0]));
+        assertTrue(set.contains(els[0]),
+            "Unique set does not contain anymore the first element");
     }
 
     @Test
@@ -87,7 +90,7 @@ public class PredicatedMultiSetTest<T> extends AbstractMultiSetTest<T> {
         final Integer i = Integer.valueOf(3);
         assertThrows(IllegalArgumentException.class, () -> multiset.add((T) i),
                 "Integer should fail string predicate.");
-        assertFalse("Collection shouldn't contain illegal element", multiset.contains(i));
+        assertFalse(multiset.contains(i), "Collection shouldn't contain illegal element");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/multiset/UnmodifiableMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/UnmodifiableMultiSetTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.multiset;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 

--- a/src/test/java/org/apache/commons/collections4/properties/AbstractPropertiesFactoryTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/AbstractPropertiesFactoryTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.properties;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.io.BufferedReader;
@@ -26,7 +29,6 @@ import java.util.Properties;
 import java.util.stream.Stream;
 
 import org.apache.commons.collections4.BulkTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,17 +51,17 @@ public abstract class AbstractPropertiesFactoryTest<T extends Properties> {
     }
 
     private void assertContents(final T properties) {
-        Assertions.assertEquals("value1", properties.getProperty("key1"));
-        Assertions.assertEquals("value2", properties.getProperty("key2"));
-        Assertions.assertEquals("value3", properties.getProperty("key3"));
-        Assertions.assertEquals("value4", properties.getProperty("key4"));
-        Assertions.assertEquals("value5", properties.getProperty("key5"));
-        Assertions.assertEquals("value6", properties.getProperty("key6"));
-        Assertions.assertEquals("value7", properties.getProperty("key7"));
-        Assertions.assertEquals("value8", properties.getProperty("key8"));
-        Assertions.assertEquals("value9", properties.getProperty("key9"));
-        Assertions.assertEquals("value10", properties.getProperty("key10"));
-        Assertions.assertEquals("value11", properties.getProperty("key11"));
+        assertEquals("value1", properties.getProperty("key1"));
+        assertEquals("value2", properties.getProperty("key2"));
+        assertEquals("value3", properties.getProperty("key3"));
+        assertEquals("value4", properties.getProperty("key4"));
+        assertEquals("value5", properties.getProperty("key5"));
+        assertEquals("value6", properties.getProperty("key6"));
+        assertEquals("value7", properties.getProperty("key7"));
+        assertEquals("value8", properties.getProperty("key8"));
+        assertEquals("value9", properties.getProperty("key9"));
+        assertEquals("value10", properties.getProperty("key10"));
+        assertEquals("value11", properties.getProperty("key11"));
     }
 
     private boolean isXmlTest(final String fileExtension) {
@@ -72,13 +74,13 @@ public abstract class AbstractPropertiesFactoryTest<T extends Properties> {
 
     @Test
     public void testInstance() {
-        Assertions.assertNotNull(PropertiesFactory.INSTANCE);
+        assertNotNull(PropertiesFactory.INSTANCE);
     }
 
     @ParameterizedTest
     @MethodSource(value = "getParameters")
     public void testLoadClassLoaderMissingResource(final String fileExtension) throws Exception {
-        Assertions.assertNull(factory.load(ClassLoader.getSystemClassLoader(), "missing/test" + fileExtension));
+        assertNull(factory.load(ClassLoader.getSystemClassLoader(), "missing/test" + fileExtension));
     }
 
     @ParameterizedTest

--- a/src/test/java/org/apache/commons/collections4/properties/PropertiesFactoryTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/PropertiesFactoryTest.java
@@ -17,9 +17,10 @@
 
 package org.apache.commons.collections4.properties;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.util.Properties;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class PropertiesFactoryTest extends AbstractPropertiesFactoryTest<Properties> {
@@ -31,7 +32,7 @@ public class PropertiesFactoryTest extends AbstractPropertiesFactoryTest<Propert
     @Test
     @Override
     public void testInstance() {
-        Assertions.assertNotNull(PropertiesFactory.INSTANCE);
+        assertNotNull(PropertiesFactory.INSTANCE);
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesFactoryTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesFactoryTest.java
@@ -16,7 +16,8 @@
  */
 package org.apache.commons.collections4.properties;
 
-import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import org.junit.jupiter.api.Test;
 
 public class SortedPropertiesFactoryTest extends AbstractPropertiesFactoryTest<SortedProperties> {
@@ -28,7 +29,7 @@ public class SortedPropertiesFactoryTest extends AbstractPropertiesFactoryTest<S
     @Test
     @Override
     public void testInstance() {
-        Assertions.assertNotNull(SortedPropertiesFactory.INSTANCE);
+        assertNotNull(SortedPropertiesFactory.INSTANCE);
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/SortedPropertiesTest.java
@@ -16,11 +16,12 @@
  */
 package org.apache.commons.collections4.properties;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class SortedPropertiesTest {
@@ -34,8 +35,8 @@ public class SortedPropertiesTest {
         final Iterator<Map.Entry<Object, Object>> entries = sortedProperties.entrySet().iterator();
         for (char ch = 'A'; ch <= 'Z'; ch++) {
             final Map.Entry<Object, Object> entry = entries.next();
-            Assertions.assertEquals(String.valueOf(ch), entry.getKey());
-            Assertions.assertEquals("Value" + ch, entry.getValue());
+            assertEquals(String.valueOf(ch), entry.getKey());
+            assertEquals("Value" + ch, entry.getValue());
         }
     }
 
@@ -47,7 +48,7 @@ public class SortedPropertiesTest {
         }
         final Enumeration<Object> keys = sortedProperties.keys();
         for (char ch = 'A'; ch <= 'Z'; ch++) {
-            Assertions.assertEquals(String.valueOf(ch), keys.nextElement());
+            assertEquals(String.valueOf(ch), keys.nextElement());
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/queue/AbstractQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/AbstractQueueTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.collections4.queue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -141,8 +145,8 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
             final boolean r = getCollection().offer(element);
             getConfirmed().add(element);
             verify();
-            assertTrue("Empty queue changed after add", r);
-            assertEquals("Queue size is 1 after first add", 1, getCollection().size());
+            assertTrue(r, "Empty queue changed after add");
+            assertEquals(1, getCollection().size(), "Queue size is 1 after first add");
         }
 
         resetEmpty();
@@ -154,8 +158,8 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
             if (r) {
                 size++;
             }
-            assertEquals("Queue size should grow after add", size, getCollection().size());
-            assertTrue("Queue should contain added element", getCollection().contains(element));
+            assertEquals(size, getCollection().size(), "Queue size should grow after add");
+            assertTrue(getCollection().contains(element), "Queue should contain added element");
         }
     }
 
@@ -253,7 +257,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
         for (int i = 0; i < max; i++) {
             final E element = getCollection().remove();
             final boolean success = getConfirmed().remove(element);
-            assertTrue("remove should return correct element", success);
+            assertTrue(success, "remove should return correct element");
             verify();
         }
 
@@ -281,7 +285,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
         for (int i = 0; i < max; i++) {
             element = getCollection().poll();
             final boolean success = getConfirmed().remove(element);
-            assertTrue("poll should return correct element", success);
+            assertTrue(success, "poll should return correct element");
             verify();
         }
 
@@ -300,8 +304,8 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
         final byte[] object = writeExternalFormToBytes((Serializable) queue);
         final Queue<E> queue2 = (Queue<E>) readExternalFormFromBytes(object);
 
-        assertEquals("Both queues are empty", 0, queue.size());
-        assertEquals("Both queues are empty", 0, queue2.size());
+        assertEquals(0, queue.size(), "Both queues are empty");
+        assertEquals(0, queue2.size(), "Both queues are empty");
     }
 
     @Test
@@ -316,8 +320,8 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
         final byte[] object = writeExternalFormToBytes((Serializable) queue);
         final Queue<E> queue2 = (Queue<E>) readExternalFormFromBytes(object);
 
-        assertEquals("Both queues are same size", size, queue.size());
-        assertEquals("Both queues are same size", size, queue2.size());
+        assertEquals(size, queue.size(), "Both queues are same size");
+        assertEquals(size, queue2.size(), "Both queues are same size");
     }
 
     /**
@@ -340,7 +344,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
         if (queue instanceof Serializable && !skipSerializedCanonicalTests()
                 && isTestSerialization()) {
             final Queue<E> queue2 = (Queue<E>) readExternalFormFromDisk(getCanonicalEmptyCollectionName(queue));
-            assertEquals("Queue is empty", 0, queue2.size());
+            assertEquals(0, queue2.size(), "Queue is empty");
         }
     }
 
@@ -363,7 +367,7 @@ public abstract class AbstractQueueTest<E> extends AbstractCollectionTest<E> {
         final Queue<E> queue = makeFullCollection();
         if (queue instanceof Serializable && !skipSerializedCanonicalTests() && isTestSerialization()) {
             final Queue<E> queue2 = (Queue<E>) readExternalFormFromDisk(getCanonicalFullCollectionName(queue));
-            assertEquals("Queues are not the right size", queue.size(), queue2.size());
+            assertEquals(queue.size(), queue2.size(), "Queues are not the right size");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/queue/CircularFifoQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/CircularFifoQueueTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.queue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -148,7 +151,7 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
         for (int i = 0; i < size; i++) {
             final Object o1 = getCollection().remove();
             final Object o2 = ((List<?>) getConfirmed()).remove(0);
-            assertEquals("Removed objects should be equal", o1, o2);
+            assertEquals(o1, o2, "Removed objects should be equal");
             verify();
         }
 

--- a/src/test/java/org/apache/commons/collections4/queue/PredicatedQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/PredicatedQueueTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.queue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -83,7 +86,7 @@ public class PredicatedQueueTest<E> extends AbstractQueueTest<E> {
         queue.add((E) "one");
         queue.add((E) "two");
         queue.add((E) "three");
-        assertEquals("Queue get", "one", queue.peek());
+        assertEquals("one", queue.peek(), "Queue get");
     }
 
     @Test
@@ -91,7 +94,7 @@ public class PredicatedQueueTest<E> extends AbstractQueueTest<E> {
     public void testRemove() {
         final Queue<E> queue = makeTestQueue();
         queue.add((E) "one");
-        assertEquals("Queue get", "one", queue.poll());
+        assertEquals("one", queue.poll(), "Queue get");
         assertNull(queue.peek());
     }
 

--- a/src/test/java/org/apache/commons/collections4/queue/TransformedQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/TransformedQueueTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.queue;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;

--- a/src/test/java/org/apache/commons/collections4/queue/UnmodifiableQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/UnmodifiableQueueTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.queue;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/src/test/java/org/apache/commons/collections4/set/AbstractNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/AbstractNavigableSetTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Iterator;
 import java.util.NavigableSet;
 import java.util.TreeSet;
@@ -83,19 +85,19 @@ public abstract class AbstractNavigableSetTest<E> extends AbstractSortedSetTest<
         while (collIter.hasNext()) {
             final E element = collIter.next();
             final E confElement = confIter.next();
-            assertEquals("Element appears to be out of order.", confElement, element);
+            assertEquals(confElement, element, "Element appears to be out of order.");
 
-            assertEquals("Incorrect element returned by higher().", getConfirmed().higher(element),
-                                                                    getCollection().higher(element));
+            assertEquals(getConfirmed().higher(element),
+                    getCollection().higher(element), "Incorrect element returned by higher().");
 
-            assertEquals("Incorrect element returned by lower().", getConfirmed().lower(element),
-                                                                   getCollection().lower(element));
+            assertEquals(getConfirmed().lower(element),
+                    getCollection().lower(element), "Incorrect element returned by lower().");
 
-            assertEquals("Incorrect element returned by floor().", getConfirmed().floor(element),
-                                                                   getCollection().floor(element));
+            assertEquals(getConfirmed().floor(element),
+                    getCollection().floor(element), "Incorrect element returned by floor().");
 
-            assertEquals("Incorrect element returned by ceiling().", getConfirmed().ceiling(element),
-                                                                     getCollection().ceiling(element));
+            assertEquals(getConfirmed().ceiling(element),
+                    getCollection().ceiling(element), "Incorrect element returned by ceiling().");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/set/AbstractSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/AbstractSetTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -58,12 +62,12 @@ public abstract class AbstractSetTest<E> extends AbstractCollectionTest<E> {
     public void verify() {
         super.verify();
 
-        assertEquals("Sets should be equal", getConfirmed(), getCollection());
-        assertEquals("Sets should have equal hashCodes",
-                     getConfirmed().hashCode(), getCollection().hashCode());
+        assertEquals(getConfirmed(), getCollection(), "Sets should be equal");
+        assertEquals(getConfirmed().hashCode(), getCollection().hashCode(),
+                     "Sets should have equal hashCodes");
         final Collection<E> set = makeConfirmedCollection();
         for (final E element : getCollection()) {
-            assertTrue("Set.iterator should only return unique elements", set.add(element));
+            assertTrue(set.add(element), "Set.iterator should only return unique elements");
         }
     }
 
@@ -143,20 +147,20 @@ public abstract class AbstractSetTest<E> extends AbstractCollectionTest<E> {
     @SuppressWarnings("unchecked")
     public void testSetEquals() {
         resetEmpty();
-        assertEquals("Empty sets should be equal", getCollection(), getConfirmed());
+        assertEquals(getCollection(), getConfirmed(), "Empty sets should be equal");
         verify();
 
         final Collection<E> set2 = makeConfirmedCollection();
         set2.add((E) "foo");
-        assertFalse("Empty set shouldn't equal nonempty set", getCollection().equals(set2));
+        assertFalse(getCollection().equals(set2), "Empty set shouldn't equal nonempty set");
 
         resetFull();
-        assertEquals("Full sets should be equal", getCollection(), getConfirmed());
+        assertEquals(getCollection(), getConfirmed(), "Full sets should be equal");
         verify();
 
         set2.clear();
         set2.addAll(Arrays.asList(getOtherElements()));
-        assertFalse("Sets with different contents shouldn't be equal", getCollection().equals(set2));
+        assertFalse(getCollection().equals(set2), "Sets with different contents shouldn't be equal");
     }
 
     /**
@@ -165,12 +169,12 @@ public abstract class AbstractSetTest<E> extends AbstractCollectionTest<E> {
     @Test
     public void testSetHashCode() {
         resetEmpty();
-        assertEquals("Empty sets have equal hashCodes",
-                getCollection().hashCode(), getConfirmed().hashCode());
+        assertEquals(getCollection().hashCode(), getConfirmed().hashCode(),
+                "Empty sets have equal hashCodes");
 
         resetFull();
-        assertEquals("Equal sets have equal hashCodes",
-                getCollection().hashCode(), getConfirmed().hashCode());
+        assertEquals(getCollection().hashCode(), getConfirmed().hashCode(),
+                "Equal sets have equal hashCodes");
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/set/AbstractSortedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/AbstractSortedSetTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.util.Iterator;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -64,13 +66,13 @@ public abstract class AbstractSortedSetTest<E> extends AbstractSetTest<E> {
             } else {
                 last = collIter.next();
             }
-            assertEquals("Element appears to be out of order.", last, confIter.next());
+            assertEquals(last, confIter.next(), "Element appears to be out of order.");
         }
         if (!getCollection().isEmpty()) {
-            assertEquals("Incorrect element returned by first().", first,
-                getCollection().first());
-            assertEquals("Incorrect element returned by last().", last,
-                getCollection().last());
+            assertEquals(first,
+                getCollection().first(), "Incorrect element returned by first().");
+            assertEquals(last,
+                getCollection().last(), "Incorrect element returned by last().");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/set/CompositeSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/CompositeSetTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collection;
 import java.util.HashSet;

--- a/src/test/java/org/apache/commons/collections4/set/ListOrderedSet2Test.java
+++ b/src/test/java/org/apache/commons/collections4/set/ListOrderedSet2Test.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -61,30 +65,30 @@ public class ListOrderedSet2Test<E> extends AbstractSetTest<E> {
         Iterator<E> it = set.iterator();
 
         for (int i = 0; i < 10; i++) {
-            assertEquals("Sequence is wrong", Integer.toString(i), it.next());
+            assertEquals(Integer.toString(i), it.next(), "Sequence is wrong");
         }
 
         for (int i = 0; i < 10; i += 2) {
-            assertTrue("Must be able to remove int", set.remove(Integer.toString(i)));
+            assertTrue(set.remove(Integer.toString(i)), "Must be able to remove int");
         }
 
         it = set.iterator();
         for (int i = 1; i < 10; i += 2) {
-            assertEquals("Sequence is wrong after remove ", Integer.toString(i), it.next());
+            assertEquals(Integer.toString(i), it.next(), "Sequence is wrong after remove ");
         }
 
         for (int i = 0; i < 10; i++) {
             set.add((E) Integer.toString(i));
         }
 
-        assertEquals("Size of set is wrong!", 10, set.size());
+        assertEquals(10, set.size(), "Size of set is wrong!");
 
         it = set.iterator();
         for (int i = 1; i < 10; i += 2) {
-            assertEquals("Sequence is wrong", Integer.toString(i), it.next());
+            assertEquals(Integer.toString(i), it.next(), "Sequence is wrong");
         }
         for (int i = 0; i < 10; i += 2) {
-            assertEquals("Sequence is wrong", Integer.toString(i), it.next());
+            assertEquals(Integer.toString(i), it.next(), "Sequence is wrong");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/set/ListOrderedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/ListOrderedSetTest.java
@@ -17,7 +17,10 @@
 package org.apache.commons.collections4.set;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -72,32 +75,32 @@ public class ListOrderedSetTest<E>
         Iterator<E> it = set.iterator();
 
         for (int i = 0; i < 10; i++) {
-            assertEquals("Sequence is wrong", Integer.toString(i), it.next());
+            assertEquals(Integer.toString(i), it.next(), "Sequence is wrong");
         }
 
         for (int i = 0; i < 10; i += 2) {
-            assertTrue("Must be able to remove int",
-                       set.remove(Integer.toString(i)));
+            assertTrue(set.remove(Integer.toString(i)),
+                       "Must be able to remove int");
         }
 
         it = set.iterator();
         for (int i = 1; i < 10; i += 2) {
-            assertEquals("Sequence is wrong after remove ",
-                         Integer.toString(i), it.next());
+            assertEquals(Integer.toString(i), it.next(),
+                         "Sequence is wrong after remove ");
         }
 
         for (int i = 0; i < 10; i++) {
             set.add((E) Integer.toString(i));
         }
 
-        assertEquals("Size of set is wrong!", 10, set.size());
+        assertEquals(10, set.size(), "Size of set is wrong!");
 
         it = set.iterator();
         for (int i = 1; i < 10; i += 2) {
-            assertEquals("Sequence is wrong", Integer.toString(i), it.next());
+            assertEquals(Integer.toString(i), it.next(), "Sequence is wrong");
         }
         for (int i = 0; i < 10; i += 2) {
-            assertEquals("Sequence is wrong", Integer.toString(i), it.next());
+            assertEquals(Integer.toString(i), it.next(), "Sequence is wrong");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/set/MapBackedSet2Test.java
+++ b/src/test/java/org/apache/commons/collections4/set/MapBackedSet2Test.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Iterator;
 import java.util.Set;
 
@@ -55,30 +58,30 @@ public class MapBackedSet2Test<E> extends AbstractSetTest<E> {
         Iterator<E> it = set.iterator();
 
         for (int i = 0; i < 10; i++) {
-            assertEquals("Sequence is wrong", Integer.toString(i), it.next());
+            assertEquals(Integer.toString(i), it.next(), "Sequence is wrong");
         }
 
         for (int i = 0; i < 10; i += 2) {
-            assertTrue("Must be able to remove int", set.remove(Integer.toString(i)));
+            assertTrue(set.remove(Integer.toString(i)), "Must be able to remove int");
         }
 
         it = set.iterator();
         for (int i = 1; i < 10; i += 2) {
-            assertEquals("Sequence is wrong after remove ", Integer.toString(i), it.next());
+            assertEquals(Integer.toString(i), it.next(), "Sequence is wrong after remove ");
         }
 
         for (int i = 0; i < 10; i++) {
             set.add((E) Integer.toString(i));
         }
 
-        assertEquals("Size of set is wrong!", 10, set.size());
+        assertEquals(10, set.size(), "Size of set is wrong!");
 
         it = set.iterator();
         for (int i = 1; i < 10; i += 2) {
-            assertEquals("Sequence is wrong", Integer.toString(i), it.next());
+            assertEquals(Integer.toString(i), it.next(), "Sequence is wrong");
         }
         for (int i = 0; i < 10; i += 2) {
-            assertEquals("Sequence is wrong", Integer.toString(i), it.next());
+            assertEquals(Integer.toString(i), it.next(), "Sequence is wrong");
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/set/PredicatedNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/PredicatedNavigableSetTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
@@ -63,7 +66,7 @@ public class PredicatedNavigableSetTest<E> extends AbstractNavigableSetTest<E> {
     @Test
     public void testGetSet() {
         final PredicatedNavigableSet<E> set = makeTestSet();
-        assertNotNull("returned set should not be null", set.decorated());
+        assertNotNull(set.decorated(), "returned set should not be null");
     }
 
     @Test
@@ -73,7 +76,7 @@ public class PredicatedNavigableSetTest<E> extends AbstractNavigableSetTest<E> {
         final String testString = "B";
         assertThrows(IllegalArgumentException.class, () -> set.add((E) testString),
                 "Should fail string predicate.");
-        assertFalse("Collection shouldn't contain illegal element", set.contains(testString));
+        assertFalse(set.contains(testString), "Collection shouldn't contain illegal element");
     }
 
     @Test
@@ -87,17 +90,17 @@ public class PredicatedNavigableSetTest<E> extends AbstractNavigableSetTest<E> {
         elements.add((E) "Afour");
         assertThrows(IllegalArgumentException.class, () -> set.addAll(elements),
                 "Should fail string predicate.");
-        assertFalse("Set shouldn't contain illegal element", set.contains("Aone"));
-        assertFalse("Set shouldn't contain illegal element", set.contains("Atwo"));
-        assertFalse("Set shouldn't contain illegal element", set.contains("Bthree"));
-        assertFalse("Set shouldn't contain illegal element", set.contains("Afour"));
+        assertFalse(set.contains("Aone"), "Set shouldn't contain illegal element");
+        assertFalse(set.contains("Atwo"), "Set shouldn't contain illegal element");
+        assertFalse(set.contains("Bthree"), "Set shouldn't contain illegal element");
+        assertFalse(set.contains("Afour"), "Set shouldn't contain illegal element");
     }
 
     @Test
     public void testComparator() {
         final NavigableSet<E> set = makeTestSet();
         final Comparator<? super E> c = set.comparator();
-        assertNull("natural order, so comparator should be null", c);
+        assertNull(c, "natural order, so comparator should be null");
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/set/PredicatedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/PredicatedSetTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashSet;
@@ -64,7 +66,7 @@ public class PredicatedSetTest<E> extends AbstractSetTest<E> {
     @Test
     public void testGetSet() {
         final PredicatedSet<E> set = makeTestSet();
-        assertNotNull("returned set should not be null", set.decorated());
+        assertNotNull(set.decorated(), "returned set should not be null");
     }
 
     @Test
@@ -74,7 +76,7 @@ public class PredicatedSetTest<E> extends AbstractSetTest<E> {
         final Integer i = Integer.valueOf(3);
         assertThrows(IllegalArgumentException.class, () -> set.add((E) i),
                 "Integer should fail string predicate.");
-        assertFalse("Collection shouldn't contain illegal element", set.contains(i));
+        assertFalse(set.contains(i), "Collection shouldn't contain illegal element");
     }
 
     @Test
@@ -88,10 +90,10 @@ public class PredicatedSetTest<E> extends AbstractSetTest<E> {
         elements.add((E) "four");
         assertThrows(IllegalArgumentException.class, () -> set.addAll(elements),
                 "Integer should fail string predicate.");
-        assertFalse("Set shouldn't contain illegal element", set.contains("one"));
-        assertFalse("Set shouldn't contain illegal element", set.contains("two"));
-        assertFalse("Set shouldn't contain illegal element", set.contains(Integer.valueOf(3)));
-        assertFalse("Set shouldn't contain illegal element", set.contains("four"));
+        assertFalse(set.contains("one"), "Set shouldn't contain illegal element");
+        assertFalse(set.contains("two"), "Set shouldn't contain illegal element");
+        assertFalse(set.contains(Integer.valueOf(3)), "Set shouldn't contain illegal element");
+        assertFalse(set.contains("four"), "Set shouldn't contain illegal element");
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/set/PredicatedSortedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/PredicatedSortedSetTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
@@ -63,7 +66,7 @@ public class PredicatedSortedSetTest<E> extends AbstractSortedSetTest<E> {
     @Test
     public void testGetSet() {
         final PredicatedSortedSet<E> set = makeTestSet();
-        assertNotNull("returned set should not be null", set.decorated());
+        assertNotNull(set.decorated(), "returned set should not be null");
     }
 
     @Test
@@ -73,7 +76,7 @@ public class PredicatedSortedSetTest<E> extends AbstractSortedSetTest<E> {
         final String testString = "B";
         assertThrows(IllegalArgumentException.class, () -> set.add((E) testString),
                 "Should fail string predicate.");
-        assertFalse("Collection shouldn't contain illegal element", set.contains(testString));
+        assertFalse(set.contains(testString), "Collection shouldn't contain illegal element");
     }
 
     @Test
@@ -87,17 +90,17 @@ public class PredicatedSortedSetTest<E> extends AbstractSortedSetTest<E> {
         elements.add((E) "Afour");
         assertThrows(IllegalArgumentException.class, () -> set.addAll(elements),
                 "Should fail string predicate.");
-        assertFalse("Set shouldn't contain illegal element", set.contains("Aone"));
-        assertFalse("Set shouldn't contain illegal element", set.contains("Atwo"));
-        assertFalse("Set shouldn't contain illegal element", set.contains("Bthree"));
-        assertFalse("Set shouldn't contain illegal element", set.contains("Afour"));
+        assertFalse(set.contains("Aone"), "Set shouldn't contain illegal element");
+        assertFalse(set.contains("Atwo"), "Set shouldn't contain illegal element");
+        assertFalse(set.contains("Bthree"), "Set shouldn't contain illegal element");
+        assertFalse(set.contains("Afour"), "Set shouldn't contain illegal element");
     }
 
     @Test
     public void testComparator() {
         final SortedSet<E> set = makeTestSet();
         final Comparator<? super E> c = set.comparator();
-        assertNull("natural order, so comparator should be null", c);
+        assertNull(c, "natural order, so comparator should be null");
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/set/TransformedNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/TransformedNavigableSetTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.NavigableSet;

--- a/src/test/java/org/apache/commons/collections4/set/TransformedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/TransformedSetTest.java
@@ -16,6 +16,10 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;

--- a/src/test/java/org/apache/commons/collections4/set/TransformedSortedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/TransformedSortedSetTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableNavigableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableNavigableSetTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
@@ -119,7 +121,7 @@ public class UnmodifiableNavigableSetTest<E> extends AbstractNavigableSetTest<E>
     public void testComparator() {
         setupSet();
         final Comparator<? super E> c = set.comparator();
-        assertNull("natural order, so comparator should be null", c);
+        assertNull(c, "natural order, so comparator should be null");
     }
 
 

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableSetTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.set;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/src/test/java/org/apache/commons/collections4/set/UnmodifiableSortedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/UnmodifiableSortedSetTest.java
@@ -17,6 +17,8 @@
 package org.apache.commons.collections4.set;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
@@ -116,7 +118,7 @@ public class UnmodifiableSortedSetTest<E> extends AbstractSortedSetTest<E> {
     public void testComparator() {
         setupSet();
         final Comparator<? super E> c = set.comparator();
-        assertNull("natural order, so comparator should be null", c);
+        assertNull(c, "natural order, so comparator should be null");
     }
 
 

--- a/src/test/java/org/apache/commons/collections4/splitmap/TransformedSplitMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/splitmap/TransformedSplitMapTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections4.splitmap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -119,8 +124,8 @@ public class TransformedSplitMapTest extends BulkTest {
         in.close();
 
         final TransformedSplitMap<?, ?, ?, ?> readMap = (TransformedSplitMap<?, ?, ?, ?>) readObject;
-        assertTrue( "Map should be empty", readMap.isEmpty() );
-        assertEquals( map.entrySet(), readMap.entrySet() );
+        assertTrue(readMap.isEmpty(), "Map should be empty");
+        assertEquals(map.entrySet(), readMap.entrySet());
     }
 
     @Test
@@ -140,7 +145,7 @@ public class TransformedSplitMapTest extends BulkTest {
         in.close();
 
         final TransformedSplitMap<?, ?, ?, ?> readMap = (TransformedSplitMap<?, ?, ?, ?>) readObject;
-        assertFalse( "Map should not be empty", readMap.isEmpty() );
+        assertFalse(readMap.isEmpty(), "Map should not be empty");
         assertEquals( map.entrySet(), readMap.entrySet() );
     }
 

--- a/src/test/java/org/apache/commons/collections4/trie/PatriciaTrieTest.java
+++ b/src/test/java/org/apache/commons/collections4/trie/PatriciaTrieTest.java
@@ -16,6 +16,14 @@
  */
 package org.apache.commons.collections4.trie;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.ConcurrentModificationException;
@@ -28,7 +36,6 @@ import java.util.SortedMap;
 
 import org.apache.commons.collections4.Trie;
 import org.apache.commons.collections4.map.AbstractSortedMapTest;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -74,211 +81,211 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
         Map.Entry<String, String> entry;
 
         map = trie.prefixMap("Al");
-        Assertions.assertEquals(8, map.size());
-        Assertions.assertEquals("Alabama", map.firstKey());
-        Assertions.assertEquals("Alliese", map.lastKey());
-        Assertions.assertEquals("Albertoo", map.get("Albertoo"));
-        Assertions.assertNotNull(trie.get("Xavier"));
-        Assertions.assertNull(map.get("Xavier"));
-        Assertions.assertNull(trie.get("Alice"));
-        Assertions.assertNull(map.get("Alice"));
+        assertEquals(8, map.size());
+        assertEquals("Alabama", map.firstKey());
+        assertEquals("Alliese", map.lastKey());
+        assertEquals("Albertoo", map.get("Albertoo"));
+        assertNotNull(trie.get("Xavier"));
+        assertNull(map.get("Xavier"));
+        assertNull(trie.get("Alice"));
+        assertNull(map.get("Alice"));
         iterator = map.values().iterator();
-        Assertions.assertEquals("Alabama", iterator.next());
-        Assertions.assertEquals("Albert", iterator.next());
-        Assertions.assertEquals("Alberto", iterator.next());
-        Assertions.assertEquals("Albertoo", iterator.next());
-        Assertions.assertEquals("Alberts", iterator.next());
-        Assertions.assertEquals("Alien", iterator.next());
-        Assertions.assertEquals("Allie", iterator.next());
-        Assertions.assertEquals("Alliese", iterator.next());
-        Assertions.assertFalse(iterator.hasNext());
+        assertEquals("Alabama", iterator.next());
+        assertEquals("Albert", iterator.next());
+        assertEquals("Alberto", iterator.next());
+        assertEquals("Albertoo", iterator.next());
+        assertEquals("Alberts", iterator.next());
+        assertEquals("Alien", iterator.next());
+        assertEquals("Allie", iterator.next());
+        assertEquals("Alliese", iterator.next());
+        assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("Albert");
         iterator = map.keySet().iterator();
-        Assertions.assertEquals("Albert", iterator.next());
-        Assertions.assertEquals("Alberto", iterator.next());
-        Assertions.assertEquals("Albertoo", iterator.next());
-        Assertions.assertEquals("Alberts", iterator.next());
-        Assertions.assertFalse(iterator.hasNext());
-        Assertions.assertEquals(4, map.size());
-        Assertions.assertEquals("Albert", map.firstKey());
-        Assertions.assertEquals("Alberts", map.lastKey());
-        Assertions.assertNull(trie.get("Albertz"));
+        assertEquals("Albert", iterator.next());
+        assertEquals("Alberto", iterator.next());
+        assertEquals("Albertoo", iterator.next());
+        assertEquals("Alberts", iterator.next());
+        assertFalse(iterator.hasNext());
+        assertEquals(4, map.size());
+        assertEquals("Albert", map.firstKey());
+        assertEquals("Alberts", map.lastKey());
+        assertNull(trie.get("Albertz"));
         map.put("Albertz", "Albertz");
-        Assertions.assertEquals("Albertz", trie.get("Albertz"));
-        Assertions.assertEquals(5, map.size());
-        Assertions.assertEquals("Albertz", map.lastKey());
+        assertEquals("Albertz", trie.get("Albertz"));
+        assertEquals(5, map.size());
+        assertEquals("Albertz", map.lastKey());
         iterator = map.keySet().iterator();
-        Assertions.assertEquals("Albert", iterator.next());
-        Assertions.assertEquals("Alberto", iterator.next());
-        Assertions.assertEquals("Albertoo", iterator.next());
-        Assertions.assertEquals("Alberts", iterator.next());
-        Assertions.assertEquals("Albertz", iterator.next());
-        Assertions.assertFalse(iterator.hasNext());
-        Assertions.assertEquals("Albertz", map.remove("Albertz"));
+        assertEquals("Albert", iterator.next());
+        assertEquals("Alberto", iterator.next());
+        assertEquals("Albertoo", iterator.next());
+        assertEquals("Alberts", iterator.next());
+        assertEquals("Albertz", iterator.next());
+        assertFalse(iterator.hasNext());
+        assertEquals("Albertz", map.remove("Albertz"));
 
         map = trie.prefixMap("Alberto");
-        Assertions.assertEquals(2, map.size());
-        Assertions.assertEquals("Alberto", map.firstKey());
-        Assertions.assertEquals("Albertoo", map.lastKey());
+        assertEquals(2, map.size());
+        assertEquals("Alberto", map.firstKey());
+        assertEquals("Albertoo", map.lastKey());
         entryIterator = map.entrySet().iterator();
         entry = entryIterator.next();
-        Assertions.assertEquals("Alberto", entry.getKey());
-        Assertions.assertEquals("Alberto", entry.getValue());
+        assertEquals("Alberto", entry.getKey());
+        assertEquals("Alberto", entry.getValue());
         entry = entryIterator.next();
-        Assertions.assertEquals("Albertoo", entry.getKey());
-        Assertions.assertEquals("Albertoo", entry.getValue());
-        Assertions.assertFalse(entryIterator.hasNext());
+        assertEquals("Albertoo", entry.getKey());
+        assertEquals("Albertoo", entry.getValue());
+        assertFalse(entryIterator.hasNext());
         trie.put("Albertoad", "Albertoad");
-        Assertions.assertEquals(3, map.size());
-        Assertions.assertEquals("Alberto", map.firstKey());
-        Assertions.assertEquals("Albertoo", map.lastKey());
+        assertEquals(3, map.size());
+        assertEquals("Alberto", map.firstKey());
+        assertEquals("Albertoo", map.lastKey());
         entryIterator = map.entrySet().iterator();
         entry = entryIterator.next();
-        Assertions.assertEquals("Alberto", entry.getKey());
-        Assertions.assertEquals("Alberto", entry.getValue());
+        assertEquals("Alberto", entry.getKey());
+        assertEquals("Alberto", entry.getValue());
         entry = entryIterator.next();
-        Assertions.assertEquals("Albertoad", entry.getKey());
-        Assertions.assertEquals("Albertoad", entry.getValue());
+        assertEquals("Albertoad", entry.getKey());
+        assertEquals("Albertoad", entry.getValue());
         entry = entryIterator.next();
-        Assertions.assertEquals("Albertoo", entry.getKey());
-        Assertions.assertEquals("Albertoo", entry.getValue());
-        Assertions.assertFalse(entryIterator.hasNext());
-        Assertions.assertEquals("Albertoo", trie.remove("Albertoo"));
-        Assertions.assertEquals("Alberto", map.firstKey());
-        Assertions.assertEquals("Albertoad", map.lastKey());
-        Assertions.assertEquals(2, map.size());
+        assertEquals("Albertoo", entry.getKey());
+        assertEquals("Albertoo", entry.getValue());
+        assertFalse(entryIterator.hasNext());
+        assertEquals("Albertoo", trie.remove("Albertoo"));
+        assertEquals("Alberto", map.firstKey());
+        assertEquals("Albertoad", map.lastKey());
+        assertEquals(2, map.size());
         entryIterator = map.entrySet().iterator();
         entry = entryIterator.next();
-        Assertions.assertEquals("Alberto", entry.getKey());
-        Assertions.assertEquals("Alberto", entry.getValue());
+        assertEquals("Alberto", entry.getKey());
+        assertEquals("Alberto", entry.getValue());
         entry = entryIterator.next();
-        Assertions.assertEquals("Albertoad", entry.getKey());
-        Assertions.assertEquals("Albertoad", entry.getValue());
-        Assertions.assertFalse(entryIterator.hasNext());
-        Assertions.assertEquals("Albertoad", trie.remove("Albertoad"));
+        assertEquals("Albertoad", entry.getKey());
+        assertEquals("Albertoad", entry.getValue());
+        assertFalse(entryIterator.hasNext());
+        assertEquals("Albertoad", trie.remove("Albertoad"));
         trie.put("Albertoo", "Albertoo");
 
         map = trie.prefixMap("X");
-        Assertions.assertEquals(2, map.size());
-        Assertions.assertFalse(map.containsKey("Albert"));
-        Assertions.assertTrue(map.containsKey("Xavier"));
-        Assertions.assertFalse(map.containsKey("Xalan"));
+        assertEquals(2, map.size());
+        assertFalse(map.containsKey("Albert"));
+        assertTrue(map.containsKey("Xavier"));
+        assertFalse(map.containsKey("Xalan"));
         iterator = map.values().iterator();
-        Assertions.assertEquals("Xavier", iterator.next());
-        Assertions.assertEquals("XyZ", iterator.next());
-        Assertions.assertFalse(iterator.hasNext());
+        assertEquals("Xavier", iterator.next());
+        assertEquals("XyZ", iterator.next());
+        assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("An");
-        Assertions.assertEquals(1, map.size());
-        Assertions.assertEquals("Anna", map.firstKey());
-        Assertions.assertEquals("Anna", map.lastKey());
+        assertEquals(1, map.size());
+        assertEquals("Anna", map.firstKey());
+        assertEquals("Anna", map.lastKey());
         iterator = map.keySet().iterator();
-        Assertions.assertEquals("Anna", iterator.next());
-        Assertions.assertFalse(iterator.hasNext());
+        assertEquals("Anna", iterator.next());
+        assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("Ban");
-        Assertions.assertEquals(1, map.size());
-        Assertions.assertEquals("Banane", map.firstKey());
-        Assertions.assertEquals("Banane", map.lastKey());
+        assertEquals(1, map.size());
+        assertEquals("Banane", map.firstKey());
+        assertEquals("Banane", map.lastKey());
         iterator = map.keySet().iterator();
-        Assertions.assertEquals("Banane", iterator.next());
-        Assertions.assertFalse(iterator.hasNext());
+        assertEquals("Banane", iterator.next());
+        assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("Am");
-        Assertions.assertFalse(map.isEmpty());
-        Assertions.assertEquals(3, map.size());
-        Assertions.assertEquals("Amber", trie.remove("Amber"));
+        assertFalse(map.isEmpty());
+        assertEquals(3, map.size());
+        assertEquals("Amber", trie.remove("Amber"));
         iterator = map.keySet().iterator();
-        Assertions.assertEquals("Amma", iterator.next());
-        Assertions.assertEquals("Ammun", iterator.next());
-        Assertions.assertFalse(iterator.hasNext());
+        assertEquals("Amma", iterator.next());
+        assertEquals("Ammun", iterator.next());
+        assertFalse(iterator.hasNext());
         iterator = map.keySet().iterator();
         map.put("Amber", "Amber");
-        Assertions.assertEquals(3, map.size());
+        assertEquals(3, map.size());
 
         final Iterator<String> iterator1 = iterator;
-        Assertions.assertThrows(ConcurrentModificationException.class, () -> iterator1.next());
+        assertThrows(ConcurrentModificationException.class, () -> iterator1.next());
 
-        Assertions.assertEquals("Amber", map.firstKey());
-        Assertions.assertEquals("Ammun", map.lastKey());
+        assertEquals("Amber", map.firstKey());
+        assertEquals("Ammun", map.lastKey());
 
         map = trie.prefixMap("Ak\0");
-        Assertions.assertTrue(map.isEmpty());
+        assertTrue(map.isEmpty());
 
         map = trie.prefixMap("Ak");
-        Assertions.assertEquals(2, map.size());
-        Assertions.assertEquals("Akka", map.firstKey());
-        Assertions.assertEquals("Akko", map.lastKey());
+        assertEquals(2, map.size());
+        assertEquals("Akka", map.firstKey());
+        assertEquals("Akko", map.lastKey());
         map.put("Ak", "Ak");
-        Assertions.assertEquals("Ak", map.firstKey());
-        Assertions.assertEquals("Akko", map.lastKey());
-        Assertions.assertEquals(3, map.size());
+        assertEquals("Ak", map.firstKey());
+        assertEquals("Akko", map.lastKey());
+        assertEquals(3, map.size());
         trie.put("Al", "Al");
-        Assertions.assertEquals(3, map.size());
-        Assertions.assertEquals("Ak", map.remove("Ak"));
-        Assertions.assertEquals("Akka", map.firstKey());
-        Assertions.assertEquals("Akko", map.lastKey());
-        Assertions.assertEquals(2, map.size());
+        assertEquals(3, map.size());
+        assertEquals("Ak", map.remove("Ak"));
+        assertEquals("Akka", map.firstKey());
+        assertEquals("Akko", map.lastKey());
+        assertEquals(2, map.size());
         iterator = map.keySet().iterator();
-        Assertions.assertEquals("Akka", iterator.next());
-        Assertions.assertEquals("Akko", iterator.next());
-        Assertions.assertFalse(iterator.hasNext());
-        Assertions.assertEquals("Al", trie.remove("Al"));
+        assertEquals("Akka", iterator.next());
+        assertEquals("Akko", iterator.next());
+        assertFalse(iterator.hasNext());
+        assertEquals("Al", trie.remove("Al"));
 
         map = trie.prefixMap("Akka");
-        Assertions.assertEquals(1, map.size());
-        Assertions.assertEquals("Akka", map.firstKey());
-        Assertions.assertEquals("Akka", map.lastKey());
+        assertEquals(1, map.size());
+        assertEquals("Akka", map.firstKey());
+        assertEquals("Akka", map.lastKey());
         iterator = map.keySet().iterator();
-        Assertions.assertEquals("Akka", iterator.next());
-        Assertions.assertFalse(iterator.hasNext());
+        assertEquals("Akka", iterator.next());
+        assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("Ab");
-        Assertions.assertTrue(map.isEmpty());
-        Assertions.assertEquals(0, map.size());
+        assertTrue(map.isEmpty());
+        assertEquals(0, map.size());
 
         final SortedMap<String, String> map1 = map;
-        Assertions.assertThrows(NoSuchElementException.class, () -> map1.firstKey());
+        assertThrows(NoSuchElementException.class, () -> map1.firstKey());
 
         final SortedMap<String, String> map2 = map;
-        Assertions.assertThrows(NoSuchElementException.class, () -> map2.lastKey());
+        assertThrows(NoSuchElementException.class, () -> map2.lastKey());
 
         iterator = map.values().iterator();
-        Assertions.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("Albertooo");
-        Assertions.assertTrue(map.isEmpty());
-        Assertions.assertEquals(0, map.size());
+        assertTrue(map.isEmpty());
+        assertEquals(0, map.size());
 
         final SortedMap<String, String> map3 = map;
-        Assertions.assertThrows(NoSuchElementException.class, () -> map3.firstKey(),
+        assertThrows(NoSuchElementException.class, () -> map3.firstKey(),
                 () -> "got a first key: " + map3.firstKey());
 
         final SortedMap<String, String> map4 = map;
-        Assertions.assertThrows(NoSuchElementException.class, () -> map4.lastKey(),
+        assertThrows(NoSuchElementException.class, () -> map4.lastKey(),
                 () -> "got a last key: " + map4.lastKey());
 
         iterator = map.values().iterator();
-        Assertions.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
 
         map = trie.prefixMap("");
-        Assertions.assertSame(trie, map); // stricter than necessary, but a good check
+        assertSame(trie, map); // stricter than necessary, but a good check
 
         map = trie.prefixMap("\0");
-        Assertions.assertTrue(map.isEmpty());
-        Assertions.assertEquals(0, map.size());
+        assertTrue(map.isEmpty());
+        assertEquals(0, map.size());
 
         final SortedMap<String, String> map5 = map;
-        Assertions.assertThrows(NoSuchElementException.class, () -> map5.firstKey(),
+        assertThrows(NoSuchElementException.class, () -> map5.firstKey(),
                 () -> "got a first key: " + map5.firstKey());
 
         final SortedMap<String, String> map6 = map;
-        Assertions.assertThrows(NoSuchElementException.class, () -> map6.lastKey(),
+        assertThrows(NoSuchElementException.class, () -> map6.lastKey(),
                 () -> "got a last key: " + map6.lastKey());
 
         iterator = map.values().iterator();
-        Assertions.assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
     }
 
     @Test
@@ -297,32 +304,32 @@ public class PatriciaTrieTest<V> extends AbstractSortedMapTest<String, V> {
         }
 
         SortedMap<String, String> map = trie.prefixMap("Al");
-        Assertions.assertEquals(8, map.size());
+        assertEquals(8, map.size());
         Iterator<String> iter = map.keySet().iterator();
-        Assertions.assertEquals("Alabama", iter.next());
-        Assertions.assertEquals("Albert", iter.next());
-        Assertions.assertEquals("Alberto", iter.next());
-        Assertions.assertEquals("Albertoo", iter.next());
-        Assertions.assertEquals("Alberts", iter.next());
-        Assertions.assertEquals("Alien", iter.next());
+        assertEquals("Alabama", iter.next());
+        assertEquals("Albert", iter.next());
+        assertEquals("Alberto", iter.next());
+        assertEquals("Albertoo", iter.next());
+        assertEquals("Alberts", iter.next());
+        assertEquals("Alien", iter.next());
         iter.remove();
-        Assertions.assertEquals(7, map.size());
-        Assertions.assertEquals("Allie", iter.next());
-        Assertions.assertEquals("Alliese", iter.next());
-        Assertions.assertFalse(iter.hasNext());
+        assertEquals(7, map.size());
+        assertEquals("Allie", iter.next());
+        assertEquals("Alliese", iter.next());
+        assertFalse(iter.hasNext());
 
         map = trie.prefixMap("Ak");
-        Assertions.assertEquals(2, map.size());
+        assertEquals(2, map.size());
         iter = map.keySet().iterator();
-        Assertions.assertEquals("Akka", iter.next());
+        assertEquals("Akka", iter.next());
         iter.remove();
-        Assertions.assertEquals(1, map.size());
-        Assertions.assertEquals("Akko", iter.next());
+        assertEquals(1, map.size());
+        assertEquals("Akko", iter.next());
 
         final Iterator<String> iter1 = iter;
-        Assertions.assertFalse(iter.hasNext(), () -> "shouldn't have next (but was: " + iter1.next() + ")");
+        assertFalse(iter.hasNext(), () -> "shouldn't have next (but was: " + iter1.next() + ")");
 
-        Assertions.assertFalse(iter.hasNext());
+        assertFalse(iter.hasNext());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/trie/UnmodifiableTrieTest.java
+++ b/src/test/java/org/apache/commons/collections4/trie/UnmodifiableTrieTest.java
@@ -16,7 +16,9 @@
  */
 package org.apache.commons.collections4.trie;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.commons.collections4.Trie;
 import org.apache.commons.collections4.Unmodifiable;


### PR DESCRIPTION
As part of the migration to Junit 5, target to replace all assertion api to Junit 5, for all Map related test class.
So there is no need for `BulkTest`  to extend `TestCase`.
