### PR TITLE
Make AbstractPatriciaTrie public

### DIFF
--- a/src/main/java/org/apache/commons/collections4/trie/AbstractPatriciaTrie.java
+++ b/src/main/java/org/apache/commons/collections4/trie/AbstractPatriciaTrie.java
@@ -34,11 +34,14 @@ import java.util.Set;
 import java.util.SortedMap;
 
 import org.apache.commons.collections4.OrderedMapIterator;
+import org.apache.commons.collections4.Trie;
 
 /**
  * This class implements the base PATRICIA algorithm and everything that
  * is related to the {@link Map} interface.
  *
+ * @param <K> the type of the keys in this map
+ * @param <V> the type of the values in this map
  * @since 4.0
  */
 public abstract class AbstractPatriciaTrie<K, V> extends AbstractBitwiseTrie<K, V> {
@@ -66,6 +69,11 @@ public abstract class AbstractPatriciaTrie<K, V> extends AbstractBitwiseTrie<K, 
      */
     protected transient int modCount;
 
+    /**
+     * Constructs a new {@link Trie} using the given {@link KeyAnalyzer}.
+     *
+     * @param keyAnalyzer  the {@link KeyAnalyzer} to use
+     */
     protected AbstractPatriciaTrie(final KeyAnalyzer<? super K> keyAnalyzer) {
         super(keyAnalyzer);
     }

--- a/src/main/java/org/apache/commons/collections4/trie/AbstractPatriciaTrie.java
+++ b/src/main/java/org/apache/commons/collections4/trie/AbstractPatriciaTrie.java
@@ -41,7 +41,7 @@ import org.apache.commons.collections4.OrderedMapIterator;
  *
  * @since 4.0
  */
-abstract class AbstractPatriciaTrie<K, V> extends AbstractBitwiseTrie<K, V> {
+public abstract class AbstractPatriciaTrie<K, V> extends AbstractBitwiseTrie<K, V> {
 
     private static final long serialVersionUID = 5155253417231339498L;
 


### PR DESCRIPTION
I extend this class [here](https://github.com/vad0/gfjson/blob/master/src/main/java/org/apache/commons/collections4/trie/AsciiTrie.java) to make an implementation which works with an `AsciiSequenceView` instead of `String`. Package visibility forces me to create a package org.apache.commons.collections4.trie in my project. This hack works, but it prevents me from migrating to the java modules system, which prohibits using the same package names in the different modules. So I think the best solution here wil be to make AbstractPatriciaTrie public.