### PR TITLE
Fix grammatical error in Javadoc

### DIFF
--- a/src/main/java/org/apache/commons/collections4/queue/AbstractQueueDecorator.java
+++ b/src/main/java/org/apache/commons/collections4/queue/AbstractQueueDecorator.java
@@ -28,7 +28,7 @@ import org.apache.commons.collections4.collection.AbstractCollectionDecorator;
  * <p>
  * This implementation does not forward the hashCode and equals methods through
  * to the backing object, but relies on Object's implementation. This is
- * necessary as some Queue implementations, e.g. LinkedList, have custom a
+ * necessary as some Queue implementations, e.g. LinkedList, have a custom
  * equals implementation for which symmetry can not be preserved.
  * See class javadoc of AbstractCollectionDecorator for more information.
  * </p>


### PR DESCRIPTION
This PR fixes a grammatical error in the class Javadoc of `AbstractQueueDecorator` (introduced in 30e5023).