### PR TITLE
[COLLECTIONS-795] Add PairedIterator to allow iterating over different-types of iterators

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,6 +461,9 @@
     <contributor>
       <name>Arturo Bernal</name>
     </contributor>
+    <contributor>
+      <name>Anant Damle</name>
+    </contributor>
   </contributors>
 
   <dependencies>

--- a/src/main/java/org/apache/commons/collections4/IterableUtils.java
+++ b/src/main/java/org/apache/commons/collections4/IterableUtils.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import org.apache.commons.collections4.functors.EqualPredicate;
 import org.apache.commons.collections4.iterators.LazyIteratorChain;
+import org.apache.commons.collections4.iterators.PairedIterator.PairedItem;
 import org.apache.commons.collections4.iterators.ReverseListIterator;
 import org.apache.commons.collections4.iterators.UniqueFilterIterator;
 
@@ -517,6 +518,41 @@ public class IterableUtils {
             }
         };
     }
+
+    /**
+     * Provides iteration over the elements contained in a pair of Iterables in-tandem.
+     * <p>
+     * The returned iterable has an iterator that traverses the elements in {@code a}
+     * and {@code b} together until one of the iterables is traversed completely.
+     * </p>
+     *
+     * <p>
+     * The returned iterable's iterator does NOT support {@code remove()}.
+     * </p>
+     *
+     * @param <L> the left elements' type
+     * @param <R> the right elements' type
+     * @param left the iterable for the left side elements
+     * @param right the iterable for the right side elements
+     * @return an iterable, over the decorated iterables to traverse them together until one is
+     * exhausted
+     * @throws NullPointerException if any iterator is null
+     * @since 4.5
+     */
+    public static <L, R> Iterable<PairedItem<L, R>> pairedIterable(final Iterable<L> left, final Iterable<R> right) {
+        checkNotNull(left);
+        checkNotNull(right);
+
+        return new FluentIterable<PairedItem<L, R>>(){
+            @Override
+            public Iterator<PairedItem<L, R>> iterator() {
+                return IteratorUtils.pairedIterator(left.iterator(), right.iterator());
+            }
+        };
+    }
+
+    // Utility methods
+    // ----------------------------------------------------------------------
 
     /**
      * Returns an immutable empty iterable if the argument is null,

--- a/src/main/java/org/apache/commons/collections4/IteratorUtils.java
+++ b/src/main/java/org/apache/commons/collections4/IteratorUtils.java
@@ -30,38 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.apache.commons.collections4.functors.EqualPredicate;
-import org.apache.commons.collections4.iterators.ArrayIterator;
-import org.apache.commons.collections4.iterators.ArrayListIterator;
-import org.apache.commons.collections4.iterators.BoundedIterator;
-import org.apache.commons.collections4.iterators.CollatingIterator;
-import org.apache.commons.collections4.iterators.EmptyIterator;
-import org.apache.commons.collections4.iterators.EmptyListIterator;
-import org.apache.commons.collections4.iterators.EmptyMapIterator;
-import org.apache.commons.collections4.iterators.EmptyOrderedIterator;
-import org.apache.commons.collections4.iterators.EmptyOrderedMapIterator;
-import org.apache.commons.collections4.iterators.EnumerationIterator;
-import org.apache.commons.collections4.iterators.FilterIterator;
-import org.apache.commons.collections4.iterators.FilterListIterator;
-import org.apache.commons.collections4.iterators.IteratorChain;
-import org.apache.commons.collections4.iterators.IteratorEnumeration;
-import org.apache.commons.collections4.iterators.IteratorIterable;
-import org.apache.commons.collections4.iterators.ListIteratorWrapper;
-import org.apache.commons.collections4.iterators.LoopingIterator;
-import org.apache.commons.collections4.iterators.LoopingListIterator;
-import org.apache.commons.collections4.iterators.NodeListIterator;
-import org.apache.commons.collections4.iterators.ObjectArrayIterator;
-import org.apache.commons.collections4.iterators.ObjectArrayListIterator;
-import org.apache.commons.collections4.iterators.ObjectGraphIterator;
-import org.apache.commons.collections4.iterators.PeekingIterator;
-import org.apache.commons.collections4.iterators.PushbackIterator;
-import org.apache.commons.collections4.iterators.SingletonIterator;
-import org.apache.commons.collections4.iterators.SingletonListIterator;
-import org.apache.commons.collections4.iterators.SkippingIterator;
-import org.apache.commons.collections4.iterators.TransformIterator;
-import org.apache.commons.collections4.iterators.UnmodifiableIterator;
-import org.apache.commons.collections4.iterators.UnmodifiableListIterator;
-import org.apache.commons.collections4.iterators.UnmodifiableMapIterator;
-import org.apache.commons.collections4.iterators.ZippingIterator;
+import org.apache.commons.collections4.iterators.*;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -887,6 +856,25 @@ public class IteratorUtils {
      */
     public static <E> ZippingIterator<E> zippingIterator(final Iterator<? extends E>... iterators) {
         return new ZippingIterator<>(iterators);
+    }
+
+    /**
+     * Gets an Iterator over the elements contained in a pair of Iterables in-tandem.
+     * <p>
+     * The returned iterator traverses the elements in {@code a} and {@code b} together until one of the iterators
+     * is exhausted.
+     * <p>
+     * The returned iterator does NOT support {@code remove()}.
+     *
+     * @param <L> the left elements' type
+     * @param <R> the right elements' type
+     * @param left the iterator for the left side elements
+     * @param right the iterator for the right side elements
+     * @return an iterator, to iterate over the decorated iterators together until one is exhausted
+     * @throws NullPointerException if any iterator is null
+     */
+    public static <L, R> PairedIterator<L, R> pairedIterator(final Iterator<L> left, Iterator<R> right) {
+        return PairedIterator.of(left, right);
     }
 
     // Views

--- a/src/main/java/org/apache/commons/collections4/PairedIterable.java
+++ b/src/main/java/org/apache/commons/collections4/PairedIterable.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4;
+
+import org.apache.commons.collections4.iterators.PairedIterator;
+import org.apache.commons.collections4.iterators.PairedIterator.PairedItem;
+
+import java.util.Iterator;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Provides iteration over the elements contained in a pair of Iterables in-tandem.
+ *
+ * <p>
+ * Given two {@link Iterable} instances {@code A} and {@code B}, the {@link #iterator} method on this
+ * iterator provide a Pair of {@code A.next()} and {@code B.next()} until one of the iterators is
+ * exhausted.
+ * </p>
+ * This can simplify zipping over two iterables using the for-each construct.
+ * Example usage:
+ * <pre>{@code
+ *   List<Integer> studentIds = ...
+ *   List<String> studentNames = ...
+ *
+ *   for (PairedItem<Integer, String> items : PairedIterable.of(studentIds, studentNames) {
+ *     Integer studentId = item.getLeft();
+ *     String studentName = item.getRight();
+ *     ...
+ *   }
+ * }</pre>
+ *
+ * @param <L> the left elements' type
+ * @param <R> the right elements' type
+ */
+public class PairedIterable<L, R> implements Iterable<PairedItem<L, R>> {
+
+    /**
+     * The left {@link Iterable}s to evaluate.
+     */
+    private final Iterable<L> leftIterable;
+
+    /**
+     * The right {@link Iterable}s to evaluate.
+     */
+    private final Iterable<R> rightIterable;
+
+    // Constructor
+    // ----------------------------------------------------------------------
+
+    /**
+     * Constructs a new {@code PairedIterable} that will provide iteration over two given iterables.
+     *
+     * @param leftIterable  the iterable for the left side element.
+     * @param rightIterable the iterable for the right side element.
+     * @throws NullPointerException if either iterator is null
+     */
+    public PairedIterable(Iterable<L> leftIterable, Iterable<R> rightIterable) {
+        this.leftIterable = requireNonNull(leftIterable);
+        this.rightIterable = requireNonNull(rightIterable);
+    }
+
+    /**
+     * Convenience static factory to construct the PairedIterable from provided
+     * {@link Iterable} sources.
+     *
+     * @param leftIterable  the iterable for the left side element.
+     * @param rightIterable the iterable for the right side element.
+     * @return the Iterable to iterate over the elements derived from the provided iterables.
+     * @throws NullPointerException if either iterables is null
+     */
+    public static <L, R> PairedIterable<L, R> of(Iterable<L> leftIterable, Iterable<R> rightIterable) {
+        return new PairedIterable<>(leftIterable, rightIterable);
+    }
+
+    // Iterable Methods
+    // -------------------------------------------------------------------
+
+    @Override
+    public Iterator<PairedItem<L, R>> iterator() {
+        return PairedIterator.ofIterables(leftIterable, rightIterable);
+    }
+
+    public Stream<PairedItem<L, R>> stream() {
+        return StreamSupport.stream(spliterator(), /*parallel=*/ false);
+    }
+}

--- a/src/main/java/org/apache/commons/collections4/iterators/PairedIterator.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/PairedIterator.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4.iterators;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import org.apache.commons.collections4.iterators.PairedIterator.PairedItem;
+
+/**
+ * Provides a iteration over the elements contained in a pair of Iterators.
+ *
+ * <p>
+ * Given two {@link Iterator} instances {@code A} and {@code B}, the {@link #next} method on this
+ * iterator provide a Pair of {@code A.next()} and {@code B.next()} until one of the iterators is
+ * exhausted.
+ * </p>
+ * Example usage:
+ * <pre>{@code
+ *   List<Integer> studentIds = ...
+ *   List<String> studentNames = ...
+ *
+ *   PairedIterator<PairedItem<Integer, String>> pairedIterator =
+ *     PairedIterator.ofIterables(studentIds, studentNames);
+ *
+ *   while (pairedIterator.hasNext()) {
+ *     PairedItem<Integer, String> item = zippedIterator.next();
+ *     ...
+ *   }
+ * }</pre>
+ *
+ * @param <L> the left elements' type
+ * @param <R> the right elements' type
+ */
+public class PairedIterator<L, R> implements Iterator<PairedItem<L, R>> {
+
+    /**
+     * The left {@link Iterator}s to evaluate.
+     */
+    private final Iterator<L> leftIterator;
+
+    /**
+     * The right {@link Iterator}s to evaluate.
+     */
+    private final Iterator<R> rightIterator;
+
+    // Constructor
+    // ----------------------------------------------------------------------
+
+    /**
+     * Constructs a new {@code ZipPairIterator} that will provide  iteration over the two given
+     * iterators.
+     *
+     * @param leftIterator  the iterator for the left side element.
+     * @param rightIterator the iterator for the right side element.
+     * @throws NullPointerException if either iterator is null
+     */
+    public PairedIterator(Iterator<L> leftIterator, Iterator<R> rightIterator) {
+        this.leftIterator = requireNonNull(leftIterator);
+        this.rightIterator = requireNonNull(rightIterator);
+    }
+
+    /**
+     * Convenience static factory to construct the ZipPairIterator
+     *
+     * @param leftIterator  the iterator for the left side element.
+     * @param rightIterator the iterator for the right side element.
+     * @return the iterator to iterate over the provided iterators.
+     * @throws NullPointerException if either iterator is null
+     */
+    public static <L, R> PairedIterator<L, R> of(Iterator<L> leftIterator, Iterator<R> rightIterator) {
+        return new PairedIterator<>(leftIterator, rightIterator);
+    }
+
+    /**
+     * Convenience static factory to construct the ZipPairIterator from any {@link Iterable} sources.
+     *
+     * @param leftIterable  the iterable for the left side element.
+     * @param rightIterable the iterable for the right side element.
+     * @return the iterator to iterate over the iterators derived from the provided iterables.
+     * @throws NullPointerException if either iterables is null
+     */
+    public static <L, R> PairedIterator<L, R> ofIterables(Iterable<L> leftIterable, Iterable<R> rightIterable) {
+        return of(requireNonNull(leftIterable).iterator(), requireNonNull(rightIterable).iterator());
+    }
+
+    // Iterator Methods
+    // -------------------------------------------------------------------
+
+    /**
+     * Returns {@code true} if both the child iterators have remaining elements.
+     *
+     * @return true if both the child iterators have remaining elements
+     */
+    @Override
+    public boolean hasNext() {
+        return leftIterator.hasNext() && rightIterator.hasNext();
+    }
+
+    /**
+     * Returns the next elements from both the child iterators.
+     *
+     * @return the next elements from both the iterators.
+     * @throws NoSuchElementException if any one child iterator is exhausted.
+     */
+    @Override
+    public PairedItem<L, R> next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        return PairedItem.of(leftIterator.next(), rightIterator.next());
+    }
+
+    /**
+     * An immutable tuple class to represent elements from both the iterators.
+     *
+     * @param <L> the left elements' type
+     * @param <R> the right elements' type
+     */
+    public static final class PairedItem<L, R> {
+
+        private final L leftItem;
+
+        private final R rightItem;
+
+        private PairedItem(L leftItem, R rightItem) {
+            this.leftItem = leftItem;
+            this.rightItem = rightItem;
+        }
+
+        /**
+         * Convenience static factory method to construct the tuple pair.
+         *
+         * @param left  the left element
+         * @param right the right element
+         * @return the Immutable tuple pair of two elements.
+         */
+        private static <L, R> PairedItem<L, R> of(L left, R right) {
+            return new PairedItem<>(left, right);
+        }
+
+        public L getLeftItem() {
+            return leftItem;
+        }
+
+        public R getRightItem() {
+            return rightItem;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("{%s, %s}", leftItem, rightItem);
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/collections4/IteratorUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/IteratorUtilsTest.java
@@ -46,16 +46,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.Vector;
 
-import org.apache.commons.collections4.iterators.ArrayIterator;
-import org.apache.commons.collections4.iterators.EmptyIterator;
-import org.apache.commons.collections4.iterators.EmptyListIterator;
-import org.apache.commons.collections4.iterators.EmptyMapIterator;
-import org.apache.commons.collections4.iterators.EmptyOrderedIterator;
-import org.apache.commons.collections4.iterators.EmptyOrderedMapIterator;
-import org.apache.commons.collections4.iterators.EnumerationIterator;
-import org.apache.commons.collections4.iterators.NodeListIterator;
-import org.apache.commons.collections4.iterators.ObjectArrayIterator;
-import org.apache.commons.collections4.iterators.ZippingIterator;
+import org.apache.commons.collections4.iterators.*;
 import org.apache.commons.collections4.map.EntrySetToMapIteratorAdapter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -1116,4 +1107,11 @@ public class IteratorUtilsTest {
         assertTrue(IteratorUtils.zippingIterator(ie, ie) instanceof ZippingIterator, "create instance fail");
     }
 
+    @Test
+    public void testPairedIterator() {
+        final ArrayList<String> stringList = new ArrayList<>();
+        final ArrayList<Integer> integerList = new ArrayList<>();
+
+        assertTrue(IteratorUtils.pairedIterator(stringList.iterator(), integerList.iterator()) instanceof PairedIterator, "create instance failed");
+    }
 }

--- a/src/test/java/org/apache/commons/collections4/PairedIterableTest.java
+++ b/src/test/java/org/apache/commons/collections4/PairedIterableTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4;
+
+import org.apache.commons.collections4.iterators.PairedIterator.PairedItem;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.*;
+import java.util.stream.IntStream;
+
+import static java.util.Collections.unmodifiableList;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+@RunWith(Enclosed.class)
+public final class PairedIterableTest {
+
+    private static final int SMALL_LIST_SIZE = 20;
+    private static final int LARGE_LIST_SIZE = 40;
+
+    private static final List<String> SMALL_STRINGS_LIST =
+            unmodifiableList(stringsList(SMALL_LIST_SIZE));
+    private static final List<String> LARGE_STRINGS_LIST =
+            unmodifiableList(stringsList(LARGE_LIST_SIZE));
+    private static final List<Integer> SMALL_INTS_LIST = unmodifiableList(intsList(SMALL_LIST_SIZE));
+    private static final List<Integer> LARGE_INTS_LIST = unmodifiableList(intsList(LARGE_LIST_SIZE));
+
+    @RunWith(Parameterized.class)
+    public static final class ParameterizedTests<L, R> {
+        private final String testCondition;
+        private final List<L> leftList;
+        private final List<R> rightList;
+        private final int expectedIterableSize;
+
+        public ParameterizedTests(
+                String testCondition, List<L> leftList, List<R> rightList, int expectedIterableSize) {
+            this.testCondition = testCondition;
+            this.leftList = leftList;
+            this.rightList = rightList;
+            this.expectedIterableSize = expectedIterableSize;
+        }
+
+        @Test
+        public void testAllowsForEach() {
+            ArrayList<PairedItem<L, R>> outputPairedIterable = new ArrayList<>();
+            for (PairedItem<L, R> item : PairedIterable.of(leftList, rightList)) {
+                outputPairedIterable.add(item);
+            }
+
+            assertEquals(expectedIterableSize, outputPairedIterable.size());
+
+            for (int i = 0; i < outputPairedIterable.size(); i++) {
+                PairedItem<L, R> item = outputPairedIterable.get(i);
+                assertEquals(leftList.get(i), item.getLeftItem());
+                assertEquals(rightList.get(i), item.getRightItem());
+            }
+        }
+
+        @Test
+        public void testStream() {
+            PairedIterable<L, R> testIterable = PairedIterable.of(leftList, rightList);
+
+            assertEquals(
+                    leftList.subList(0, expectedIterableSize),
+                    testIterable.stream().map(PairedItem::getLeftItem).collect(toList()));
+            assertEquals(
+                    rightList.subList(0, expectedIterableSize),
+                    testIterable.stream().map(PairedItem::getRightItem).collect(toList()));
+        }
+
+        @Parameters(name = "{0}")
+        public static Object[][] testingParameters() {
+            return new Object[][] {
+                    new Object[] {
+                            "left iterable (int) larger than right iterable (string)",
+                            LARGE_INTS_LIST,
+                            SMALL_STRINGS_LIST,
+                            SMALL_LIST_SIZE
+                    },
+                    new Object[] {
+                            "left iterable (string) larger than right iterable (int)",
+                            LARGE_STRINGS_LIST,
+                            SMALL_INTS_LIST,
+                            SMALL_LIST_SIZE
+                    },
+                    new Object[] {
+                            "equal sized left and right (int, string)",
+                            LARGE_INTS_LIST,
+                            LARGE_STRINGS_LIST,
+                            LARGE_LIST_SIZE
+                    },
+                    new Object[] {
+                            "equal sized left and right (string, int)",
+                            SMALL_STRINGS_LIST,
+                            SMALL_INTS_LIST,
+                            SMALL_LIST_SIZE
+                    },
+                    new Object[] {
+                            "Left empty, right small list", Collections.<Integer>emptyList(), LARGE_STRINGS_LIST, 0
+                    },
+                    new Object[] {
+                            "Right empty, left small list", LARGE_STRINGS_LIST, Collections.<Integer>emptyList(), 0
+                    },
+                    new Object[] {
+                            "Right and left both empty lists", Collections.emptyList(), Collections.emptyList(), 0
+                    },
+            };
+        }
+    }
+
+    @RunWith(JUnit4.class)
+    public static final class ErrorTest {
+
+        @Test
+        public void leftIterableNullThrowsException() {
+            assertThrows(NullPointerException.class, () -> PairedIterable.of(null, SMALL_INTS_LIST));
+        }
+
+        @Test
+        public void rightIterableNullThrowsException() {
+            assertThrows(NullPointerException.class, () -> PairedIterable.of(SMALL_INTS_LIST, null));
+        }
+    }
+
+    private static List<String> stringsList(int size) {
+        return IntStream.range(0, size)
+                .boxed()
+                .map(x -> UUID.randomUUID().toString())
+                .collect(toList());
+    }
+
+    private static List<Integer> intsList(int size) {
+        Random rnd = new Random();
+        return IntStream.range(0, size).boxed().map(x -> rnd.nextInt()).collect(toList());
+    }
+}

--- a/src/test/java/org/apache/commons/collections4/iterators/PairedIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/PairedIteratorTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4.iterators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.commons.collections4.IteratorUtils;
+import org.apache.commons.collections4.iterators.PairedIterator.PairedItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.Random;
+import java.util.UUID;
+
+
+/** Unit test suite for {@link PairedIterator}. */
+public final class PairedIteratorTest
+        extends AbstractIteratorTest<PairedItem<String, Integer>> {
+
+    public PairedIteratorTest() { super(ObjectArrayIteratorTest.class.getSimpleName()); }
+
+    private ArrayList<String> smallStringsList;
+    private ArrayList<String> largeStringsList;
+    private ArrayList<Integer> smallIntsList;
+    private ArrayList<Integer> largeIntsList;
+
+    private static final int SMALL_LIST_SIZE = 20;
+    private static final int LARGE_LIST_SIZE = 40;
+
+
+    @BeforeEach
+    public void setUp() throws Exception {
+
+        smallStringsList = new ArrayList<>();
+        largeStringsList = new ArrayList<>();
+        smallIntsList = new ArrayList<>();
+        largeIntsList = new ArrayList<>();
+
+        Random random = new Random();
+
+        for (int i = 0; i < SMALL_LIST_SIZE; i++) {
+            smallIntsList.add(random.nextInt());
+            smallStringsList.add(UUID.randomUUID().toString());
+        }
+
+        for (int i = 0; i < LARGE_LIST_SIZE; i++) {
+            largeIntsList.add(random.nextInt());
+            largeStringsList.add(UUID.randomUUID().toString());
+        }
+    }
+
+    @Override
+    public boolean supportsRemove() {
+        return false;
+    }
+
+    @Override
+    public Iterator<PairedItem<String, Integer>> makeEmptyIterator() {
+        return PairedIterator.of(IteratorUtils.emptyIterator(), IteratorUtils.emptyIterator());
+    }
+
+    @Override
+    public Iterator<PairedItem<String, Integer>> makeObject() {
+        return PairedIterator.of(smallStringsList.iterator(), smallIntsList.iterator());
+    }
+
+    @Test
+    public void testLeftIteratorLargerThanRight() {
+        Iterator<PairedItem<String, Integer>> zipPairIterator =
+                PairedIterator.ofIterables(largeStringsList, smallIntsList);
+
+
+        for (int i = 0; i < SMALL_LIST_SIZE; i++) {
+            assertTrue(zipPairIterator.hasNext());
+            PairedItem<String, Integer> zippedItem = zipPairIterator.next();
+
+            assertEquals(largeStringsList.get(i), zippedItem.getLeftItem());
+            assertEquals(smallIntsList.get(i), zippedItem.getRightItem());
+        }
+
+        assertFalse(zipPairIterator.hasNext());
+    }
+
+    @Test
+    public void testRightIteratorLargerThanLeft() {
+        Iterator<PairedItem<String, Integer>> zipPairIterator =
+                PairedIterator.ofIterables(smallStringsList, largeIntsList);
+
+
+        for (int i = 0; i < SMALL_LIST_SIZE; i++) {
+            assertTrue(zipPairIterator.hasNext());
+            PairedItem<String, Integer> zippedItem = zipPairIterator.next();
+
+            assertEquals(smallStringsList.get(i), zippedItem.getLeftItem());
+            assertEquals(largeIntsList.get(i), zippedItem.getRightItem());
+        }
+
+        assertFalse(zipPairIterator.hasNext());
+    }
+
+    @Test
+    public void testEmptyLeftIterator() {
+        Iterator<PairedItem<String, Integer>> zipPairIterator =
+                PairedIterator.of(IteratorUtils.emptyIterator(), largeIntsList.iterator());
+
+        assertFalse(zipPairIterator.hasNext());
+    }
+
+    @Test
+    public void testEmptyRightIterator() {
+        Iterator<PairedItem<String, Integer>> zipPairIterator =
+                PairedIterator.of(largeStringsList.iterator(), IteratorUtils.emptyIterator());
+
+        assertFalse(zipPairIterator.hasNext());
+    }
+
+    @Test
+    public void testValidTupleString() {
+        Iterator<PairedItem<String, Integer>> zipPairIterator =
+                PairedIterator.ofIterables(smallStringsList, largeIntsList);
+
+
+        for (int i = 0; i < SMALL_LIST_SIZE; i++) {
+            assertTrue(zipPairIterator.hasNext());
+            PairedItem<String, Integer> zippedItem = zipPairIterator.next();
+
+            assertEquals(
+                    String.format("{%s, %s}", zippedItem.getLeftItem(), zippedItem.getRightItem()),
+                    zippedItem.toString());
+        }
+
+        assertFalse(zipPairIterator.hasNext());
+    }
+}


### PR DESCRIPTION
[COLLECTIONS-795] Add a new Iterator to allowing zipping over two iterators of different types

This is different from ZippingIterator which only permits sub-iterators of same type.
Created as #238 was overwhelmed with multiple commits due to inactivity for 2+ years.

@garydgregory can you please consider this proposal