### PR TITLE
COLLECTIONS-804- Fix flaky test testCollectionToArray2

### DIFF
--- a/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
@@ -1644,7 +1644,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
 
         @Override
         protected int getIterationBehaviour(){
-             return UNORDERED;
+            return UNORDERED;
         }
 
         @Test

--- a/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
@@ -1644,7 +1644,7 @@ public abstract class AbstractMapTest<K, V> extends AbstractObjectTest {
 
         @Override
         protected int getIterationBehaviour(){
-            return AbstractMapTest.this.getIterationBehaviour();
+             return UNORDERED;
         }
 
         @Test


### PR DESCRIPTION
## **Problem:**
The test testCollectionToArray2 is flaky because the array in use does not maintain the order of the elements. This was caught by the [nondex](https://github.com/TestingResearchIllinois/NonDex) tool created by the researchers of UIUC.
Related issue : https://issues.apache.org/jira/browse/COLLECTIONS-804
Related PR with a similar fix: https://github.com/apache/commons-collections/pull/341
## **Description:**
The flakiness occurs in two places

https://github.com/apache/commons-collections/blob/35e408717379eed0085cdb29e879209dbadc1ead/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java#L1132-L1136

https://github.com/apache/commons-collections/blob/35e408717379eed0085cdb29e879209dbadc1ead/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java#L1156-L1162


The function `getIterationBehaviour()` returns 0 by default mentioning the array is ordered and the constant `UNORDERED` is used for the functions that might be unordered in which a different assertion `assertUnorderedArrayEquals` will be used .
Since the code is part of the abstract class, this code has to remain untouched but the `getIterationBehaviour()`  of the classes implementing this abstract class can be changed.

`getIterationBehaviour()` of the class `TestMapEntrySet` returns 0 which means it assumes the array being ordered for `TestMapEntrySet` which is not true. The order of elements can be changed and will be nondeterministic.

## **Fix:**
In the overriding function, the return value has to be changed from 0 to 1 which mentions it can be unordered and this will only affect the `TestMapEntrySet` and not other classes.

https://github.com/anirudh711/commons-collections/blob/90a80f010822fca17323bfc043f14ebc71c92a78/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java#L1644-L1648

