### PR TITLE
COLLECTIONS-850- Fix Flaky test testMultiValuedMapIterator

### DIFF
--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -836,24 +836,28 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
 
         if (!isHashSetValue() && isAddSupported()) {
             assertTrue(it.hasNext() );
-            assertEquals("one", it.next());
-            assertEquals("one", it.getKey());
-            assertEquals("uno", it.getValue());
-            assertEquals("one", it.next());
-            assertEquals("one", it.getKey());
-            assertEquals("un", it.getValue());
-            assertEquals("two", it.next());
-            assertEquals("two", it.getKey());
-            assertEquals("dos", it.getValue());
-            assertEquals("two", it.next());
-            assertEquals("two", it.getKey());
-            assertEquals("deux", it.getValue());
-            assertEquals("three", it.next());
-            assertEquals("three", it.getKey());
-            assertEquals("tres", it.getValue());
-            assertEquals("three", it.next());
-            assertEquals("three", it.getKey());
-            assertEquals("trois", it.getValue());
+            while (it.hasNext()) {
+                it.next();
+                if ("one".equals(it.getKey())) {
+                    assertEquals("one", it.getKey());
+                    assertEquals("uno", it.getValue());
+                    assertEquals("one", it.next());
+                    assertEquals("one", it.getKey());
+                    assertEquals("un", it.getValue());
+                } else if ("two".equals(it.getKey())) {
+                    assertEquals("two", it.getKey());
+                    assertEquals("dos", it.getValue());
+                    assertEquals("two", it.next());
+                    assertEquals("two", it.getKey());
+                    assertEquals("deux", it.getValue());
+                } else if ("three".equals(it.getKey())) {
+                    assertEquals("three", it.getKey());
+                    assertEquals("tres", it.getValue());
+                    assertEquals("three", it.next());
+                    assertEquals("three", it.getKey());
+                    assertEquals("trois", it.getValue());
+                }
+            }
             assertThrows(UnsupportedOperationException.class, () -> it.setValue((V) "threetrois"));
         }
     }


### PR DESCRIPTION
## PR Overview

This PR propses a fix for the following tests: 
- `org.apache.commons.collections4.multimap.ArrayListValuedHashMapTest.testMultiValuedMapIterator`

- `org.apache.commons.collections4.multimap.TransformedMultiValuedMapTest.testMultiValuedMapIterator`

JIRA Issue Link: https://issues.apache.org/jira/browse/COLLECTIONS-850

## Test Overview
The test `testMultiValuedMapIterator` tests how the iteration of a multi-value map works. A MultiValuedMap is basically a map with a key value that can associate itself with either a single value or multiple values (Collections).  Here the MultiValueMap has a key that associates to an array of values.

You can reproduce the issue by running the following commands -
```
mvn install -pl . -am -DskipTests
mvn  -Dtest=org.apache.commons.collections4.multimap.ArrayListValuedHashMapTest#testMultiValuedMapIterator
mvn  edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.commons.collections4.multimap.ArrayListValuedHashMapTest#testMultiValuedMapIterator
```

## Problem
In this test, a multivalued map is defined and an iterator is defined on top of that. The test is flaky since the order inside the multivalued map is not maintained. 
Since the order is not maintained, the iterator can have any one key of the three keys for this test ( one, two, three) in random fashion. This flakiness was identified by the [nondex tool](https://github.com/TestingResearchIllinois/NonDex) created by the researchers of UIUC.
The following code snippet fails because of the above reason
https://github.com/apache/commons-collections/blob/35e408717379eed0085cdb29e879209dbadc1ead/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java#L837-L857

## Fix 
To maintain order, we can implement a TreeMap or a LinkedHashMap but that will change the base code and affect all other entities related to this.
This PR proposes a fix inside the test while keeping the test logic intact.  Since the order is not maintained, we check for the iterator's next value to either be one of the keys and if it is, we check the original assert statements. We follow the same approach to assert all the cases.

https://github.com/apache/commons-collections/blob/02f85e2c9f6cba3a9c76ab30e51bd9d64070977d/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java#L837-L860

This PR provides a fix on the abstract class which fixes the classes that implement it, hence fixing the tests with classes implementing the abstract class