### PR TITLE
Fix incorrect Javadoc description

### DIFF
--- a/src/main/java/org/apache/commons/collections4/multimap/AbstractSetValuedMap.java
+++ b/src/main/java/org/apache/commons/collections4/multimap/AbstractSetValuedMap.java
@@ -62,7 +62,7 @@ public abstract class AbstractSetValuedMap<K, V> extends AbstractMultiValuedMap<
 
     /**
      * Creates a new value collection using the provided factory.
-     * @return a new list
+     * @return a new set
      */
     @Override
     protected abstract Set<V> createCollection();


### PR DESCRIPTION
This PR fixes an incorrect Javadoc description in [AbstractSetValuedMap](../blob/81dfadf/src/main/java/org/apache/commons/collections4/multimap/AbstractListValuedMap.java).