### PR TITLE
[COLLECTIONS-852] Add layerd bloom filter clean method

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bloomfilter/LayerManager.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/LayerManager.java
@@ -380,4 +380,15 @@ public class LayerManager implements BloomFilterProducer {
         this.filterCleanup.accept(filters);
         addFilter();
     }
+
+    /**
+     * Forces execution the filterCleanup without creating a new filter except in cases
+     * where the cleanup removes all the layers.
+     */
+    void clean() {
+        this.filterCleanup.accept(filters);
+        if (filters.isEmpty()) {
+            addFilter();
+        }
+    }
 }

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/LayerManager.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/LayerManager.java
@@ -82,7 +82,7 @@ public class LayerManager implements BloomFilterProducer {
          *
          * @param cleanup the Consumer that will modify the list of filters removing out
          *                dated or stale filters.
-         * @return this for chaining.
+         * @return this
          */
         public Builder setCleanup(Consumer<LinkedList<BloomFilter>> cleanup) {
             this.cleanup = cleanup;
@@ -375,6 +375,8 @@ public class LayerManager implements BloomFilterProducer {
      * Ths method is used within {@link #getTarget()} when the configured
      * {@code ExtendCheck} returns {@code true}.
      * </p>
+     * @see LayerManager.Builder#setExtendCheck(Predicate)
+     * @see LayerManager.Builder#setCleanup(Consumer)
      */
     void next() {
         this.filterCleanup.accept(filters);
@@ -382,10 +384,11 @@ public class LayerManager implements BloomFilterProducer {
     }
 
     /**
-     * Forces execution the filterCleanup without creating a new filter except in cases
+     * Forces execution the configured cleanup without creating a new filter except in cases
      * where the cleanup removes all the layers.
+     * @see LayerManager.Builder#setCleanup(Consumer)
      */
-    void clean() {
+    void cleanup() {
         this.filterCleanup.accept(filters);
         if (filters.isEmpty()) {
             addFilter();

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilter.java
@@ -372,9 +372,18 @@ public class LayeredBloomFilter implements BloomFilter, BloomFilterProducer {
      * Forces and advance to the next layer. Executes the same logic as when
      * LayerManager.extendCheck returns {@code true}
      *
-     * @see LayerManager
+     * @see LayerManager#next()
      */
     public void next() {
         layerManager.next();
+    }
+
+    /**
+     * Forces the execution of {@code LayerManager.clean()}.
+     * 
+     * @see LayerManager#clear()
+     */
+    public void clean() {
+        layerManager.clean();
     }
 }

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilter.java
@@ -369,21 +369,24 @@ public class LayeredBloomFilter implements BloomFilter, BloomFilterProducer {
     }
 
     /**
-     * Forces and advance to the next layer. Executes the same logic as when
-     * LayerManager.extendCheck returns {@code true}
+     * Forces and advance to the next layer. This method will clean-up the current
+     * layers and generate a new filter layer. In most cases is it unnecessary to
+     * call this method directly.
      *
-     * @see LayerManager#next()
+     * @see LayerManager.Builder#setCleanup(java.util.function.Consumer)
+     * @see LayerManager.Builder#setExtendCheck(Predicate)
      */
     public void next() {
         layerManager.next();
     }
 
     /**
-     * Forces the execution of {@code LayerManager.clean()}.
+     * Forces the execution of the cleanup Consumer that was provided when the associated LayerManager
+     * was built.
      *
-     * @see LayerManager#clear()
+     * @see LayerManager.Builder#setCleanup(java.util.function.Consumer)
      */
-    public void clean() {
-        layerManager.clean();
+    public void cleanup() {
+        layerManager.cleanup();
     }
 }

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilter.java
@@ -380,7 +380,7 @@ public class LayeredBloomFilter implements BloomFilter, BloomFilterProducer {
 
     /**
      * Forces the execution of {@code LayerManager.clean()}.
-     * 
+     *
      * @see LayerManager#clear()
      */
     public void clean() {

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
@@ -199,7 +199,7 @@ public class LayerManagerTest {
         LayerManager underTest = LayerManager.builder()
                 .setSupplier(() -> new NumberedBloomFilter(shape, 3, sequence[0]++))
                 .setExtendCheck(ExtendCheck.neverAdvance())
-                .setCleanup(ll -> ll.removeIf( f -> (((NumberedBloomFilter)f).value-- == 0))).build();
+                .setCleanup(ll -> ll.removeIf( f -> (((NumberedBloomFilter) f).value-- == 0))).build();
         assertEquals(1, underTest.getDepth());
         underTest.getTarget().merge(TestingHashers.randomHasher());
         underTest.clean(); // first count == 2
@@ -208,19 +208,19 @@ public class LayerManagerTest {
         assertEquals(2, underTest.getDepth());
         underTest.getTarget().merge(TestingHashers.randomHasher());
         underTest.clean(); // first count == 0
-        NumberedBloomFilter f = (NumberedBloomFilter)underTest.get(0);
+        NumberedBloomFilter f = (NumberedBloomFilter) underTest.get(0);
         assertEquals(1, f.sequence);
-        
+
         assertEquals(2, underTest.getDepth());
         underTest.clean(); // should be removed ; second is now 1st with value 1
         assertEquals(1, underTest.getDepth());
-        f = (NumberedBloomFilter)underTest.get(0);
+        f = (NumberedBloomFilter) underTest.get(0);
         assertEquals(2, f.sequence);
-        
+
         underTest.clean(); // first count == 0
         underTest.clean(); // should be removed.  But there is always at least one
         assertEquals(1, underTest.getDepth());
-        f = (NumberedBloomFilter)underTest.get(0);
+        f = (NumberedBloomFilter) underTest.get(0);
         assertEquals(3, f.sequence);  // it is a new one.
     }
 
@@ -323,7 +323,7 @@ public class LayerManagerTest {
         assertEquals(2, supplierCount[0]);
     }
 
-    class NumberedBloomFilter extends WrappedBloomFilter {
+    static class NumberedBloomFilter extends WrappedBloomFilter {
         int value;
         int sequence;
         NumberedBloomFilter(Shape shape, int value, int sequence) {
@@ -331,6 +331,5 @@ public class LayerManagerTest {
             this.value = value;
             this.sequence = sequence;
         }
-        
     }
 }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
@@ -33,7 +33,6 @@ import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-import org.apache.commons.collections4.bloomfilter.LayerManager.ExtendCheck;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -191,37 +190,6 @@ public class LayerManagerTest {
         assertEquals(1, underTest.getDepth());
         underTest.next();
         assertEquals(2, underTest.getDepth());
-    }
-
-    @Test
-    public void testClean() {
-        int[] sequence = {1};
-        LayerManager underTest = LayerManager.builder()
-                .setSupplier(() -> new NumberedBloomFilter(shape, 3, sequence[0]++))
-                .setExtendCheck(ExtendCheck.neverAdvance())
-                .setCleanup(ll -> ll.removeIf( f -> (((NumberedBloomFilter) f).value-- == 0))).build();
-        assertEquals(1, underTest.getDepth());
-        underTest.getTarget().merge(TestingHashers.randomHasher());
-        underTest.clean(); // first count == 2
-        assertEquals(1, underTest.getDepth());
-        underTest.next(); // first count == 1
-        assertEquals(2, underTest.getDepth());
-        underTest.getTarget().merge(TestingHashers.randomHasher());
-        underTest.clean(); // first count == 0
-        NumberedBloomFilter f = (NumberedBloomFilter) underTest.get(0);
-        assertEquals(1, f.sequence);
-
-        assertEquals(2, underTest.getDepth());
-        underTest.clean(); // should be removed ; second is now 1st with value 1
-        assertEquals(1, underTest.getDepth());
-        f = (NumberedBloomFilter) underTest.get(0);
-        assertEquals(2, f.sequence);
-
-        underTest.clean(); // first count == 0
-        underTest.clean(); // should be removed.  But there is always at least one
-        assertEquals(1, underTest.getDepth());
-        f = (NumberedBloomFilter) underTest.get(0);
-        assertEquals(3, f.sequence);  // it is a new one.
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
@@ -33,6 +33,7 @@ import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
+import org.apache.commons.collections4.bloomfilter.LayerManager.ExtendCheck;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -193,6 +194,37 @@ public class LayerManagerTest {
     }
 
     @Test
+    public void testClean() {
+        int[] sequence = {1};
+        LayerManager underTest = LayerManager.builder()
+                .setSupplier(() -> new NumberedBloomFilter(shape, 3, sequence[0]++))
+                .setExtendCheck(ExtendCheck.neverAdvance())
+                .setCleanup(ll -> ll.removeIf( f -> (((NumberedBloomFilter)f).value-- == 0))).build();
+        assertEquals(1, underTest.getDepth());
+        underTest.getTarget().merge(TestingHashers.randomHasher());
+        underTest.clean(); // first count == 2
+        assertEquals(1, underTest.getDepth());
+        underTest.next(); // first count == 1
+        assertEquals(2, underTest.getDepth());
+        underTest.getTarget().merge(TestingHashers.randomHasher());
+        underTest.clean(); // first count == 0
+        NumberedBloomFilter f = (NumberedBloomFilter)underTest.get(0);
+        assertEquals(1, f.sequence);
+        
+        assertEquals(2, underTest.getDepth());
+        underTest.clean(); // should be removed ; second is now 1st with value 1
+        assertEquals(1, underTest.getDepth());
+        f = (NumberedBloomFilter)underTest.get(0);
+        assertEquals(2, f.sequence);
+        
+        underTest.clean(); // first count == 0
+        underTest.clean(); // should be removed.  But there is always at least one
+        assertEquals(1, underTest.getDepth());
+        f = (NumberedBloomFilter)underTest.get(0);
+        assertEquals(3, f.sequence);  // it is a new one.
+    }
+
+    @Test
     public void testNoCleanup() {
         Consumer<LinkedList<BloomFilter>> underTest = LayerManager.Cleanup.noCleanup();
         LinkedList<BloomFilter> list = new LinkedList<>();
@@ -291,4 +323,14 @@ public class LayerManagerTest {
         assertEquals(2, supplierCount[0]);
     }
 
+    class NumberedBloomFilter extends WrappedBloomFilter {
+        int value;
+        int sequence;
+        NumberedBloomFilter(Shape shape, int value, int sequence) {
+            super(new SimpleBloomFilter(shape));
+            this.value = value;
+            this.sequence = sequence;
+        }
+        
+    }
 }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilterTest.java
@@ -315,7 +315,7 @@ public class LayeredBloomFilterTest extends AbstractBloomFilterTest<LayeredBloom
     }
 
     @Test
-    public void testClean() {
+    public void testCleanup() {
         int[] sequence = {1};
         LayerManager layerManager = LayerManager.builder()
                 .setSupplier(() -> new NumberedBloomFilter(getTestShape(), 3, sequence[0]++))
@@ -324,23 +324,23 @@ public class LayeredBloomFilterTest extends AbstractBloomFilterTest<LayeredBloom
         LayeredBloomFilter underTest = new LayeredBloomFilter(getTestShape(), layerManager );
         assertEquals(1, underTest.getDepth());
         underTest.merge(TestingHashers.randomHasher());
-        underTest.clean(); // first count == 2
+        underTest.cleanup(); // first count == 2
         assertEquals(1, underTest.getDepth());
         underTest.next(); // first count == 1
         assertEquals(2, underTest.getDepth());
         underTest.merge(TestingHashers.randomHasher());
-        underTest.clean(); // first count == 0
+        underTest.cleanup(); // first count == 0
         NumberedBloomFilter f = (NumberedBloomFilter) underTest.get(0);
         assertEquals(1, f.sequence);
 
         assertEquals(2, underTest.getDepth());
-        underTest.clean(); // should be removed ; second is now 1st with value 1
+        underTest.cleanup(); // should be removed ; second is now 1st with value 1
         assertEquals(1, underTest.getDepth());
         f = (NumberedBloomFilter) underTest.get(0);
         assertEquals(2, f.sequence);
 
-        underTest.clean(); // first count == 0
-        underTest.clean(); // should be removed.  But there is always at least one
+        underTest.cleanup(); // first count == 0
+        underTest.cleanup(); // should be removed.  But there is always at least one
         assertEquals(1, underTest.getDepth());
         f = (NumberedBloomFilter) underTest.get(0);
         assertEquals(3, f.sequence);  // it is a new one.


### PR DESCRIPTION
Provides a method to call the LayerManager cleanup consumer without adding additional layers to the LayeredBloomFilter.

fix for [COLLECTIONS-852](https://issues.apache.org/jira/browse/COLLECTIONS-852)
