### PR TITLE
COLLECTIONS-853: Change LayerManager to use List and added generics to LayerdedBloomFilter

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bloomfilter/BloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/BloomFilter.java
@@ -120,7 +120,7 @@ public interface BloomFilter extends IndexProducer, BitMapProducer {
      * Creates a new instance of the BloomFilter with the same properties as the current one.
      * @return a copy of this BloomFilter
      */
-    BloomFilter copy();
+    <T extends BloomFilter> T copy();
 
     // update operations
 

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/LayerManager.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/LayerManager.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.bloomfilter;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/LayerManager.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/LayerManager.java
@@ -16,9 +16,7 @@
  */
 package org.apache.commons.collections4.bloomfilter;
 
-import java.util.LinkedList;
-import java.util.NoSuchElementException;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -50,15 +48,15 @@ import java.util.function.Supplier;
  *
  * @since 4.5
  */
-public class LayerManager implements BloomFilterProducer {
+public class LayerManager<T extends BloomFilter> implements BloomFilterProducer {
 
     /**
      * Builder to create Layer Manager
      */
-    public static class Builder {
-        private Predicate<LayerManager> extendCheck;
-        private Supplier<BloomFilter> supplier;
-        private Consumer<LinkedList<BloomFilter>> cleanup;
+    public static class Builder<T extends BloomFilter> {
+        private Predicate<LayerManager<T>> extendCheck;
+        private Supplier<T> supplier;
+        private Consumer<List<? extends BloomFilter>> cleanup;
 
         private Builder() {
             extendCheck = ExtendCheck.neverAdvance();
@@ -70,11 +68,11 @@ public class LayerManager implements BloomFilterProducer {
          *
          * @return a new LayerManager.
          */
-        public LayerManager build() {
+        public LayerManager<T> build() {
             Objects.requireNonNull(supplier, "Supplier must not be null");
             Objects.requireNonNull(extendCheck, "ExtendCheck must not be null");
             Objects.requireNonNull(cleanup, "Cleanup must not be null");
-            return new LayerManager(supplier, extendCheck, cleanup, true);
+            return new LayerManager<>(supplier, extendCheck, cleanup, true);
         }
 
         /**
@@ -84,7 +82,7 @@ public class LayerManager implements BloomFilterProducer {
          *                dated or stale filters.
          * @return this
          */
-        public Builder setCleanup(Consumer<LinkedList<BloomFilter>> cleanup) {
+        public Builder<T> setCleanup(Consumer<List<? extends BloomFilter>> cleanup) {
             this.cleanup = cleanup;
             return this;
         }
@@ -97,7 +95,7 @@ public class LayerManager implements BloomFilterProducer {
          *                    created.
          * @return this for chaining.
          */
-        public Builder setExtendCheck(Predicate<LayerManager> extendCheck) {
+        public Builder<T> setExtendCheck(Predicate<LayerManager<T>> extendCheck) {
             this.extendCheck = extendCheck;
             return this;
         }
@@ -109,14 +107,14 @@ public class LayerManager implements BloomFilterProducer {
          * @param supplier The supplier of new Bloom filter instances.
          * @return this for chaining.
          */
-        public Builder setSupplier(Supplier<BloomFilter> supplier) {
+        public Builder<T> setSupplier(Supplier<T> supplier) {
             this.supplier = supplier;
             return this;
         }
     }
 
     /**
-     * Static methods to create a Consumer of a LinkedList of BloomFilter perform
+     * Static methods to create a Consumer of a List of BloomFilter perform
      * tests on whether to reduce the collection of Bloom filters.
      */
     public static final class Cleanup {
@@ -124,7 +122,7 @@ public class LayerManager implements BloomFilterProducer {
          * A Cleanup that never removes anything.
          * @return A Consumer suitable for the LayerManager {@code cleanup} parameter.
          */
-        public static Consumer<LinkedList<BloomFilter>> noCleanup() {
+        public static Consumer<List<? extends BloomFilter>> noCleanup() {
             return x -> {};
         }
 
@@ -137,13 +135,13 @@ public class LayerManager implements BloomFilterProducer {
          * @return A Consumer suitable for the LayerManager {@code cleanup} parameter.
          * @throws IllegalArgumentException if {@code maxSize <= 0}.
          */
-        public static Consumer<LinkedList<BloomFilter>> onMaxSize(int maxSize) {
+        public static <T extends BloomFilter> Consumer<List<? extends BloomFilter>> onMaxSize(int maxSize) {
             if (maxSize <= 0) {
                 throw new IllegalArgumentException("'maxSize' must be greater than 0");
             }
             return ll -> {
                 while (ll.size() > maxSize) {
-                    ll.removeFirst();
+                    ll.remove(0);
                 }
             };
         }
@@ -154,10 +152,10 @@ public class LayerManager implements BloomFilterProducer {
          *
          * @return A Consumer suitable for the LayerManager {@code cleanup} parameter.
          */
-        public static Consumer<LinkedList<BloomFilter>> removeEmptyTarget() {
+        public static <T extends BloomFilter> Consumer<List<? extends BloomFilter>> removeEmptyTarget() {
             return x -> {
-                if (x.getLast().cardinality() == 0) {
-                    x.removeLast();
+                if (!x.isEmpty() && x.get(x.size()-1).isEmpty()) {
+                    x.remove(x.size()-1);
                 }
             };
         }
@@ -179,15 +177,15 @@ public class LayerManager implements BloomFilterProducer {
          * @return A Predicate suitable for the LayerManager {@code extendCheck} parameter.
          * @throws IllegalArgumentException if {@code breakAt <= 0}
          */
-        public static Predicate<LayerManager> advanceOnCount(int breakAt) {
+        public static <T extends BloomFilter> Predicate<LayerManager<T>> advanceOnCount(int breakAt) {
             if (breakAt <= 0) {
                 throw new IllegalArgumentException("'breakAt' must be greater than 0");
             }
-            return new Predicate<LayerManager>() {
+            return new Predicate<LayerManager<T>>() {
                 int count;
 
                 @Override
-                public boolean test(LayerManager filter) {
+                public boolean test(LayerManager<T> filter) {
                     return ++count % breakAt == 0;
                 }
             };
@@ -197,8 +195,11 @@ public class LayerManager implements BloomFilterProducer {
          * Advances the target once a merge has been performed.
          * @return A Predicate suitable for the LayerManager {@code extendCheck} parameter.
          */
-        public static Predicate<LayerManager> advanceOnPopulated() {
-            return lm -> !lm.filters.peekLast().isEmpty();
+        public static <T extends BloomFilter> Predicate<LayerManager<T>> advanceOnPopulated() {
+            return lm -> {
+                T t = lm.last();
+                return t != null && !t.isEmpty();
+            };
         }
 
         /**
@@ -212,13 +213,13 @@ public class LayerManager implements BloomFilterProducer {
          * @return A Predicate suitable for the LayerManager {@code extendCheck} parameter.
          * @throws IllegalArgumentException if {@code maxN <= 0}
          */
-        public static Predicate<LayerManager> advanceOnSaturation(double maxN) {
+        public static <T extends BloomFilter> Predicate<LayerManager<T>> advanceOnSaturation(double maxN) {
             if (maxN <= 0) {
                 throw new IllegalArgumentException("'maxN' must be greater than 0");
             }
             return manager -> {
-                BloomFilter bf = manager.filters.peekLast();
-                return maxN <= bf.getShape().estimateN(bf.cardinality());
+                BloomFilter bf = manager.last();
+                return bf != null && maxN <= bf.getShape().estimateN(bf.cardinality());
             };
         }
 
@@ -227,7 +228,7 @@ public class LayerManager implements BloomFilterProducer {
          * perform the advance.
          * @return A Predicate suitable for the LayerManager {@code extendCheck} parameter.
          */
-        public static Predicate<LayerManager> neverAdvance() {
+        public static <T extends BloomFilter> Predicate<LayerManager<T>> neverAdvance() {
             return x -> false;
         }
 
@@ -242,15 +243,15 @@ public class LayerManager implements BloomFilterProducer {
      * @see ExtendCheck#neverAdvance()
      * @see Cleanup#noCleanup()
      */
-    public static Builder builder() {
-        return new Builder();
+    public static <T extends BloomFilter> Builder<T> builder() {
+        return new Builder<>();
     }
-    private final LinkedList<BloomFilter> filters = new LinkedList<>();
-    private final Consumer<LinkedList<BloomFilter>> filterCleanup;
+    private final List<T> filters = new ArrayList<>();
+    private final Consumer<List<? extends BloomFilter>> filterCleanup;
 
-    private final Predicate<LayerManager> extendCheck;
+    private final Predicate<LayerManager<T>> extendCheck;
 
-    private final Supplier<BloomFilter> filterSupplier;
+    private final Supplier<T> filterSupplier;
 
     /**
      * Constructor.
@@ -263,8 +264,8 @@ public class LayerManager implements BloomFilterProducer {
      *                       list.
      * @param initialize     true if the filter list should be initialized.
      */
-    private LayerManager(Supplier<BloomFilter> filterSupplier, Predicate<LayerManager> extendCheck,
-            Consumer<LinkedList<BloomFilter>> filterCleanup, boolean initialize) {
+    private LayerManager(Supplier<T> filterSupplier, Predicate<LayerManager<T>> extendCheck,
+            Consumer<List<? extends BloomFilter>> filterCleanup, boolean initialize) {
         this.filterSupplier = filterSupplier;
         this.extendCheck = extendCheck;
         this.filterCleanup = filterCleanup;
@@ -277,7 +278,7 @@ public class LayerManager implements BloomFilterProducer {
      * Adds a new Bloom filter to the list.
      */
     private void addFilter() {
-        BloomFilter bf = filterSupplier.get();
+        T bf = filterSupplier.get();
         if (bf == null) {
             throw new NullPointerException("filterSupplier returned null.");
         }
@@ -302,10 +303,10 @@ public class LayerManager implements BloomFilterProducer {
      *
      * @return a copy of this layer Manager.
      */
-    public LayerManager copy() {
-        LayerManager newMgr = new LayerManager(filterSupplier, extendCheck, filterCleanup, false);
-        for (BloomFilter bf : filters) {
-            newMgr.filters.add(bf.copy());
+    public LayerManager<T> copy() {
+        LayerManager<T> newMgr = new LayerManager<>(filterSupplier, extendCheck, filterCleanup, false);
+        for (T bf : filters) {
+            newMgr.filters.add((T) bf.copy());
         }
         return newMgr;
     }
@@ -337,7 +338,7 @@ public class LayerManager implements BloomFilterProducer {
      * @throws NoSuchElementException if depth is not in the range
      *                                [0,filters.size())
      */
-    public final BloomFilter get(int depth) {
+    public final T get(int depth) {
         if (depth < 0 || depth >= filters.size()) {
             throw new NoSuchElementException(String.format("Depth must be in the range [0,%s)", filters.size()));
         }
@@ -355,16 +356,36 @@ public class LayerManager implements BloomFilterProducer {
     }
 
     /**
+     * Gets the Bloom filter from the first layer.
+     * No extension check is performed during this call.
+     * @return The Bloom filter from the first layer. May be {@code null}.
+     * @see #getTarget()
+     */
+    public final T first() {
+        return filters.isEmpty() ? null : filters.get(0);
+    }
+
+    /**
+     * Gets the Bloom filter from the last layer.
+     * No extension check is performed during this call.
+     * @return The Bloom filter from the last layer. May be {@code null}.
+     * @see #getTarget()
+     */
+    public final T last() {
+        return filters.isEmpty() ? null : filters.get(filters.size()-1);
+    }
+
+    /**
      * Returns the current target filter. If a new filter should be created based on
      * {@code extendCheck} it will be created before this method returns.
      *
      * @return the current target filter after any extension.
      */
-    public final BloomFilter getTarget() {
+    public final T getTarget() {
         if (extendCheck.test(this)) {
             next();
         }
-        return filters.peekLast();
+        return last();
     }
 
     /**

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/LayerManager.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/LayerManager.java
@@ -199,10 +199,7 @@ public class LayerManager<T extends BloomFilter> implements BloomFilterProducer 
          * @return A Predicate suitable for the LayerManager {@code extendCheck} parameter.
          */
         public static <T extends BloomFilter> Predicate<LayerManager<T>> advanceOnPopulated() {
-            return lm -> {
-                T t = lm.last();
-                return t != null && !t.isEmpty();
-            };
+            return lm -> !lm.last().isEmpty();
         }
 
         /**
@@ -222,7 +219,7 @@ public class LayerManager<T extends BloomFilter> implements BloomFilterProducer 
             }
             return manager -> {
                 BloomFilter bf = manager.last();
-                return bf != null && maxN <= bf.getShape().estimateN(bf.cardinality());
+                return maxN <= bf.getShape().estimateN(bf.cardinality());
             };
         }
 
@@ -350,7 +347,7 @@ public class LayerManager<T extends BloomFilter> implements BloomFilterProducer 
 
     /**
      * Returns the number of filters in the LayerManager.  In the default LayerManager implementation
-     * there is alwasy at least one layer.
+     * there is always at least one layer.
      *
      * @return the current depth.
      */
@@ -361,21 +358,21 @@ public class LayerManager<T extends BloomFilter> implements BloomFilterProducer 
     /**
      * Gets the Bloom filter from the first layer.
      * No extension check is performed during this call.
-     * @return The Bloom filter from the first layer. May be {@code null}.
+     * @return The Bloom filter from the first layer.
      * @see #getTarget()
      */
     public final T first() {
-        return filters.isEmpty() ? null : filters.get(0);
+        return filters.get(0);
     }
 
     /**
      * Gets the Bloom filter from the last layer.
      * No extension check is performed during this call.
-     * @return The Bloom filter from the last layer. May be {@code null}.
+     * @return The Bloom filter from the last layer.
      * @see #getTarget()
      */
     public final T last() {
-        return filters.isEmpty() ? null : filters.get(filters.size()-1);
+        return filters.get(filters.size()-1);
     }
 
     /**

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/LayerManager.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/LayerManager.java
@@ -199,7 +199,11 @@ public class LayerManager<T extends BloomFilter> implements BloomFilterProducer 
 
                 @Override
                 public boolean test(LayerManager<T> filter) {
-                    return ++count % breakAt == 0;
+                    if (++count == breakAt) {
+                        count = 0;
+                        return true;
+                    }
+                    return false;
                 }
             };
         }

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilter.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 /**
  * Layered Bloom filters are described in Zhiwang, Cen; Jungang, Xu; Jian, Sun
@@ -89,36 +88,6 @@ public class LayeredBloomFilter<T extends BloomFilter> implements BloomFilter, B
             bfIdx++;
             return true;
         }
-    }
-
-    /**
-     * Creates a fixed size layered bloom filter that adds new filters to the list,
-     * but never merges them. List will never exceed maxDepth. As additional filters
-     * are added earlier filters are removed.  Uses SimpleBloomFilters.
-     *
-     * @param shape    The shape for the enclosed Bloom filters.
-     * @param maxDepth The maximum depth of layers.
-     * @return An empty layered Bloom filter of the specified shape and depth.
-     */
-    public static  LayeredBloomFilter<BloomFilter> fixed(final Shape shape, int maxDepth) {
-        return fixed(shape, maxDepth, () -> new SimpleBloomFilter(shape));
-    }
-
-    /**
-     * Creates a fixed size layered bloom filter that adds new filters to the list,
-     * but never merges them. List will never exceed maxDepth. As additional filters
-     * are added earlier filters are removed.
-     *
-     * @param shape    The shape for the enclosed Bloom filters.
-     * @param maxDepth The maximum depth of layers.
-     * @param supplier A supplier of the Bloom filters to create layers with.
-     * @return An empty layered Bloom filter of the specified shape and depth.
-     */
-    public static <T extends BloomFilter> LayeredBloomFilter<T> fixed(final Shape shape, int maxDepth, Supplier<T> supplier) {
-        LayerManager.Builder<T> builder = LayerManager.builder();
-        builder.setExtendCheck(LayerManager.ExtendCheck.advanceOnPopulated())
-                .setCleanup(LayerManager.Cleanup.onMaxSize(maxDepth)).setSupplier(supplier);
-        return new LayeredBloomFilter<>(shape, builder.build());
     }
 
     private final Shape shape;

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilter.java
@@ -59,9 +59,10 @@ import java.util.function.Predicate;
  * removes them. It also checks it a new layer should be added, and if so adds
  * it and sets the {@code target} before the operation.</li>
  * </ul>
+ * @param <T> The type of Bloom Filter that is used for the layers.
  * @since 4.5
  */
-public class LayeredBloomFilter implements BloomFilter, BloomFilterProducer {
+public class LayeredBloomFilter<T extends BloomFilter> implements BloomFilter, BloomFilterProducer {
     /**
      * A class used to locate matching filters across all the layers.
      */
@@ -97,15 +98,15 @@ public class LayeredBloomFilter implements BloomFilter, BloomFilterProducer {
      * @param maxDepth The maximum depth of layers.
      * @return An empty layered Bloom filter of the specified shape and depth.
      */
-    public static LayeredBloomFilter fixed(final Shape shape, int maxDepth) {
-        LayerManager manager = LayerManager.builder().setExtendCheck(LayerManager.ExtendCheck.advanceOnPopulated())
+    public static LayeredBloomFilter<BloomFilter> fixed(final Shape shape, int maxDepth) {
+        LayerManager<BloomFilter> manager =  LayerManager.builder().setExtendCheck(LayerManager.ExtendCheck.advanceOnPopulated())
                 .setCleanup(LayerManager.Cleanup.onMaxSize(maxDepth)).setSupplier(() -> new SimpleBloomFilter(shape)).build();
-        return new LayeredBloomFilter(shape, manager);
+        return new LayeredBloomFilter<BloomFilter>(shape, manager);
     }
 
     private final Shape shape;
 
-    private LayerManager layerManager;
+    private final LayerManager<T> layerManager;
 
     /**
      * Constructor.
@@ -113,7 +114,7 @@ public class LayeredBloomFilter implements BloomFilter, BloomFilterProducer {
      * @param shape        the Shape of the enclosed Bloom filters
      * @param layerManager the LayerManager to manage the layers.
      */
-    public LayeredBloomFilter(Shape shape, LayerManager layerManager) {
+    public LayeredBloomFilter(Shape shape, LayerManager<T> layerManager) {
         this.shape = shape;
         this.layerManager = layerManager;
     }
@@ -184,8 +185,8 @@ public class LayeredBloomFilter implements BloomFilter, BloomFilterProducer {
     }
 
     @Override
-    public LayeredBloomFilter copy() {
-        return new LayeredBloomFilter(shape, layerManager.copy());
+    public LayeredBloomFilter<T> copy() {
+        return new LayeredBloomFilter<>(shape, layerManager.copy());
     }
 
     /**
@@ -329,7 +330,7 @@ public class LayeredBloomFilter implements BloomFilter, BloomFilterProducer {
      * @return the Bloom filter at the specified depth.
      * @throws NoSuchElementException if depth is not in the range [0,getDepth())
      */
-    public BloomFilter get(int depth) {
+    public T get(int depth) {
         return layerManager.get(depth);
     }
 

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilter.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.function.IntPredicate;
 import java.util.function.LongPredicate;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 /**
  * Layered Bloom filters are described in Zhiwang, Cen; Jungang, Xu; Jian, Sun
@@ -89,6 +90,20 @@ public class LayeredBloomFilter<T extends BloomFilter> implements BloomFilter, B
             return true;
         }
     }
+
+    /**
+     * Creates a fixed size layered bloom filter that adds new filters to the list,
+     * but never merges them. List will never exceed maxDepth. As additional filters
+     * are added earlier filters are removed.  Uses SimpleBloomFilters.
+     *
+     * @param shape    The shape for the enclosed Bloom filters.
+     * @param maxDepth The maximum depth of layers.
+     * @return An empty layered Bloom filter of the specified shape and depth.
+     */
+    public static  LayeredBloomFilter<BloomFilter> fixed(final Shape shape, int maxDepth) {
+        return fixed(shape, maxDepth, () -> new SimpleBloomFilter(shape));
+    }
+
     /**
      * Creates a fixed size layered bloom filter that adds new filters to the list,
      * but never merges them. List will never exceed maxDepth. As additional filters
@@ -96,12 +111,14 @@ public class LayeredBloomFilter<T extends BloomFilter> implements BloomFilter, B
      *
      * @param shape    The shape for the enclosed Bloom filters.
      * @param maxDepth The maximum depth of layers.
+     * @param supplier A supplier of the Bloom filters to create layers with.
      * @return An empty layered Bloom filter of the specified shape and depth.
      */
-    public static LayeredBloomFilter<BloomFilter> fixed(final Shape shape, int maxDepth) {
-        LayerManager<BloomFilter> manager =  LayerManager.builder().setExtendCheck(LayerManager.ExtendCheck.advanceOnPopulated())
-                .setCleanup(LayerManager.Cleanup.onMaxSize(maxDepth)).setSupplier(() -> new SimpleBloomFilter(shape)).build();
-        return new LayeredBloomFilter<BloomFilter>(shape, manager);
+    public static <T extends BloomFilter> LayeredBloomFilter<T> fixed(final Shape shape, int maxDepth, Supplier<T> supplier) {
+        LayerManager.Builder<T> builder = LayerManager.builder();
+        builder.setExtendCheck(LayerManager.ExtendCheck.advanceOnPopulated())
+                .setCleanup(LayerManager.Cleanup.onMaxSize(maxDepth)).setSupplier(supplier);
+        return new LayeredBloomFilter<>(shape, builder.build());
     }
 
     private final Shape shape;

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/WrappedBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/WrappedBloomFilter.java
@@ -25,7 +25,7 @@ import java.util.function.LongPredicate;
  * @since 4.5
  */
 public abstract class WrappedBloomFilter implements BloomFilter {
-    protected final BloomFilter wrapped;
+    private final BloomFilter wrapped;
 
     /**
      * Wraps a Bloom filter.  The wrapped filter is maintained as a reference
@@ -34,6 +34,10 @@ public abstract class WrappedBloomFilter implements BloomFilter {
      */
     public WrappedBloomFilter(BloomFilter bf) {
         this.wrapped = bf;
+    }
+
+    protected BloomFilter getWrapped() {
+        return wrapped;
     }
 
     @Override

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/WrappedBloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/WrappedBloomFilter.java
@@ -25,7 +25,7 @@ import java.util.function.LongPredicate;
  * @since 4.5
  */
 public abstract class WrappedBloomFilter implements BloomFilter {
-    final BloomFilter wrapped;
+    protected final BloomFilter wrapped;
 
     /**
      * Wraps a Bloom filter.  The wrapped filter is maintained as a reference
@@ -79,11 +79,6 @@ public abstract class WrappedBloomFilter implements BloomFilter {
     @Override
     public boolean contains(IndexProducer indexProducer) {
         return wrapped.contains(indexProducer);
-    }
-
-    @Override
-    public BloomFilter copy() {
-        return wrapped.copy();
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/BitMapProducerFromLayeredBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/BitMapProducerFromLayeredBloomFilterTest.java
@@ -22,13 +22,13 @@ public class BitMapProducerFromLayeredBloomFilterTest extends AbstractBitMapProd
 
     @Override
     protected BitMapProducer createEmptyProducer() {
-        return LayeredBloomFilter.fixed(shape, 10);
+        return LayeredBloomFilterTest.fixed(shape, 10);
     }
 
     @Override
     protected BitMapProducer createProducer() {
         final Hasher hasher = new IncrementingHasher(0, 1);
-        final BloomFilter bf = LayeredBloomFilter.fixed(shape, 10);
+        final BloomFilter bf = LayeredBloomFilterTest.fixed(shape, 10);
         bf.merge(hasher);
         return bf;
     }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/BitMapProducerFromWrappedBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/BitMapProducerFromWrappedBloomFilterTest.java
@@ -23,6 +23,12 @@ public class BitMapProducerFromWrappedBloomFilterTest extends AbstractBitMapProd
     @Override
     protected BitMapProducer createEmptyProducer() {
         return new WrappedBloomFilter(new DefaultBloomFilterTest.SparseDefaultBloomFilter(shape)) {
+            @Override
+            public BloomFilter copy() {
+                BloomFilter result = new DefaultBloomFilterTest.SparseDefaultBloomFilter(shape);
+                result.merge(wrapped);
+                return result;
+            }
         };
     }
 
@@ -30,6 +36,12 @@ public class BitMapProducerFromWrappedBloomFilterTest extends AbstractBitMapProd
     protected BitMapProducer createProducer() {
         final Hasher hasher = new IncrementingHasher(0, 1);
         final BloomFilter bf = new WrappedBloomFilter(new DefaultBloomFilterTest.SparseDefaultBloomFilter(shape)) {
+            @Override
+            public BloomFilter copy() {
+                BloomFilter result = new DefaultBloomFilterTest.SparseDefaultBloomFilter(shape);
+                result.merge(wrapped);
+                return result;
+            }
         };
         bf.merge(hasher);
         return bf;

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/BitMapProducerFromWrappedBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/BitMapProducerFromWrappedBloomFilterTest.java
@@ -26,7 +26,7 @@ public class BitMapProducerFromWrappedBloomFilterTest extends AbstractBitMapProd
             @Override
             public BloomFilter copy() {
                 BloomFilter result = new DefaultBloomFilterTest.SparseDefaultBloomFilter(shape);
-                result.merge(wrapped);
+                result.merge(getWrapped());
                 return result;
             }
         };
@@ -39,7 +39,7 @@ public class BitMapProducerFromWrappedBloomFilterTest extends AbstractBitMapProd
             @Override
             public BloomFilter copy() {
                 BloomFilter result = new DefaultBloomFilterTest.SparseDefaultBloomFilter(shape);
-                result.merge(wrapped);
+                result.merge(getWrapped());
                 return result;
             }
         };

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/CellProducerFromLayeredBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/CellProducerFromLayeredBloomFilterTest.java
@@ -22,13 +22,13 @@ public class CellProducerFromLayeredBloomFilterTest extends AbstractCellProducer
 
     @Override
     protected CellProducer createEmptyProducer() {
-        return CellProducer.from(LayeredBloomFilter.fixed(shape, 10));
+        return CellProducer.from(LayeredBloomFilterTest.fixed(shape, 10));
     }
 
     @Override
     protected CellProducer createProducer() {
         final Hasher hasher = new IncrementingHasher(3, 2);
-        final BloomFilter bf = LayeredBloomFilter.fixed(shape, 10);
+        final BloomFilter bf = LayeredBloomFilterTest.fixed(shape, 10);
         bf.merge(hasher);
         return CellProducer.from(bf);
     }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
@@ -193,7 +193,7 @@ public class LayerManagerTest {
 
     @Test
     public void testNoCleanup() {
-        Consumer<List<? extends BloomFilter>> underTest = LayerManager.Cleanup.noCleanup();
+        Consumer<List<BloomFilter>> underTest = LayerManager.Cleanup.noCleanup();
         List<BloomFilter> list = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
             assertEquals(i, list.size());
@@ -205,7 +205,7 @@ public class LayerManagerTest {
     @ParameterizedTest
     @ValueSource(ints = {5, 100, 2, 1})
     public void testOnMaxSize(int maxSize) {
-        Consumer<List<? extends BloomFilter>> underTest = LayerManager.Cleanup.onMaxSize(maxSize);
+        Consumer<List<BloomFilter>> underTest = LayerManager.Cleanup.onMaxSize(maxSize);
         List<BloomFilter> list = new ArrayList<>();
         for (int i = 0; i < maxSize; i++) {
             assertEquals(i, list.size());
@@ -229,7 +229,7 @@ public class LayerManagerTest {
 
     @Test
     public void testRemoveEmptyTarget() {
-        Consumer<List<? extends BloomFilter>> underTest = LayerManager.Cleanup.removeEmptyTarget();
+        Consumer<List<BloomFilter>> underTest = LayerManager.Cleanup.removeEmptyTarget();
         List<BloomFilter> list = new ArrayList<>();
 
         // removes an empty filter

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
@@ -289,13 +289,4 @@ public class LayerManagerTest {
         assertEquals(2, supplierCount[0]);
     }
 
-    static class NumberedBloomFilter extends WrappedBloomFilter {
-        int value;
-        int sequence;
-        NumberedBloomFilter(Shape shape, int value, int sequence) {
-            super(new SimpleBloomFilter(shape));
-            this.value = value;
-            this.sequence = sequence;
-        }
-    }
 }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
@@ -27,6 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
@@ -193,8 +195,8 @@ public class LayerManagerTest {
 
     @Test
     public void testNoCleanup() {
-        Consumer<List<BloomFilter>> underTest = LayerManager.Cleanup.noCleanup();
-        List<BloomFilter> list = new ArrayList<>();
+        Consumer<Deque<BloomFilter>> underTest = LayerManager.Cleanup.noCleanup();
+        Deque<BloomFilter> list = new LinkedList<>();
         for (int i = 0; i < 20; i++) {
             assertEquals(i, list.size());
             list.add(new SimpleBloomFilter(shape));
@@ -205,8 +207,8 @@ public class LayerManagerTest {
     @ParameterizedTest
     @ValueSource(ints = {5, 100, 2, 1})
     public void testOnMaxSize(int maxSize) {
-        Consumer<List<BloomFilter>> underTest = LayerManager.Cleanup.onMaxSize(maxSize);
-        List<BloomFilter> list = new ArrayList<>();
+        Consumer<Deque<BloomFilter>> underTest = LayerManager.Cleanup.onMaxSize(maxSize);
+        LinkedList<BloomFilter> list = new LinkedList<>();
         for (int i = 0; i < maxSize; i++) {
             assertEquals(i, list.size());
             list.add(new SimpleBloomFilter(shape));
@@ -229,8 +231,8 @@ public class LayerManagerTest {
 
     @Test
     public void testRemoveEmptyTarget() {
-        Consumer<List<BloomFilter>> underTest = LayerManager.Cleanup.removeEmptyTarget();
-        List<BloomFilter> list = new ArrayList<>();
+        Consumer<Deque<BloomFilter>> underTest = LayerManager.Cleanup.removeEmptyTarget();
+        LinkedList<BloomFilter> list = new LinkedList<>();
 
         // removes an empty filter
         BloomFilter bf = new SimpleBloomFilter(shape);

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayerManagerTest.java
@@ -16,9 +16,9 @@
  */
 package org.apache.commons.collections4.bloomfilter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
@@ -39,13 +38,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 public class LayerManagerTest {
 
-    private Shape shape = Shape.fromKM(17, 72);
+    private final Shape shape = Shape.fromKM(17, 72);
 
     @ParameterizedTest
     @ValueSource(ints = {4, 10, 2, 1})
     public void testAdvanceOnCount(int breakAt) {
-        Predicate<LayerManager> underTest = LayerManager.ExtendCheck.advanceOnCount(breakAt);
-        LayerManager layerManager = testingBuilder().build();
+        Predicate<LayerManager<BloomFilter>> underTest = LayerManager.ExtendCheck.advanceOnCount(breakAt);
+        LayerManager<BloomFilter> layerManager = testingBuilder().build();
         for (int i = 0; i < breakAt - 1; i++) {
             assertFalse(underTest.test(layerManager), "at " + i);
             layerManager.getTarget().merge(TestingHashers.FROM1);
@@ -61,8 +60,8 @@ public class LayerManagerTest {
 
     @Test
     public void testAdvanceOnPopulated() {
-        Predicate<LayerManager> underTest = LayerManager.ExtendCheck.advanceOnPopulated();
-        LayerManager layerManager = testingBuilder().build();
+        Predicate<LayerManager<BloomFilter>> underTest = LayerManager.ExtendCheck.advanceOnPopulated();
+        LayerManager<BloomFilter> layerManager = testingBuilder().build();
         assertFalse(underTest.test(layerManager));
         layerManager.getTarget().merge(TestingHashers.FROM1);
         assertTrue(underTest.test(layerManager));
@@ -70,10 +69,10 @@ public class LayerManagerTest {
 
     @Test
     public void testAdvanceOnSaturation() {
-        Double maxN = shape.estimateMaxN();
+        double maxN = shape.estimateMaxN();
         int hashStart = 0;
-        Predicate<LayerManager> underTest = LayerManager.ExtendCheck.advanceOnSaturation(maxN);
-        LayerManager layerManager = testingBuilder().build();
+        Predicate<LayerManager<BloomFilter>> underTest = LayerManager.ExtendCheck.advanceOnSaturation(maxN);
+        LayerManager<BloomFilter> layerManager = testingBuilder().build();
         while (layerManager.getTarget().getShape().estimateN(layerManager.getTarget().cardinality()) < maxN) {
             assertFalse(underTest.test(layerManager));
             layerManager.getTarget().merge(new IncrementingHasher(hashStart, shape.getNumberOfHashFunctions()));
@@ -86,15 +85,15 @@ public class LayerManagerTest {
 
     @Test
     public void testBuilder() {
-        LayerManager.Builder underTest = LayerManager.builder();
-        NullPointerException npe = assertThrows(NullPointerException.class, () -> underTest.build());
+        LayerManager.Builder<BloomFilter> underTest = LayerManager.builder();
+        NullPointerException npe = assertThrows(NullPointerException.class, underTest::build);
         assertTrue(npe.getMessage().contains("Supplier must not be null"));
         underTest.setSupplier(() -> null).setCleanup(null);
-        npe = assertThrows(NullPointerException.class, () -> underTest.build());
+        npe = assertThrows(NullPointerException.class, underTest::build);
         assertTrue(npe.getMessage().contains("Cleanup must not be null"));
         underTest.setCleanup(x -> {
         }).setExtendCheck(null);
-        npe = assertThrows(NullPointerException.class, () -> underTest.build());
+        npe = assertThrows(NullPointerException.class, underTest::build);
         assertTrue(npe.getMessage().contains("ExtendCheck must not be null"));
 
         npe = assertThrows(NullPointerException.class, () -> LayerManager.builder().setSupplier(() -> null).build());
@@ -104,7 +103,7 @@ public class LayerManagerTest {
 
     @Test
     public void testClear() {
-        LayerManager underTest = LayerManager.builder().setSupplier(() -> new SimpleBloomFilter(shape)).build();
+        LayerManager<BloomFilter> underTest = LayerManager.builder().setSupplier(() -> new SimpleBloomFilter(shape)).build();
         underTest.getTarget().merge(TestingHashers.randomHasher());
         underTest.next();
         underTest.getTarget().merge(TestingHashers.randomHasher());
@@ -118,7 +117,7 @@ public class LayerManagerTest {
 
     @Test
     public void testCopy() {
-        LayerManager underTest = LayerManager.builder().setSupplier(() -> new SimpleBloomFilter(shape)).build();
+        LayerManager<BloomFilter> underTest = LayerManager.builder().setSupplier(() -> new SimpleBloomFilter(shape)).build();
         underTest.getTarget().merge(TestingHashers.randomHasher());
         underTest.next();
         underTest.getTarget().merge(TestingHashers.randomHasher());
@@ -126,7 +125,7 @@ public class LayerManagerTest {
         underTest.getTarget().merge(TestingHashers.randomHasher());
         assertEquals(3, underTest.getDepth());
 
-        LayerManager copy = underTest.copy();
+        LayerManager<BloomFilter> copy = underTest.copy();
         assertNotSame(underTest, copy);
         // object equals not implemented
         assertNotEquals(underTest, copy);
@@ -138,7 +137,7 @@ public class LayerManagerTest {
 
     @Test
     public void testForEachBloomFilter() {
-        LayerManager underTest = LayerManager.builder().setSupplier(() -> new SimpleBloomFilter(shape))
+        LayerManager<BloomFilter> underTest = LayerManager.builder().setSupplier(() -> new SimpleBloomFilter(shape))
                 .setExtendCheck(LayerManager.ExtendCheck.advanceOnPopulated()).build();
 
         List<BloomFilter> lst = new ArrayList<>();
@@ -160,21 +159,21 @@ public class LayerManagerTest {
     @Test
     public void testGet() {
         SimpleBloomFilter f = new SimpleBloomFilter(shape);
-        LayerManager underTest = LayerManager.builder().setSupplier(() -> f).build();
+        LayerManager<BloomFilter> underTest = LayerManager.builder().setSupplier(() -> f).build();
         assertEquals(1, underTest.getDepth());
         assertSame(f, underTest.get(0));
         assertThrows(NoSuchElementException.class, () -> underTest.get(-1));
         assertThrows(NoSuchElementException.class, () -> underTest.get(1));
     }
 
-    private LayerManager.Builder testingBuilder() {
+    private LayerManager.Builder<BloomFilter> testingBuilder() {
         return LayerManager.builder().setSupplier(() -> new SimpleBloomFilter(shape));
     }
 
     @Test
     public void testNeverAdvance() {
-        Predicate<LayerManager> underTest = LayerManager.ExtendCheck.neverAdvance();
-        LayerManager layerManager = testingBuilder().build();
+        Predicate<LayerManager<BloomFilter>> underTest = LayerManager.ExtendCheck.neverAdvance();
+        LayerManager<BloomFilter> layerManager = testingBuilder().build();
         assertFalse(underTest.test(layerManager));
         for (int i = 0; i < 10; i++) {
             layerManager.getTarget().merge(TestingHashers.randomHasher());
@@ -184,7 +183,7 @@ public class LayerManagerTest {
 
     @Test
     public void testNextAndGetDepth() {
-        LayerManager underTest = LayerManager.builder().setSupplier(() -> new SimpleBloomFilter(shape)).build();
+        LayerManager<BloomFilter> underTest = LayerManager.builder().setSupplier(() -> new SimpleBloomFilter(shape)).build();
         assertEquals(1, underTest.getDepth());
         underTest.getTarget().merge(TestingHashers.randomHasher());
         assertEquals(1, underTest.getDepth());
@@ -194,8 +193,8 @@ public class LayerManagerTest {
 
     @Test
     public void testNoCleanup() {
-        Consumer<LinkedList<BloomFilter>> underTest = LayerManager.Cleanup.noCleanup();
-        LinkedList<BloomFilter> list = new LinkedList<>();
+        Consumer<List<? extends BloomFilter>> underTest = LayerManager.Cleanup.noCleanup();
+        List<BloomFilter> list = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
             assertEquals(i, list.size());
             list.add(new SimpleBloomFilter(shape));
@@ -206,8 +205,8 @@ public class LayerManagerTest {
     @ParameterizedTest
     @ValueSource(ints = {5, 100, 2, 1})
     public void testOnMaxSize(int maxSize) {
-        Consumer<LinkedList<BloomFilter>> underTest = LayerManager.Cleanup.onMaxSize(maxSize);
-        LinkedList<BloomFilter> list = new LinkedList<>();
+        Consumer<List<? extends BloomFilter>> underTest = LayerManager.Cleanup.onMaxSize(maxSize);
+        List<BloomFilter> list = new ArrayList<>();
         for (int i = 0; i < maxSize; i++) {
             assertEquals(i, list.size());
             list.add(new SimpleBloomFilter(shape));
@@ -230,8 +229,8 @@ public class LayerManagerTest {
 
     @Test
     public void testRemoveEmptyTarget() {
-        Consumer<LinkedList<BloomFilter>> underTest = LayerManager.Cleanup.removeEmptyTarget();
-        LinkedList<BloomFilter> list = new LinkedList<>();
+        Consumer<List<? extends BloomFilter>> underTest = LayerManager.Cleanup.removeEmptyTarget();
+        List<BloomFilter> list = new ArrayList<>();
 
         // removes an empty filter
         BloomFilter bf = new SimpleBloomFilter(shape);
@@ -265,7 +264,6 @@ public class LayerManagerTest {
         underTest.accept(list);
         assertEquals(2, list.size());
         assertEquals(bf, list.get(0));
-
     }
 
     @Test
@@ -273,7 +271,7 @@ public class LayerManagerTest {
         boolean[] extendCheckCalled = { false };
         boolean[] cleanupCalled = { false };
         int[] supplierCount = { 0 };
-        LayerManager underTest = LayerManager.builder().setSupplier(() -> {
+        LayerManager<BloomFilter> underTest = LayerManager.builder().setSupplier(() -> {
             supplierCount[0]++;
             return new SimpleBloomFilter(shape);
         }).setExtendCheck(lm -> {

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilterTest.java
@@ -27,12 +27,43 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.apache.commons.collections4.bloomfilter.LayerManager.Cleanup;
 import org.apache.commons.collections4.bloomfilter.LayerManager.ExtendCheck;
 import org.junit.jupiter.api.Test;
 
 public class LayeredBloomFilterTest extends AbstractBloomFilterTest<LayeredBloomFilter<?>> {
+
+    /**
+     * Creates a fixed size layered bloom filter that adds new filters to the list,
+     * but never merges them. List will never exceed maxDepth. As additional filters
+     * are added earlier filters are removed.  Uses SimpleBloomFilters.
+     *
+     * @param shape    The shape for the enclosed Bloom filters.
+     * @param maxDepth The maximum depth of layers.
+     * @return An empty layered Bloom filter of the specified shape and depth.
+     */
+    public static  LayeredBloomFilter<BloomFilter> fixed(final Shape shape, int maxDepth) {
+        return fixed(shape, maxDepth, () -> new SimpleBloomFilter(shape));
+    }
+
+    /**
+     * Creates a fixed size layered bloom filter that adds new filters to the list,
+     * but never merges them. List will never exceed maxDepth. As additional filters
+     * are added earlier filters are removed.
+     *
+     * @param shape    The shape for the enclosed Bloom filters.
+     * @param maxDepth The maximum depth of layers.
+     * @param supplier A supplier of the Bloom filters to create layers with.
+     * @return An empty layered Bloom filter of the specified shape and depth.
+     */
+    public static <T extends BloomFilter> LayeredBloomFilter<T> fixed(final Shape shape, int maxDepth, Supplier<T> supplier) {
+        LayerManager.Builder<T> builder = LayerManager.builder();
+        builder.setExtendCheck(LayerManager.ExtendCheck.advanceOnPopulated())
+                .setCleanup(LayerManager.Cleanup.onMaxSize(maxDepth)).setSupplier(supplier);
+        return new LayeredBloomFilter<>(shape, builder.build());
+    }
 
     /**
      * A Predicate that advances after a quantum of time.
@@ -146,7 +177,7 @@ public class LayeredBloomFilterTest extends AbstractBloomFilterTest<LayeredBloom
 
     @Override
     protected LayeredBloomFilter<BloomFilter> createEmptyFilter(Shape shape) {
-        return LayeredBloomFilter.fixed(shape, 10);
+        return LayeredBloomFilterTest.fixed(shape, 10);
     }
 
     protected BloomFilter makeFilter(Hasher h) {
@@ -166,7 +197,7 @@ public class LayeredBloomFilterTest extends AbstractBloomFilterTest<LayeredBloom
     }
 
     private LayeredBloomFilter<BloomFilter> setupFindTest() {
-        LayeredBloomFilter<BloomFilter> filter = LayeredBloomFilter.fixed(getTestShape(), 10);
+        LayeredBloomFilter<BloomFilter> filter = LayeredBloomFilterTest.fixed(getTestShape(), 10);
         filter.merge(TestingHashers.FROM1);
         filter.merge(TestingHashers.FROM11);
         filter.merge(new IncrementingHasher(11, 2));
@@ -286,7 +317,7 @@ public class LayeredBloomFilterTest extends AbstractBloomFilterTest<LayeredBloom
     public final void testGetLayer() {
         BloomFilter bf = new SimpleBloomFilter(getTestShape());
         bf.merge(TestingHashers.FROM11);
-        LayeredBloomFilter<BloomFilter> filter = LayeredBloomFilter.fixed(getTestShape(), 10);
+        LayeredBloomFilter<BloomFilter> filter = LayeredBloomFilterTest.fixed(getTestShape(), 10);
         filter.merge(TestingHashers.FROM1);
         filter.merge(TestingHashers.FROM11);
         filter.merge(new IncrementingHasher(11, 2));
@@ -296,7 +327,7 @@ public class LayeredBloomFilterTest extends AbstractBloomFilterTest<LayeredBloom
 
     @Test
     public void testMultipleFilters() {
-        LayeredBloomFilter<BloomFilter> filter = LayeredBloomFilter.fixed(getTestShape(), 10);
+        LayeredBloomFilter<BloomFilter> filter = LayeredBloomFilterTest.fixed(getTestShape(), 10);
         filter.merge(TestingHashers.FROM1);
         filter.merge(TestingHashers.FROM11);
         assertEquals(2, filter.getDepth());

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilterTest.java
@@ -102,7 +102,7 @@ public class LayeredBloomFilterTest extends AbstractBloomFilterTest<LayeredBloom
 
         @Override
         public TimestampedBloomFilter copy() {
-            return new TimestampedBloomFilter(this.wrapped.copy(), timestamp);
+            return new TimestampedBloomFilter(this.getWrapped().copy(), timestamp);
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilterTest.java
@@ -47,8 +47,7 @@ public class LayeredBloomFilterTest extends AbstractBloomFilterTest<LayeredBloom
         @Override
         public boolean test(LayerManager<TimestampedBloomFilter> lm) {
             // can not use getTarget() as it causes recursion.
-            TimestampedBloomFilter bf =  lm.last();
-            return bf != null && bf.timestamp + quanta < System.currentTimeMillis();
+            return lm.last().timestamp + quanta < System.currentTimeMillis();
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilterTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -155,7 +156,7 @@ public class LayeredBloomFilterTest extends AbstractBloomFilterTest<LayeredBloom
     static LayeredBloomFilter<TimestampedBloomFilter> createTimedLayeredFilter(Shape shape, long duration, TimeUnit dUnit, long quanta,
             TimeUnit qUnit) {
         LayerManager.Builder<TimestampedBloomFilter> builder = LayerManager.builder();
-        Consumer<List<TimestampedBloomFilter>> cleanup = Cleanup.removeEmptyTarget().andThen(new CleanByTime(duration, dUnit));
+        Consumer<Deque<TimestampedBloomFilter>> cleanup = Cleanup.removeEmptyTarget().andThen(new CleanByTime(duration, dUnit));
         LayerManager<TimestampedBloomFilter> layerManager = builder
                 .setSupplier(() -> new TimestampedBloomFilter(new SimpleBloomFilter(shape)))
                 .setCleanup(cleanup)

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/LayeredBloomFilterTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.collections4.bloomfilter;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,7 +30,6 @@ import java.util.function.Predicate;
 
 import org.apache.commons.collections4.bloomfilter.LayerManager.Cleanup;
 import org.apache.commons.collections4.bloomfilter.LayerManager.ExtendCheck;
-import org.apache.commons.collections4.bloomfilter.LayerManagerTest.NumberedBloomFilter;
 import org.junit.jupiter.api.Test;
 
 public class LayeredBloomFilterTest extends AbstractBloomFilterTest<LayeredBloomFilter<?>> {
@@ -360,5 +358,20 @@ public class LayeredBloomFilterTest extends AbstractBloomFilterTest<LayeredBloom
         assertEquals(1, underTest.getDepth());
         f = (NumberedBloomFilter) underTest.get(0);
         assertEquals(3, f.sequence);  // it is a new one.
+    }
+
+    static class NumberedBloomFilter extends WrappedBloomFilter {
+        int value;
+        int sequence;
+        NumberedBloomFilter(Shape shape, int value, int sequence) {
+            super(new SimpleBloomFilter(shape));
+            this.value = value;
+            this.sequence = sequence;
+        }
+
+        @Override
+        public BloomFilter copy() {
+            return new NumberedBloomFilter(getShape(), value, sequence);
+        }
     }
 }

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/WrappedBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/WrappedBloomFilterTest.java
@@ -29,7 +29,7 @@ public class WrappedBloomFilterTest extends AbstractBloomFilterTest<WrappedBloom
             @Override
             public BloomFilter copy() {
                 BloomFilter result = new DefaultBloomFilterTest.SparseDefaultBloomFilter(shape);
-                result.merge(this.wrapped);
+                result.merge(this.getWrapped());
                 return result;
             }
         };
@@ -49,7 +49,7 @@ public class WrappedBloomFilterTest extends AbstractBloomFilterTest<WrappedBloom
             @Override
             public BloomFilter copy() {
                 BloomFilter result = new DefaultBloomFilterTest.SparseDefaultBloomFilter(shape);
-                result.merge(this.wrapped);
+                result.merge(this.getWrapped());
                 return result;
             }
         };

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/WrappedBloomFilterTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/WrappedBloomFilterTest.java
@@ -26,6 +26,12 @@ public class WrappedBloomFilterTest extends AbstractBloomFilterTest<WrappedBloom
     @Override
     protected WrappedBloomFilter createEmptyFilter(Shape shape) {
         return new WrappedBloomFilter(new DefaultBloomFilterTest.SparseDefaultBloomFilter(shape)) {
+            @Override
+            public BloomFilter copy() {
+                BloomFilter result = new DefaultBloomFilterTest.SparseDefaultBloomFilter(shape);
+                result.merge(this.wrapped);
+                return result;
+            }
         };
     }
 
@@ -39,7 +45,14 @@ public class WrappedBloomFilterTest extends AbstractBloomFilterTest<WrappedBloom
                 return characteristics;
             }
         };
-        WrappedBloomFilter underTest = new WrappedBloomFilter(inner) {};
+        WrappedBloomFilter underTest = new WrappedBloomFilter(inner) {
+            @Override
+            public BloomFilter copy() {
+                BloomFilter result = new DefaultBloomFilterTest.SparseDefaultBloomFilter(shape);
+                result.merge(this.wrapped);
+                return result;
+            }
+        };
         assertEquals(characteristics, underTest.characteristics());
     }
 }


### PR DESCRIPTION
Changes to the is code:

1. Added generics to LayeredBloomFilter and LayerManager so that the implementation of the enclosed Bloom filter can be specified.
2. Modified WrappedBloomfFilter to require copy() implementation.
3.  Changed the LayerManager internal LinkedList declaration to List.