### PR TITLE
Fix the bug of MapUtils.getString

### DIFF
--- a/src/main/java/org/apache/commons/collections4/MapUtils.java
+++ b/src/main/java/org/apache/commons/collections4/MapUtils.java
@@ -1142,15 +1142,14 @@ public class MapUtils {
      * produce the default value if the conversion fails.
      *
      * @param <K> the key type
+     * @param defaultFunction what to produce the default value if the value is null or if the conversion fails
      * @param map the map whose value to look up
      * @param key the key of the value to look up in that map
-     * @param defaultFunction what to produce the default value if the value is null or if the conversion fails
      * @return the value in the map as a string, or defaultValue produced by the defaultFunction if the original value
      *         is null, the map is null or the string conversion fails
      * @since 4.5.0
      */
-    public static <K> String getString(final Map<? super K, ?> map, final K key,
-            final Function<K, String> defaultFunction) {
+    public static <K> String getString(final Function<K, String> defaultFunction, final Map<? super K, ?> map, final K key) {
         return applyDefaultFunction(map, key, MapUtils::getString, defaultFunction);
     }
 

--- a/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
@@ -605,12 +605,13 @@ public class MapUtilsTest {
         assertEquals("str", MapUtils.getString(in, "key"));
         assertNull(MapUtils.getString(null, "key"));
         assertEquals("default", MapUtils.getString(in, "noKey", "default"));
-        assertEquals("default", MapUtils.getString(in, "noKey", key -> {
+        assertEquals(null, MapUtils.getString(in, "noKey", null));
+        assertEquals("default", MapUtils.getString(key -> {
             if ("noKey".equals(key)) {
                 return "default";
             }
             return StringUtils.EMPTY;
-        }));
+        }, in, "noKey"));
         assertEquals("default", MapUtils.getString(null, "noKey", "default"));
     }
 


### PR DESCRIPTION
MapUtils have added several new methods as getXXX allowing 3rd param as functional input
But for String, it allowed this in 4.4
![image](https://github.com/user-attachments/assets/6633d193-2e75-4604-b51a-75a63a218e8d)

But now it would **make static compilation error** in 4.5.0-M2
![image](https://github.com/user-attachments/assets/e00c63b4-2d46-47db-8272-2ac1353f6d4b)

**It's a design bug for conflict input param and stopped our old project**, there are 3 ways to fix:
--Type1 is like this pull, adjust the sequence of params. (Recommended)