### PR TITLE
COLLECTIONS-873: create PatriciaTrieSet

### DIFF
--- a/src/main/java/org/apache/commons/collections4/set/PatriciaTrieSet.java
+++ b/src/main/java/org/apache/commons/collections4/set/PatriciaTrieSet.java
@@ -1,0 +1,145 @@
+package org.apache.commons.collections4.set;
+
+import org.apache.commons.collections4.trie.PatriciaTrie;
+
+import java.io.IOException;
+import java.util.AbstractSet;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.io.Serializable;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * Add  {@code Set} to work with PatriciaTree with unique key ignore corresponding values
+ * <p>
+ * This set exists to provide interface to work with Set + PatriciaTree
+ * </p>
+ * <p>
+ * One usage would be to ensure that no null entries are added to the set.
+ * </p>
+ * <pre>PatriciaTrieSet = new PatriciaTrieSet();</pre>
+ * <p>
+ * This class is Serializable and Cloneable.
+ * </p>
+ *
+ * @since 5.0
+ */
+public class PatriciaTrieSet extends AbstractSet<String> implements TrieSet<String>, Serializable {
+
+    private static final long serialVersionUID = -2365733183789787136L;
+
+    // Stub for all values in PatriciaTrie
+    static final Object PRESENT = new Object();
+    transient PatriciaTrie<Object> trie;
+
+    public PatriciaTrieSet() {
+        trie = new PatriciaTrie<>();
+    }
+
+    @Override
+    public Iterator<String> iterator() {
+        return trie.keySet().iterator();
+    }
+
+    @Override
+    public int size() {
+        return trie.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return trie.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return trie.containsKey(o);
+    }
+
+    @Override
+    public boolean add(String e) {
+        return trie.put(e, PRESENT) == null;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return trie.remove(o) == PRESENT;
+    }
+
+    @Override
+    public void clear() {
+        trie.clear();
+    }
+
+    /**
+     * Serializes this object to an ObjectOutputStream.
+     *
+     * @param out the target ObjectOutputStream.
+     * @throws IOException thrown when an I/O errors occur writing to the target stream.
+     */
+    private void writeObject(java.io.ObjectOutputStream out)
+            throws IOException {
+        out.defaultWriteObject();
+        out.writeInt(trie.size());
+
+        for (String entry : this.trie.keySet()) {
+            out.writeObject(entry);
+        }
+    }
+
+    /**
+     * Deserializes the set in using a custom routine.
+     *
+     * @param s the input stream
+     * @throws IOException            if an error occurs while reading from the stream
+     * @throws ClassNotFoundException if an object read from the stream cannot be loaded
+     */
+    @SuppressWarnings("unchecked")
+    private void readObject(java.io.ObjectInputStream s)
+            throws IOException, ClassNotFoundException {
+        s.readFields();
+        int size = s.readInt();
+        this.trie = new PatriciaTrie<>();
+
+        for (int i = 0; i < size; i++) {
+            this.add((String) s.readObject());
+        }
+    }
+
+    @Override
+    public SortedSet<String> prefixSet(String key) {
+        return new TreeSet<>(trie.prefixMap(key).keySet());
+    }
+
+    @Override
+    public Comparator<? super String> comparator() {
+        return trie.comparator();
+    }
+
+    @Override
+    public SortedSet<String> subSet(String fromElement, String toElement) {
+        return new TreeSet<>(trie.subMap(fromElement, toElement).keySet());
+    }
+
+    @Override
+    public SortedSet<String> headSet(String toElement) {
+        return new TreeSet<>(trie.headMap(toElement).keySet());
+    }
+
+    @Override
+    public SortedSet<String> tailSet(String fromElement) {
+        return new TreeSet<>(trie.tailMap(fromElement).keySet());
+    }
+
+    @Override
+    public String first() {
+        return trie.firstKey();
+    }
+
+    @Override
+    public String last() {
+        return trie.lastKey();
+    }
+
+}

--- a/src/main/java/org/apache/commons/collections4/set/PatriciaTrieSet.java
+++ b/src/main/java/org/apache/commons/collections4/set/PatriciaTrieSet.java
@@ -54,7 +54,10 @@ public class PatriciaTrieSet extends AbstractSet<String> implements TrieSet<Stri
 
     @Override
     public boolean contains(Object o) {
-        return trie.containsKey(o);
+        if (o instanceof String)
+            return trie.containsKey(o);
+
+        return false;
     }
 
     @Override
@@ -95,7 +98,6 @@ public class PatriciaTrieSet extends AbstractSet<String> implements TrieSet<Stri
      * @throws IOException            if an error occurs while reading from the stream
      * @throws ClassNotFoundException if an object read from the stream cannot be loaded
      */
-    @SuppressWarnings("unchecked")
     private void readObject(java.io.ObjectInputStream s)
             throws IOException, ClassNotFoundException {
         s.readFields();

--- a/src/main/java/org/apache/commons/collections4/set/TrieSet.java
+++ b/src/main/java/org/apache/commons/collections4/set/TrieSet.java
@@ -1,0 +1,26 @@
+package org.apache.commons.collections4.set;
+
+import java.util.SortedSet;
+
+/**
+ * Defines the interface for a prefix set, an ordered tree data structure. For more information, see <a href="https://en.wikipedia.org/wiki/Trie">Tries</a>.
+ *
+ * @param <K> – the type of elements maintained by this set
+ */
+public interface TrieSet<K> extends SortedSet<K> {
+
+    /**
+     * Returns a view of this {@link TrieSet} of all elements that are prefixed by the given key without duplicates
+     * <p>
+     * In a {@link TrieSet} with fixed size keys, this is essentially a {@link #contains(Object)} operation.
+     * </p>
+     * <p>
+     * For example, if the {@link TrieSet} contains 'Anna', 'Anael', 'Analu', 'Andreas', 'Andrea', 'Andres', and 'Anatole', then a lookup of 'And' would return
+     * 'Andreas', 'Andrea', and 'Andres'.
+     * </p>
+     *
+     * @param key the key used in the search
+     * @return a {@link SortedSet} view of this {@link TrieSet} with all elements whose key is prefixed by the search key
+     */
+    SortedSet<K> prefixSet(K key);
+}

--- a/src/test/java/org/apache/commons/collections4/set/PatriciaTrieSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/PatriciaTrieSetTest.java
@@ -1,0 +1,230 @@
+package org.apache.commons.collections4.set;
+
+import org.apache.commons.collections4.trie.analyzer.StringKeyAnalyzer;
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.SortedSet;
+
+public class PatriciaTrieSetTest {
+
+    PatriciaTrieSet patriciaTrieSet = new PatriciaTrieSet();
+
+    @BeforeEach
+    public void preInitTest() {
+        patriciaTrieSet.clear();
+    }
+
+    @Test
+    public void setShouldContainUniqueElements() {
+        patriciaTrieSet.add("Alberto");
+        patriciaTrieSet.add("Albe");
+        patriciaTrieSet.add("Alberto");
+        patriciaTrieSet.add("Albe");
+
+        Assertions.assertEquals(2, patriciaTrieSet.size());
+    }
+
+    @Test
+    public void setShouldNotContainsNullKey() {
+        Assertions.assertThrows(NullPointerException.class, () -> patriciaTrieSet.add(null));
+    }
+
+    @Test
+    public void clearShouldClearAllElements() {
+        patriciaTrieSet.add("Alberto");
+        patriciaTrieSet.add("Albe");
+
+        patriciaTrieSet.clear();
+
+        Assertions.assertEquals(0, patriciaTrieSet.size());
+        Assertions.assertTrue(patriciaTrieSet.isEmpty());
+    }
+
+    @Test
+    public void isEmptyShouldReturnFalseIfElementsExist() {
+        Assertions.assertTrue(patriciaTrieSet.isEmpty());
+        patriciaTrieSet.add("Alberto");
+
+        Assertions.assertFalse(patriciaTrieSet.isEmpty());
+    }
+
+    @Test
+    public void iteratorShouldContainsAllElements() {
+        patriciaTrieSet.add("Alberto");
+        patriciaTrieSet.add("Albe");
+
+        HashSet<String> set = new HashSet<>(2);
+        set.add("Alberto");
+        set.add("Albe");
+
+        for (String value : patriciaTrieSet) {
+            Assertions.assertTrue(set.remove(value), "Value " + value + " not exists!");
+        }
+    }
+
+    @Test
+    public void containsShouldReturnCorrectValue() {
+        patriciaTrieSet.add("Alberto");
+        patriciaTrieSet.add("Albe");
+        patriciaTrieSet.add("Al");
+        patriciaTrieSet.add("A");
+
+        Assertions.assertTrue(patriciaTrieSet.contains("A"));
+        Assertions.assertTrue(patriciaTrieSet.contains("Al"));
+        Assertions.assertTrue(patriciaTrieSet.contains("Albe"));
+        Assertions.assertTrue(patriciaTrieSet.contains("Alberto"));
+        Assertions.assertFalse(patriciaTrieSet.contains("Albert"));
+    }
+
+    @Test
+    public void addShouldReturnFalseIfValueExists() {
+        patriciaTrieSet.add("Alberto");
+
+        Assertions.assertFalse(patriciaTrieSet.add("Alberto"));
+    }
+
+    @Test
+    public void addShouldReturnTrueIfValueNotExists() {
+        Assertions.assertTrue(patriciaTrieSet.add("Alberto"));
+    }
+
+    @Test
+    public void removeShouldReturnTrueIfValueExists() {
+        patriciaTrieSet.add("Alberto");
+
+        Assertions.assertTrue(patriciaTrieSet.remove("Alberto"));
+    }
+
+    @Test
+    public void removeShouldReturnFalseIfValueNotExist() {
+        Assertions.assertFalse(patriciaTrieSet.remove("Alberto"));
+    }
+
+    @Test
+    public void serializeShouldSerializeAndDeserializedCorrectly() {
+        patriciaTrieSet.add("Alberto");
+        patriciaTrieSet.add("Albe");
+        patriciaTrieSet.add("Al");
+        patriciaTrieSet.add("A");
+
+        byte[] serializedBytes = SerializationUtils.serialize(patriciaTrieSet);
+        PatriciaTrieSet expected = SerializationUtils.deserialize(serializedBytes);
+
+        Assertions.assertEquals(4, expected.size());
+        Assertions.assertTrue(patriciaTrieSet.contains("A"));
+        Assertions.assertTrue(patriciaTrieSet.contains("Al"));
+        Assertions.assertTrue(patriciaTrieSet.contains("Albe"));
+        Assertions.assertTrue(patriciaTrieSet.contains("Alberto"));
+    }
+
+    @Test
+    public void serializeShouldSerializeAndDeserializedCorrectlyEmptyObject() {
+        byte[] serializedBytes = SerializationUtils.serialize(patriciaTrieSet);
+        PatriciaTrieSet expected = SerializationUtils.deserialize(serializedBytes);
+
+        Assertions.assertEquals(0, expected.size());
+    }
+
+    @Test
+    public void prefixSetShouldReturnCorrectObject() {
+        patriciaTrieSet.add("Alberto");
+        patriciaTrieSet.add("Bbe");
+        patriciaTrieSet.add("Bb");
+        patriciaTrieSet.add("Al");
+        patriciaTrieSet.add("A");
+
+        SortedSet<String> set = patriciaTrieSet.prefixSet("Bb");
+        Assertions.assertEquals(2, set.size());
+
+        Assertions.assertEquals("Bb", set.first());
+        Assertions.assertEquals("Bbe", set.last());
+    }
+
+    @Test
+    public void subSetShouldReturnCorrectObject() {
+        patriciaTrieSet.add("Alberto");
+        patriciaTrieSet.add("Bbe");
+        patriciaTrieSet.add("Bb");
+        patriciaTrieSet.add("Al");
+        patriciaTrieSet.add("A");
+
+        SortedSet<String> set = patriciaTrieSet.subSet("Al", "Bbe");
+        Assertions.assertEquals(3, set.size());
+
+        String[] array = new String[3];
+        set.toArray(array);
+
+        Assertions.assertEquals("Al", array[0]);
+        Assertions.assertEquals("Alberto", array[1]);
+        Assertions.assertEquals("Bb", array[2]);
+    }
+
+    @Test
+    public void headSetShouldReturnCorrectObject() {
+        patriciaTrieSet.add("Alberto");
+        patriciaTrieSet.add("Bbe");
+        patriciaTrieSet.add("Bb");
+        patriciaTrieSet.add("Al");
+        patriciaTrieSet.add("A");
+
+        SortedSet<String> set = patriciaTrieSet.headSet("Bbe");
+        Assertions.assertEquals(4, set.size());
+
+        String[] array = new String[4];
+        set.toArray(array);
+
+        Assertions.assertEquals("A", array[0]);
+        Assertions.assertEquals("Al", array[1]);
+        Assertions.assertEquals("Alberto", array[2]);
+        Assertions.assertEquals("Bb", array[3]);
+    }
+
+    @Test
+    public void tailSetShouldReturnCorrectObject() {
+        patriciaTrieSet.add("Alberto");
+        patriciaTrieSet.add("Bbe");
+        patriciaTrieSet.add("Bb");
+        patriciaTrieSet.add("Al");
+        patriciaTrieSet.add("Z");
+
+        SortedSet<String> set = patriciaTrieSet.tailSet("Bbe");
+        Assertions.assertEquals(2, set.size());
+
+        String[] array = new String[2];
+        set.toArray(array);
+
+        Assertions.assertEquals("Bbe", array[0]);
+        Assertions.assertEquals("Z", array[1]);
+    }
+
+    @Test
+    public void firstKeyShouldReturnCorrectObject() {
+        patriciaTrieSet.add("Alberto");
+        patriciaTrieSet.add("Bbe");
+        patriciaTrieSet.add("Bb");
+        patriciaTrieSet.add("Al");
+        patriciaTrieSet.add("Z");
+
+        Assertions.assertEquals("Al", patriciaTrieSet.first());
+    }
+
+    @Test
+    public void lastKeyShouldReturnCorrectObject() {
+        patriciaTrieSet.add("Alberto");
+        patriciaTrieSet.add("Bbe");
+        patriciaTrieSet.add("Bb");
+        patriciaTrieSet.add("Al");
+        patriciaTrieSet.add("Zz");
+
+        Assertions.assertEquals("Zz", patriciaTrieSet.last());
+    }
+
+    @Test
+    public void comparatorShouReturnSetComparator() {
+        Assertions.assertEquals(StringKeyAnalyzer.INSTANCE, patriciaTrieSet.comparator());
+    }
+}


### PR DESCRIPTION
According to https://issues.apache.org/jira/browse/COLLECTIONS-873

MR is basically a draft or discussion of what to do.

I make PatriciaTrieSet based on PatriciaTrie under the hood.

Below I type what I don't like. Please give some advice.

The main problem is when I access PatriciaTrie, I have to return SortedSet.
But all collections under the hood of PatriciaTrie don't use SortedSet.
Thus, I wrap call under TreeSet.

For example

```
@Override
    public SortedSet<String> headSet(String toElement) {
        return new TreeSet<>(trie.headMap(toElement).keySet());
    }
```

This is overwhelming because the keySet is already sorted, and adding to a TreeSet also takes time.

To improve the situation, I make two approaches:

1. Fully rewrite PatriciaTrieSet, copying logic with bit operations to the corresponding class.
The drawback is that a change (bug) in bit operations leads to a rewrite in PatriciaTrieSet and PatriciaTrie independently.
2. Extend the internal PatricaiTrie class to implement NavigableMap (PrefixRangeMap and RangeEntryMap + some other classes).
`public interface NavigableMap<K,V> extends SortedMap<K,V> `
From NavigableMap, I can get navigableKeySet and work with it in PatriciaTrieSet.
