### PR TITLE
Added missing functionality test for MultiKeyMap.put, MultiKeyMap.multiKeyMap, MultiKeyMap.removeAll, CircularFifoQueue.add, CircularFifoQueue.isEmpty

### DIFF
--- a/src/test/java/org/apache/commons/collections4/map/MultiKeyMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/MultiKeyMapTest.java
@@ -490,6 +490,45 @@ public class MultiKeyMapTest<K, V> extends AbstractIterableMapTest<MultiKey<? ex
     }
 
     @Test
+    void testClassCastExceptionOnNonMultiKey() {
+        MultiKeyMap<String, String> map = new MultiKeyMap<>();
+        Object nonMultiKey = "test";
+        assertThrows(ClassCastException.class, () -> map.put((MultiKey<? extends String>) nonMultiKey, "value"));
+    }
+
+    @Test
+    void testMultiKeyMapNullMap() {
+        assertThrows(NullPointerException.class, () -> MultiKeyMap.multiKeyMap(null));
+    }
+
+    @Test
+    void testMultiKeyRemoveAll_ReturnsTrueWhenEntriesRemoved() {
+        resetFull();
+        final MultiKeyMap<K, V> multimap = getMap();
+        assertEquals(12, multimap.size());
+
+        boolean result = multimap.removeAll(I1);
+        assertEquals(8, multimap.size());
+        assertTrue(result);
+
+        for (final MapIterator<MultiKey<? extends K>, V> it = multimap.mapIterator(); it.hasNext();) {
+            final MultiKey<? extends K> key = it.next();
+            assertFalse(I1.equals(key.getKey(0)));
+        }
+    }
+
+    @Test
+    void testMultiKeyRemoveAll_ReturnsFalseWhenNoEntriesRemoved() {
+        resetFull();
+        MultiKeyMap<K, V> multimap = getMap();
+        assertEquals(12, multimap.size());
+
+        boolean result = multimap.removeAll(new Object());
+        assertEquals(12, multimap.size());
+        assertFalse(result);
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     void testNullHandling() {
         resetFull();

--- a/src/test/java/org/apache/commons/collections4/queue/CircularFifoQueueTest.java
+++ b/src/test/java/org/apache/commons/collections4/queue/CircularFifoQueueTest.java
@@ -451,6 +451,26 @@ public class CircularFifoQueueTest<E> extends AbstractQueueTest<E> {
 //        writeExternalFormToDisk((java.io.Serializable) getCollection(), "src/test/resources/data/test/CircularFifoQueue.fullCollection.version4.obj");
 //    }
 
+    @Test
+    void testAddAlwaysReturnsTrue() {
+        final CircularFifoQueue<E> queue = new CircularFifoQueue<>(3);
+        queue.add((E) "1");
+        queue.add((E) "2");
+        queue.add((E)"3");
+        assertTrue(queue.add((E)"4"));
+        assertTrue(queue.add((E)"5"));
+    }
+
+    @Test
+    void testIsEmpty() {
+        CircularFifoQueue<String> queue = new CircularFifoQueue<>(10);
+        assertTrue(queue.isEmpty());
+        queue.add("test");
+        assertFalse(queue.isEmpty());
+        queue.remove("test");
+        assertTrue(queue.isEmpty());
+    }
+
     /**
      *  Runs through the regular verifications, but also verifies that
      *  the buffer contains the same elements in the same sequence as the


### PR DESCRIPTION
Hi,

I’ve added unit tests for certain behaviors in the `CircularFifoQueue` and `MultiKeyMap` classes that are described in the Javadoc but were not explicitly tested before. These tests do not increase code coverage, as the relevant lines are already executed by other tests, but they help make the intended behavior more explicit and well-documented through testing.

For `CircularFifoQueue`:

- `add` always returns true, even if an element is discarded.
- `isEmpty` returns a boolean indicating whether the queue is empty.

For `MultiKeyMap`:
-`put` throws a `ClassCastException` if the key is not a MultiKey.
- `multiKeyMap` throws a `NullPointerException` when the provided map is null.
- `removeAll` returns a boolean to indicate if any entries were removed.

I added separate test methods for each of these behaviors in their respective test classes. Even though they don’t increase coverage metrics, I believe these tests are useful for improving clarity, helping future maintainers understand the method contracts better, and guarding against subtle regressions.

Thanks!