### PR TITLE
[collections-722] deeply nested chainedIterator performance problems fixed

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -33,6 +33,7 @@
     <action type="fix" dev="ggregory" due-to="Gary Gregory">Fix exception message in org.apache.commons.collections4.functors.FunctorUtils.validate(Consumer...)</action>
     <action type="fix" dev="ggregory" due-to="Gary Gregory">Fix exception message in org.apache.commons.collections4.iterators.UnmodifiableIterator.remove() to match java.util.Iterator.remove().</action>
     <action type="fix" dev="pkarwasz" due-to="Piotr P. Karwasz, Joerg Budischewski" issue="COLLECTIONS-838">Calling SetUtils.union on multiple instances of SetView causes JVM to hang</action>
+    <action type="fix" dev="pkarwasz" due-to="Piotr P. Karwasz, Joerg Budischewski" issue="COLLECTIONS-722">Improve IteratorUtils.chainedIterator() performance.</action>
     <!-- ADD -->
     <action type="add" dev="ggregory" due-to="Gary Gregory">Add generics to UnmodifiableIterator for the wrapped type.</action>
     <!-- UPDATE -->

--- a/src/main/java/org/apache/commons/collections4/iterators/UnmodifiableIterator.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/UnmodifiableIterator.java
@@ -79,4 +79,15 @@ public final class UnmodifiableIterator<E> implements Iterator<E>, Unmodifiable 
         throw new UnsupportedOperationException("remove() is not supported");
     }
 
+    /**
+     * Allows package scoped access to the wrapped iterator for a very specific IteratorChain usecase.
+     * @return the wrapped IteratorChain instance or null when wrapped iterator is not a IteratorChain
+     */
+    IteratorChain<? extends E> getPossibleUnderlyingIteratorChain() {
+        if (iterator instanceof IteratorChain) {
+            return (IteratorChain<? extends E>) iterator;
+        }
+        return null;
+    }
+
 }

--- a/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/UnmodifiableIteratorTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -78,4 +80,10 @@ public class UnmodifiableIteratorTest<E> extends AbstractIteratorTest<E> {
         assertTrue(makeEmptyIterator() instanceof Unmodifiable);
     }
 
+    @Test
+    void testIteratorChainRetrieval() {
+        assertNull(((UnmodifiableIterator) makeObject()).getPossibleUnderlyingIteratorChain());
+        final IteratorChain iteratorChain = new IteratorChain(testList.iterator());
+        assertEquals(((UnmodifiableIterator) UnmodifiableIterator.unmodifiableIterator(iteratorChain)).getPossibleUnderlyingIteratorChain(), iteratorChain);
+    }
 }


### PR DESCRIPTION
basically 'renovated' stale PR https://github.com/apache/commons-collections/pull/308 from collections-770, ensures that rechaining chainedIterators multiple times now result in a single IteratorChain instance with all picked up underlying iterators, thus avoiding deeply nested imperformant IteratorChain instances. Additionally the UnmodifiableIterator gets a special treatment, so that SetUtils.SetView.iterator() also benefits from this solution. Raised test coverage.

Note: From the comments in PR 308  (collections-770), I think, the PR stalled because it did not directly address the issue in that ticket, however there might be other reasons I am not aware of. 
But as far as I can see, it fits perfectly for Collections-722. Cudos to original author [stevebosman-oc](https://github.com/stevebosman-oc).

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [-] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [-] I used AI to create any part of, or all of, this pull request.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
