### PR TITLE
[COLLECTIONS-878] MapUtils.invertMap() improve HashMap construction

### DIFF
--- a/src/main/java/org/apache/commons/collections4/MapUtils.java
+++ b/src/main/java/org/apache/commons/collections4/MapUtils.java
@@ -1185,7 +1185,7 @@ public class MapUtils {
      */
     public static <K, V> Map<V, K> invertMap(final Map<K, V> map) {
         Objects.requireNonNull(map, "map");
-        final Map<V, K> out = new HashMap<>(map.size());
+        final Map<V, K> out = new HashMap<>((int) Math.ceil(map.size() / 0.75d));
         for (final Entry<K, V> entry : map.entrySet()) {
             out.put(entry.getValue(), entry.getKey());
         }

--- a/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.lang.reflect.Field;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.AbstractMap;
@@ -659,6 +660,71 @@ class MapUtilsTest {
         final Exception exception = assertThrows(NullPointerException.class, () -> MapUtils.invertMap(nullMap));
         final String actualMessage = exception.getMessage();
         assertTrue(actualMessage.contains("map"));
+    }
+
+    /**
+     * Proves that the patched initial capacity calculation prevents HashMap resizing
+     * that would otherwise occur with the original {@code new HashMap<>(map.size())}.
+     *
+     * <p>The test mimics the core logic of {@link MapUtils#invertMap(Map)} but
+     * creates two output maps: one using the old capacity, one using the new formula.
+     * Entries are added in the same order, and resize events are detected via
+     * reflection by tracking changes to the internal {@code table} array.</p>
+     *
+     * <p>For Java 9+ requires JVM argument:
+     * {@code --add-opens java.base/java.util=ALL-UNNAMED}
+     * (configured in your build tool).</p>
+     */
+    @Test
+    void testInvertMapCapacityFormulaAvoidsResize() throws Exception {
+        // create an input map with a size that triggers a resize for the old formula
+        // (e.g. 14 entries → default capacity 16, threshold 12 → resize on 13th put).
+        final Map<String, String> input = new HashMap<>();
+        for (int i = 0; i < 14; i++) {
+            input.put("key" + i, "val" + i);
+        }
+
+        // ---- old capacity (original code) ----
+        final Map<String, String> oldOutput = new HashMap<>(input.size());  // line to be replaced
+
+        // ---- new capacity (patched code) ----
+        final Map<String, String> newOutput = new HashMap<>((int) Math.ceil(input.size() / 0.75d));  // should we use named constant for 0.75d?
+
+        // prepare reflective access to HashMap.table
+        final Field tableField = HashMap.class.getDeclaredField("table");
+        tableField.setAccessible(true);
+
+        int oldResizes = 0;
+        int newResizes = 0;
+        // tables are null before first put
+        Object[] prevOldTable = (Object[]) tableField.get(oldOutput);
+        Object[] prevNewTable = (Object[]) tableField.get(newOutput);
+
+        // simulate the loop from invertMap for both output maps simultaneously
+        // and check if table size changed
+        for (final Map.Entry<String, String> entry : input.entrySet()) {
+            oldOutput.put(entry.getValue(), entry.getKey());
+            newOutput.put(entry.getValue(), entry.getKey());
+
+            final Object[] currOldTable = (Object[]) tableField.get(oldOutput);
+            if (currOldTable != prevOldTable) {
+                oldResizes++;
+                prevOldTable = currOldTable;
+            }
+
+            final Object[] currNewTable = (Object[]) tableField.get(newOutput);
+            if (currNewTable != prevNewTable) {
+                newResizes++;
+                prevNewTable = currNewTable;
+            }
+
+            System.out.printf("el(%6s:%6s): old formula table size is %4d, new formula table is %4d\n", entry.getValue(), entry.getKey(), prevOldTable.length, prevNewTable.length);
+        }
+
+        assertEquals(2, oldResizes,
+                "Old capacity formula should cause exactly one resize for 14 elements, except init alloc");
+        assertEquals(1, newResizes,
+                "Patched capacity formula should prevent any resize for 14 elements, except init alloc");
     }
 
     @Test


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

According to https://issues.apache.org/jira/projects/COLLECTIONS/issues/COLLECTIONS-878

Total summary:
- Precompute initial capacity for new HashMap in MapUtils.invertMap to avoid resize during following insertion.
- Implementation same as JDK's HashMap static factory method.

```
// from HashMap (since 19)
static int calculateHashMapCapacity(int numMappings) {
    return (int) Math.ceil(numMappings / (double) DEFAULT_LOAD_FACTOR);
}
```

Why `0.75d`:
- It is DEFAULT_LOAD_FACTOR casted to double
- load factor is being casted to double in HashMap.calculateHashMapCapacity
- For very big maps we rarely can encounter lack of float precision and have extra resize.

We have extra resize for 50% of Maps. In example:
Let's inspect for maps with size on [4, 16].
- On size 4 will be allocated map with size 4 and when the 4th element will be inserted the HashMap will be resized.
- On sizes 5, 6 will be allocated map with size rounded to 8 and there will not be any resizes.
- On sizes 7, 8 will be allocated map with size rounded to 8 and there will be resize when the 7th element will be inserted.
- On sizes 9, 10, 11, 12 will be allocated map with size rounded to 16 and everything will be ok
- On sizes 13, 14, 15, 16 will be allocated map with size rounded to 16 and there will be resize on 13th element insertion.

To sum up:
For each power of two we have segment from 50% to 100%. Because 50% is previous power of two. And for each initial size from 50% to 75% (DEFAULT_LOAD_FACTOR) everything ok, but for sizes from 75% to 100% we have extra resize. So we have 50% of probability to have extra resize. 
