### PR TITLE
Reject non-positive entry count in bag/multiset doReadObject

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bag/AbstractMapBag.java
+++ b/src/main/java/org/apache/commons/collections4/bag/AbstractMapBag.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4.bag;
 
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Array;
@@ -300,6 +301,9 @@ public abstract class AbstractMapBag<E> implements Bag<E> {
             @SuppressWarnings("unchecked") // This will fail at runtime if the stream is incorrect
             final E obj = (E) in.readObject();
             final int count = in.readInt();
+            if (count < 1) {
+                throw new InvalidObjectException("Invalid count for entry: " + count);
+            }
             map.put(obj, new MutableInteger(count));
             size += count;
         }

--- a/src/main/java/org/apache/commons/collections4/bag/AbstractMapBag.java
+++ b/src/main/java/org/apache/commons/collections4/bag/AbstractMapBag.java
@@ -302,7 +302,7 @@ public abstract class AbstractMapBag<E> implements Bag<E> {
             final E obj = (E) in.readObject();
             final int count = in.readInt();
             if (count < 1) {
-                throw new InvalidObjectException("Invalid count for entry: " + count);
+                throw new InvalidObjectException("Invalid count for entry (must be >= 1): " + count);
             }
             map.put(obj, new MutableInteger(count));
             size += count;

--- a/src/main/java/org/apache/commons/collections4/multiset/AbstractMapMultiSet.java
+++ b/src/main/java/org/apache/commons/collections4/multiset/AbstractMapMultiSet.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4.multiset;
 
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Array;
@@ -366,6 +367,9 @@ public abstract class AbstractMapMultiSet<E> extends AbstractMultiSet<E> {
             @SuppressWarnings("unchecked") // This will fail at runtime if the stream is incorrect
             final E obj = (E) in.readObject();
             final int count = in.readInt();
+            if (count < 1) {
+                throw new InvalidObjectException("Invalid count for entry: " + count);
+            }
             map.put(obj, new MutableInteger(count));
             size += count;
         }

--- a/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
@@ -16,13 +16,36 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 import org.apache.commons.collections4.Bag;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractBagTest} for exercising the {@link HashBag}
  * implementation.
  */
 public class HashBagTest<T> extends AbstractBagTest<T> {
+
+    private static void replaceInt(final byte[] bytes, final int from, final int to) {
+        for (int i = 0; i + 4 <= bytes.length; i++) {
+            if (((bytes[i] & 0xFF) << 24 | (bytes[i + 1] & 0xFF) << 16
+                    | (bytes[i + 2] & 0xFF) << 8 | bytes[i + 3] & 0xFF) == from) {
+                bytes[i] = (byte) (to >>> 24);
+                bytes[i + 1] = (byte) (to >>> 16);
+                bytes[i + 2] = (byte) (to >>> 8);
+                bytes[i + 3] = (byte) to;
+                return;
+            }
+        }
+        throw new IllegalStateException("marker not found in stream");
+    }
 
     @Override
     public String getCompatibilityVersion() {
@@ -37,6 +60,26 @@ public class HashBagTest<T> extends AbstractBagTest<T> {
     @Override
     public Bag<T> makeObject() {
         return new HashBag<>();
+    }
+
+    @Test
+    void testDeserializeRejectsNonPositiveCount() throws Exception {
+        final int marker = 0x11223344;
+        final HashBag<String> bag = new HashBag<>();
+        bag.add("X", marker);
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(out)) {
+            oos.writeObject(bag);
+        }
+        for (final int count : new int[] {0, -7}) {
+            final byte[] bytes = out.toByteArray();
+            replaceInt(bytes, marker, count);
+            assertThrows(InvalidObjectException.class, () -> {
+                try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+                    ois.readObject();
+                }
+            });
+        }
     }
 
 //    void testCreate() throws Exception {

--- a/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
@@ -16,13 +16,36 @@
  */
 package org.apache.commons.collections4.multiset;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
 import org.apache.commons.collections4.MultiSet;
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractMultiSetTest} for exercising the
  * {@link HashMultiSet} implementation.
  */
 public class HashMultiSetTest<T> extends AbstractMultiSetTest<T> {
+
+    private static void replaceInt(final byte[] bytes, final int from, final int to) {
+        for (int i = 0; i + 4 <= bytes.length; i++) {
+            if (((bytes[i] & 0xFF) << 24 | (bytes[i + 1] & 0xFF) << 16
+                    | (bytes[i + 2] & 0xFF) << 8 | bytes[i + 3] & 0xFF) == from) {
+                bytes[i] = (byte) (to >>> 24);
+                bytes[i + 1] = (byte) (to >>> 16);
+                bytes[i + 2] = (byte) (to >>> 8);
+                bytes[i + 3] = (byte) to;
+                return;
+            }
+        }
+        throw new IllegalStateException("marker not found in stream");
+    }
 
     @Override
     public String getCompatibilityVersion() {
@@ -37,6 +60,26 @@ public class HashMultiSetTest<T> extends AbstractMultiSetTest<T> {
     @Override
     public MultiSet<T> makeObject() {
         return new HashMultiSet<>();
+    }
+
+    @Test
+    void testDeserializeRejectsNonPositiveCount() throws Exception {
+        final int marker = 0x11223344;
+        final HashMultiSet<String> set = new HashMultiSet<>();
+        set.add("Y", marker);
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(out)) {
+            oos.writeObject(set);
+        }
+        for (final int count : new int[] {0, -7}) {
+            final byte[] bytes = out.toByteArray();
+            replaceInt(bytes, marker, count);
+            assertThrows(InvalidObjectException.class, () -> {
+                try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+                    ois.readObject();
+                }
+            });
+        }
     }
 
 //    void testCreate() throws Exception {


### PR DESCRIPTION
`AbstractMapBag.doReadObject` and `AbstractMapMultiSet.doReadObject` read each entry's `count` with `readInt()` and store it straight into the backing map (`map.put(obj, new MutableInteger(count))`) with no lower bound, unlike the public API where `add` only stores when `nCopies > 0` and `setCount` rejects `count < 0`. Found while auditing the custom `readObject` paths: a serialized `HashBag`/`TreeBag`/`HashMultiSet` whose entry count is patched to `0` or a negative value deserializes into a collection that reports a negative `size()` and `getCount()`, a state unreachable through the API. Both overrides now reject `count < 1` with `InvalidObjectException`, matching `doWriteObject` which only ever writes existing (>= 1) entries. Regression tests added in `HashBagTest` and `HashMultiSetTest`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
