### PR TITLE
Re-validate entries in PredicatedMap/PredicatedCollection readObject

### DIFF
--- a/src/main/java/org/apache/commons/collections4/collection/PredicatedCollection.java
+++ b/src/main/java/org/apache/commons/collections4/collection/PredicatedCollection.java
@@ -421,8 +421,12 @@ public class PredicatedCollection<E> extends AbstractCollectionDecorator<E> {
      */
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        Objects.requireNonNull(decorated(), "collection");
-        Objects.requireNonNull(predicate, "predicate");
+        if (decorated() == null) {
+            throw new InvalidObjectException("Null collection");
+        }
+        if (predicate == null) {
+            throw new InvalidObjectException("Null predicate");
+        }
         try {
             decorated().forEach(this::validate);
         } catch (final IllegalArgumentException ex) {

--- a/src/main/java/org/apache/commons/collections4/collection/PredicatedCollection.java
+++ b/src/main/java/org/apache/commons/collections4/collection/PredicatedCollection.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.collection;
 
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -407,6 +410,22 @@ public class PredicatedCollection<E> extends AbstractCollectionDecorator<E> {
             validate(item);
         }
         return decorated().addAll(coll);
+    }
+
+    /**
+     * Deserializes the collection in using a custom routine.
+     *
+     * @param in  the input stream
+     * @throws IOException if an error occurs while reading from the stream
+     * @throws ClassNotFoundException if an object read from the stream cannot be loaded
+     */
+    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        try {
+            decorated().forEach(this::validate);
+        } catch (final IllegalArgumentException ex) {
+            throw new InvalidObjectException(ex.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/collections4/collection/PredicatedCollection.java
+++ b/src/main/java/org/apache/commons/collections4/collection/PredicatedCollection.java
@@ -421,10 +421,12 @@ public class PredicatedCollection<E> extends AbstractCollectionDecorator<E> {
      */
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
+        Objects.requireNonNull(decorated(), "collection");
+        Objects.requireNonNull(predicate, "predicate");
         try {
             decorated().forEach(this::validate);
         } catch (final IllegalArgumentException ex) {
-            throw new InvalidObjectException(ex.getMessage());
+            throw (InvalidObjectException) new InvalidObjectException(ex.getMessage()).initCause(ex);
         }
     }
 

--- a/src/main/java/org/apache/commons/collections4/map/PredicatedMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/PredicatedMap.java
@@ -22,7 +22,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Map;
-import java.util.Objects;
 
 import org.apache.commons.collections4.Predicate;
 
@@ -156,7 +155,10 @@ public class PredicatedMap<K, V>
     @SuppressWarnings("unchecked") // (1) should only fail if input stream is incorrect
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        map = Objects.requireNonNull((Map<K, V>) in.readObject(), "map"); // (1)
+        map = (Map<K, V>) in.readObject(); // (1)
+        if (map == null) {
+            throw new InvalidObjectException("Null map");
+        }
         try {
             map.forEach(this::validate);
         } catch (final IllegalArgumentException ex) {

--- a/src/main/java/org/apache/commons/collections4/map/PredicatedMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/PredicatedMap.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4.map;
 
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -155,6 +156,11 @@ public class PredicatedMap<K, V>
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
         map = (Map<K, V>) in.readObject(); // (1)
+        try {
+            map.forEach(this::validate);
+        } catch (final IllegalArgumentException ex) {
+            throw new InvalidObjectException(ex.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/collections4/map/PredicatedMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/PredicatedMap.java
@@ -22,6 +22,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.collections4.Predicate;
 
@@ -155,11 +156,11 @@ public class PredicatedMap<K, V>
     @SuppressWarnings("unchecked") // (1) should only fail if input stream is incorrect
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
-        map = (Map<K, V>) in.readObject(); // (1)
+        map = Objects.requireNonNull((Map<K, V>) in.readObject(), "map"); // (1)
         try {
             map.forEach(this::validate);
         } catch (final IllegalArgumentException ex) {
-            throw new InvalidObjectException(ex.getMessage());
+            throw (InvalidObjectException) new InvalidObjectException(ex.getMessage()).initCause(ex);
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/collection/PredicatedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/PredicatedCollectionTest.java
@@ -19,12 +19,18 @@ package org.apache.commons.collections4.collection;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.collections4.Predicate;
+import org.apache.commons.collections4.functors.NotNullPredicate;
 import org.apache.commons.collections4.functors.TruePredicate;
 import org.junit.jupiter.api.Test;
 
@@ -74,6 +80,24 @@ public class PredicatedCollectionTest<E> extends AbstractCollectionTest<E> {
     @Override
     public Collection<E> makeObject() {
         return decorateCollection(new ArrayList<>(), truePredicate);
+    }
+
+    @Test
+    void testDeserializeRejectsElementFailingPredicate() throws Exception {
+        final PredicatedCollection<E> coll = (PredicatedCollection<E>) decorateCollection(
+                new ArrayList<>(), NotNullPredicate.<E>notNullPredicate());
+        // a crafted stream can carry an element that never passed add(); mimic it by
+        // writing one straight into the decorated collection
+        coll.decorated().add(null);
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(out)) {
+            oos.writeObject(coll);
+        }
+        assertThrows(InvalidObjectException.class, () -> {
+            try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+                ois.readObject();
+            }
+        });
     }
 
     public Collection<E> makeTestCollection() {

--- a/src/test/java/org/apache/commons/collections4/map/PredicatedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/PredicatedMapTest.java
@@ -21,12 +21,18 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.Predicate;
+import org.apache.commons.collections4.functors.NotNullPredicate;
 import org.apache.commons.collections4.functors.TruePredicate;
 import org.junit.jupiter.api.Test;
 
@@ -60,6 +66,25 @@ public class PredicatedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
     public IterableMap<K, V> makeTestMap() {
         return decorateMap(new HashMap<>(), testPredicate, testPredicate);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testDeserializeRejectsEntryFailingPredicate() throws Exception {
+        final PredicatedMap<K, V> map = (PredicatedMap<K, V>) decorateMap(new HashMap<>(),
+                NotNullPredicate.notNullPredicate(), null);
+        // a crafted stream can carry an entry that never passed put(); mimic it by
+        // writing one straight into the decorated map
+        map.decorated().put(null, (V) "value");
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(out)) {
+            oos.writeObject(map);
+        }
+        assertThrows(InvalidObjectException.class, () -> {
+            try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+                ois.readObject();
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
`PredicatedMap.readObject` and `PredicatedCollection.readObject` rebuild the decorated map/collection straight from the stream and never re-run the predicate that the constructors apply to every element. A serialized form whose backing data was not produced through `put`/`add` (a tampered or hand-built stream) therefore deserializes into a decorator that holds elements its own predicate rejects. A `PredicatedMap` created with `NotNullPredicate` to forbid null keys, for instance, can be made to contain a null key, and code that trusts the decorator's guarantee then breaks.

I found this while checking the decorators' `readObject` paths against the invariant their constructors enforce (`map.forEach(this::validate)` / the per-element loop).

The fix re-validates each deserialized entry/element against the configured predicate and throws `InvalidObjectException` on a violation, mirroring the constructor. `PredicatedSortedMap` and the `PredicatedList` / `PredicatedSet` / `PredicatedBag` / `PredicatedQueue` / `PredicatedMultiSet` / `PredicatedNavigableSet` decorators inherit the check through these two base classes, so the whole predicated family is covered. The `Transformed*` decorators are intentionally left alone: their stored values are already transformed, so re-running the transformer on read would transform twice.

Existing serialized forms still load (the version-4 compatibility tests pass); only streams carrying predicate-violating data are now rejected.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
