### PR TITLE
[COLLECTIONS-889] Fix non-unique IndexedCollection remove

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -46,6 +46,7 @@
     <action type="fix" dev="ggregory" due-to="Partha Protim Paul" issue="COLLECTIONS-886">[javadoc] CompositeSet.addComposited(Set) does not throw NullPointerException when null is passed #675.</action>
     <action type="fix" dev="ggregory" due-to="Partha Paul, Gary Gregory" issue="COLLECTIONS-887">ConcurrentReferenceHashMap.remove(key), remove(key, value), replace(key, value), and replace(key, oldValue, newValue) throw NullPointerException inconsistently.</action>
     <action type="fix" dev="ggregory" due-to="Marc Carter, Gary Gregory" issue="COLLECTIONS-888">PatriciaTrie incompatible with Java 21 (JEP 431 Sequenced Collections).</action>
+    <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="COLLECTIONS-889">IndexedCollection.remove(Object) removes all values for a non-unique index key.</action>
     <action type="fix" dev="ggregory" due-to="Dexter.k, Gary Gregory">Reject non-positive entry count in bag/multiset doReadObject (#679).</action>
     <action type="fix" dev="ggregory" due-to="Dexter.k, Gary Gregory">Fix most Junit 5 nested tests (#681).</action>
     <action type="fix" dev="ggregory" due-to="Suhyeon Park, Gary Gregory" issue="COLLECTIONS-881">MultiMapUtils.getXXX ensure safe copy (#669).</action>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -46,11 +46,11 @@
     <action type="fix" dev="ggregory" due-to="Partha Protim Paul" issue="COLLECTIONS-886">[javadoc] CompositeSet.addComposited(Set) does not throw NullPointerException when null is passed #675.</action>
     <action type="fix" dev="ggregory" due-to="Partha Paul, Gary Gregory" issue="COLLECTIONS-887">ConcurrentReferenceHashMap.remove(key), remove(key, value), replace(key, value), and replace(key, oldValue, newValue) throw NullPointerException inconsistently.</action>
     <action type="fix" dev="ggregory" due-to="Marc Carter, Gary Gregory" issue="COLLECTIONS-888">PatriciaTrie incompatible with Java 21 (JEP 431 Sequenced Collections).</action>
-    <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="COLLECTIONS-889">IndexedCollection.remove(Object) removes all values for a non-unique index key.</action>
     <action type="fix" dev="ggregory" due-to="Dexter.k, Gary Gregory">Reject non-positive entry count in bag/multiset doReadObject (#679).</action>
     <action type="fix" dev="ggregory" due-to="Dexter.k, Gary Gregory">Fix most Junit 5 nested tests (#681).</action>
     <action type="fix" dev="ggregory" due-to="Suhyeon Park, Gary Gregory" issue="COLLECTIONS-881">MultiMapUtils.getXXX ensure safe copy (#669).</action>
     <action type="fix" dev="ggregory" due-to="Dexter.k, Gary Gregory">Re-validate entries in PredicatedMap/PredicatedCollection readObject (#682).</action>
+    <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="COLLECTIONS-889">IndexedCollection.remove(Object) removes all values for a non-unique index key.</action>
     <!-- ADD -->
     <action type="add" dev="ggregory" due-to="Gary Gregory">Add generics to UnmodifiableIterator for the wrapped type.</action>
     <action type="add" dev="ggregory" due-to="Gary Gregory">Add a Maven benchmark profile for JMH.</action>

--- a/src/main/java/org/apache/commons/collections4/collection/IndexedCollection.java
+++ b/src/main/java/org/apache/commons/collections4/collection/IndexedCollection.java
@@ -235,7 +235,7 @@ public class IndexedCollection<K, C> extends AbstractCollectionDecorator<C> {
      * @param object the object to remove
      */
     private void removeFromIndex(final C object) {
-        index.remove(keyTransformer.apply(object));
+        index.removeMapping(keyTransformer.apply(object), object);
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
@@ -161,12 +161,9 @@ class IndexedCollectionTest extends AbstractCollectionTest<String> {
         final IndexedCollection<Integer, String> indexed = (IndexedCollection<Integer, String>) decorateCollection(new ArrayList<>());
         indexed.add("01");
         indexed.add("1");
-
         indexed.remove("01");
-
         assertEquals("1", indexed.get(1));
         assertNotNull(indexed.values(1));
-        assertEquals(asList("1"), new ArrayList<>(indexed.values(1)));
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.collections4.collection;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -152,6 +153,20 @@ class IndexedCollectionTest extends AbstractCollectionTest<String> {
         assertEquals("1", indexed.get(1));
         assertEquals("2", indexed.get(2));
         assertEquals("3", indexed.get(3));
+    }
+
+    @Test
+    void testRemovePreservesRemainingValuesWithSameTransformedKey() {
+        @SuppressWarnings("unchecked")
+        final IndexedCollection<Integer, String> indexed = (IndexedCollection<Integer, String>) decorateCollection(new ArrayList<>());
+        indexed.add("01");
+        indexed.add("1");
+
+        indexed.remove("01");
+
+        assertEquals("1", indexed.get(1));
+        assertNotNull(indexed.values(1));
+        assertEquals(asList("1"), new ArrayList<>(indexed.values(1)));
     }
 
 }


### PR DESCRIPTION
## Summary

Fix `IndexedCollection.remove(Object)` so non-unique indexes keep remaining values that share the same transformed key.

## Details

Previously, removing one object removed the entire key bucket from the index. For non-unique indexes, this made other collection elements with the same transformed key disappear from indexed lookups even though they were still present in the decorated collection.

This change removes only the matching key/value mapping from the index.

## Tests

- `mvn -q -Dtest=org.apache.commons.collections4.collection.IndexedCollectionTest test`
- `mvn -q`