### PR TITLE
Validate order and uniqueness invariants in decorator readObject()

### DIFF
--- a/src/main/java/org/apache/commons/collections4/list/SetUniqueList.java
+++ b/src/main/java/org/apache/commons/collections4/list/SetUniqueList.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.list;
 
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -425,6 +428,21 @@ public class SetUniqueList<E> extends AbstractSerializableListDecorator<E> {
         final List<E> superSubList = super.subList(fromIndex, toIndex);
         final Set<E> subSet = createSetBasedOnList(set, superSubList);
         return ListUtils.unmodifiableList(new SetUniqueList<>(superSubList, subSet));
+    }
+
+    /**
+     * Deserializes the list and re-checks the no-duplicate invariant the
+     * constructors guarantee.
+     *
+     * @param in  the input stream
+     * @throws IOException if an error occurs while reading from the stream
+     * @throws ClassNotFoundException if a class read from the stream cannot be loaded
+     */
+    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        if (set.size() != size() || !new HashSet<>(decorated()).equals(set)) {
+            throw new InvalidObjectException("Inconsistent SetUniqueList deserialized: backing list does not match the uniqueness set");
+        }
     }
 
 }

--- a/src/main/java/org/apache/commons/collections4/map/ListOrderedMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/ListOrderedMap.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4.map;
 
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -25,6 +26,7 @@ import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -687,6 +689,9 @@ public class ListOrderedMap<K, V>
     private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
         map = (Map<K, V>) in.readObject(); // (1)
+        if (insertOrder.size() != map.size() || !new HashSet<>(insertOrder).equals(map.keySet())) {
+            throw new InvalidObjectException("Inconsistent ListOrderedMap deserialized: key order does not match the map keys");
+        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/collections4/set/ListOrderedSet.java
+++ b/src/main/java/org/apache/commons/collections4/set/ListOrderedSet.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.collections4.set;
 
+import java.io.IOException;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -411,6 +414,21 @@ public class ListOrderedSet<E>
     @Override
     public String toString() {
         return setOrder.toString();
+    }
+
+    /**
+     * Deserializes the set and re-checks that the iteration order matches the
+     * decorated set, as the constructors guarantee.
+     *
+     * @param in  the input stream
+     * @throws IOException if an error occurs while reading from the stream
+     * @throws ClassNotFoundException if a class read from the stream cannot be loaded
+     */
+    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+        if (setOrder.size() != size() || !new HashSet<>(setOrder).equals(decorated())) {
+            throw new InvalidObjectException("Inconsistent ListOrderedSet deserialized: iteration order does not match the set");
+        }
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
@@ -22,6 +22,11 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -99,6 +104,24 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
     @Override
     public List<E> makeObject() {
         return new SetUniqueList<>(new ArrayList<>(), new HashSet<>());
+    }
+
+    @Test
+    void testDeserializeRejectsDuplicateInBackingList() throws Exception {
+        final SetUniqueList<String> list = SetUniqueList.setUniqueList(new ArrayList<>());
+        list.add("alpha");
+        list.add("beta");
+        // push a duplicate straight onto the decorated list, bypassing the uniqueness set
+        list.decorated().add("alpha");
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(out)) {
+            oos.writeObject(list);
+        }
+        assertThrows(InvalidObjectException.class, () -> {
+            try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+                ois.readObject();
+            }
+        });
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/map/ListOrderedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ListOrderedMapTest.java
@@ -21,6 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -164,6 +169,24 @@ public class ListOrderedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
     @Override
     public ListOrderedMap<K, V> makeObject() {
         return ListOrderedMap.listOrderedMap(new HashMap<>());
+    }
+
+    @Test
+    void testDeserializeRejectsKeyOrderMismatch() throws Exception {
+        final ListOrderedMap<String, String> map = new ListOrderedMap<>();
+        map.put("one", "1");
+        map.put("two", "2");
+        // drop a key straight from the backing map; the insert-order list still names it
+        map.decorated().remove("one");
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(out)) {
+            oos.writeObject(map);
+        }
+        assertThrows(InvalidObjectException.class, () -> {
+            try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+                ois.readObject();
+            }
+        });
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/set/ListOrderedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/ListOrderedSetTest.java
@@ -21,6 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -90,6 +95,24 @@ public class ListOrderedSetTest<E>
             set.add((E) Integer.toString(i));
         }
         return set;
+    }
+
+    @Test
+    void testDeserializeRejectsOrderMismatch() throws Exception {
+        final ListOrderedSet<String> set = ListOrderedSet.listOrderedSet(new HashSet<>());
+        set.add("red");
+        set.add("green");
+        // remove an element from the decorated set only; the order list keeps naming it
+        set.decorated().remove("red");
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(out)) {
+            oos.writeObject(set);
+        }
+        assertThrows(InvalidObjectException.class, () -> {
+            try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+                ois.readObject();
+            }
+        });
     }
 
     @Test


### PR DESCRIPTION
`readObject` in `ListOrderedMap`, `ListOrderedSet` and `SetUniqueList` restores the backing collection and the parallel structure that records iteration order / enforces uniqueness (`insertOrder`, `setOrder`, and the dedup `set`) as two independent stream fields and never checks the two agree, unlike the constructors which derive the order/dedup structure from the backing collection so they always match. Found while auditing the custom `readObject` paths against the invariant the constructors hold: a tampered or hand-built stream whose two fields disagree deserializes into a decorator whose state is impossible through the API. A `SetUniqueList` can be made to hold duplicates in its backing list, and a `ListOrderedMap`/`ListOrderedSet` can be made to carry an order list that names keys/elements absent from the backing collection (or repeats one), so `keyList()`/iteration surface phantom or duplicate entries while `size()` reports the backing count. Each `readObject` now re-checks that the order/dedup structure is a duplicate-free match for the backing collection and throws `InvalidObjectException` otherwise, mirroring the constructor contract. Existing serialized forms still load (the version-4 compatibility tests pass); only streams carrying inconsistent data are rejected. Regression tests added in `ListOrderedMapTest`, `ListOrderedSetTest` and `SetUniqueListTest`.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
