### PR TITLE
[COLLECTIONS-891] Fix IndexedCollection contains equality

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -52,6 +52,7 @@
     <action type="fix" dev="ggregory" due-to="Dexter.k, Gary Gregory">Re-validate entries in PredicatedMap/PredicatedCollection readObject (#682).</action>
     <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="COLLECTIONS-889">IndexedCollection.remove(Object) removes all values for a non-unique index key.</action>
     <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="COLLECTIONS-890">TransformIterator throws NullPointerException when its transformer is null.</action>
+    <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="COLLECTIONS-891">IndexedCollection.contains(Object) can return true for objects that were never added.</action>
     <action type="fix" dev="ggregory" due-to="Maxim Safronov, Gary Gregory" issue="COLLECTIONS-878">MapUtils.invertMap() improves HashMap construction (#652).</action>
     <action type="fix" dev="ggregory" due-to="Dexter.k, Gary Gregory">Validate order and uniqueness invariants in decorator readObject() (#684).</action>
     <!-- ADD -->

--- a/src/main/java/org/apache/commons/collections4/collection/IndexedCollection.java
+++ b/src/main/java/org/apache/commons/collections4/collection/IndexedCollection.java
@@ -159,7 +159,8 @@ public class IndexedCollection<K, C> extends AbstractCollectionDecorator<C> {
     @SuppressWarnings("unchecked")
     @Override
     public boolean contains(final Object object) {
-        return index.containsKey(keyTransformer.apply((C) object));
+        final Collection<C> values = (Collection<C>) index.get(keyTransformer.apply((C) object));
+        return values != null && values.contains(object);
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.collections4.collection;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -114,6 +115,22 @@ class IndexedCollectionTest extends AbstractCollectionTest<String> {
         assertEquals("2", indexed.get(2));
         assertEquals("3", indexed.get(3));
         assertEquals("4", indexed.get(4));
+    }
+
+    @Test
+    void testContainsUsesObjectEqualityNotOnlyTransformedKey() {
+        final Collection<String> coll = makeUniqueTestCollection();
+        coll.add("01");
+
+        assertFalse(coll.contains("1"));
+    }
+
+    @Test
+    void testContainsUsesObjectEqualityWithNonUniqueIndex() {
+        final Collection<String> coll = makeTestCollection();
+        coll.add("01");
+
+        assertFalse(coll.contains("1"));
     }
 
     @Test


### PR DESCRIPTION
[COLLECTIONS-891] Fix IndexedCollection contains equality

IndexedCollection#contains(Object) used the transformed key only, so it could return true for an object that was never added when another object mapped to the same key.

This change keeps the indexed lookup as a fast candidate filter, then checks object equality within the indexed values before returning true.

Tests cover both unique and non-unique indexed collections where "01" and "1" map to the same key but are not equal objects.

Tests run:
- mvn -q -Dtest=org.apache.commons.collections4.collection.IndexedCollectionTest#testContainsUsesObjectEqualityNotOnlyTransformedKey test
- mvn -q -Dtest=org.apache.commons.collections4.collection.IndexedCollectionTest#testContainsUsesObjectEqualityWithNonUniqueIndex test
- mvn -q -Dtest=org.apache.commons.collections4.collection.IndexedCollectionTest test
- mvn -q