### PR TITLE
[COLLECTIONS-892] Fix unique IndexedCollection add atomicity

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -52,6 +52,7 @@
     <action type="fix" dev="ggregory" due-to="Dexter.k, Gary Gregory">Re-validate entries in PredicatedMap/PredicatedCollection readObject (#682).</action>
     <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="COLLECTIONS-889">IndexedCollection.remove(Object) removes all values for a non-unique index key.</action>
     <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="COLLECTIONS-890">TransformIterator throws NullPointerException when its transformer is null.</action>
+    <action type="fix" dev="ggregory" due-to="Ruiqi Dong, Gary Gregory" issue="COLLECTIONS-892">IndexedCollection.add(Object) mutates unique indexed collections before rejecting duplicate keys.</action>
     <action type="fix" dev="ggregory" due-to="Maxim Safronov, Gary Gregory" issue="COLLECTIONS-878">MapUtils.invertMap() improves HashMap construction (#652).</action>
     <action type="fix" dev="ggregory" due-to="Dexter.k, Gary Gregory">Validate order and uniqueness invariants in decorator readObject() (#684).</action>
     <!-- ADD -->

--- a/src/main/java/org/apache/commons/collections4/collection/IndexedCollection.java
+++ b/src/main/java/org/apache/commons/collections4/collection/IndexedCollection.java
@@ -113,6 +113,17 @@ public class IndexedCollection<K, C> extends AbstractCollectionDecorator<C> {
      */
     @Override
     public boolean add(final C object) {
+        if (uniqueIndex) {
+            final K key = keyTransformer.apply(object);
+            if (index.containsKey(key)) {
+                throw new IllegalArgumentException("Duplicate key in uniquely indexed collection.");
+            }
+            final boolean added = super.add(object);
+            if (added) {
+                index.put(key, object);
+            }
+            return added;
+        }
         final boolean added = super.add(object);
         if (added) {
             addToIndex(object);

--- a/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
@@ -136,6 +136,17 @@ class IndexedCollectionTest extends AbstractCollectionTest<String> {
     }
 
     @Test
+    void testFailedUniqueAddDoesNotPolluteDecoratedCollection() {
+        final IndexedCollection<Integer, String> indexed = decorateUniqueCollection(new ArrayList<>());
+        indexed.add("01");
+
+        assertThrows(IllegalArgumentException.class, () -> indexed.add("1"));
+        assertEquals(1, indexed.size());
+        assertEquals(asList("01"), new ArrayList<>(indexed));
+        assertEquals("01", indexed.get(1));
+    }
+
+    @Test
     void testReindexUpdatesIndexWhenDecoratedCollectionIsModifiedSeparately() throws Exception {
         final Collection<String> original = new ArrayList<>();
         final IndexedCollection<Integer, String> indexed = decorateUniqueCollection(original);


### PR DESCRIPTION
[COLLECTIONS-892] Fix unique IndexedCollection add atomicity

IndexedCollection#add(Object) updated the decorated collection before checking the unique index constraint. If a duplicate transformed key was rejected, the exception was thrown after the decorated collection had already been mutated, leaving the collection and index out of sync.

This change checks duplicate keys before mutating the decorated collection for unique indexed collections. Non-unique indexed collections keep the existing add path.

Tests cover a failed unique add where "01" and "1" map to the same key, and verify that the decorated collection and index still contain only the original value.

Tests run:
- mvn -q -Dtest=org.apache.commons.collections4.collection.IndexedCollectionTest#testFailedUniqueAddDoesNotPolluteDecoratedCollection test
- mvn -q -Dtest=org.apache.commons.collections4.collection.IndexedCollectionTest test
- mvn -q
- git diff --check