### PR TITLE
[COLLECTIONS-884] Fix JUnit 5 test discovery for Map EntrySet and Values views

### DIFF
--- a/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
@@ -1316,7 +1316,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
      *  raise <code>UnsupportedOperationException.
      */
     @Test
-    void testUnsupportedAdd() {
+    public void testUnsupportedAdd() {
         if (isAddSupported()) {
             return;
         }
@@ -1353,7 +1353,7 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
      *  operations raise an UnsupportedOperationException.
      */
     @Test
-    void testUnsupportedRemove() {
+    public void testUnsupportedRemove() {
         if (isRemoveSupported()) {
             return;
         }

--- a/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
@@ -139,7 +139,8 @@ import org.junit.jupiter.api.Test;
  */
 public abstract class AbstractMapTest<M extends Map<K, V>, K, V> extends AbstractObjectTest {
 
-    public abstract class MapEntrySetTest extends AbstractSetTest<Map.Entry<K, V>> {
+    @Nested
+    public class MapEntrySetTest extends AbstractSetTest<Map.Entry<K, V>> {
 
         @Override
         public boolean areEqualElementsDistinguishable() {
@@ -401,7 +402,8 @@ public abstract class AbstractMapTest<M extends Map<K, V>, K, V> extends Abstrac
     // to the confirmed, that the already-constructed collection views
     // are still equal to the confirmed's collection views.
 
-    public abstract class MapValuesTest extends AbstractCollectionTest<V> {
+    @Nested
+    public class MapValuesTest extends AbstractCollectionTest<V> {
 
         @Override
         public boolean areEqualElementsDistinguishable() {
@@ -556,8 +558,7 @@ public abstract class AbstractMapTest<M extends Map<K, V>, K, V> extends Abstrac
      * @return a {@link AbstractSetTest} instance for testing the map's entry set
      */
     public BulkTest bulkTestMapEntrySet() {
-        return new MapEntrySetTest() {
-        };
+        return new MapEntrySetTest();
     }
 
     /**
@@ -577,8 +578,7 @@ public abstract class AbstractMapTest<M extends Map<K, V>, K, V> extends Abstrac
      * @return a {@link AbstractCollectionTest} instance for testing the map's values collection
      */
     public BulkTest bulkTestMapValues() {
-        return new MapValuesTest() {
-        };
+        return new MapValuesTest();
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/map/CompositeMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/CompositeMapTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -35,6 +36,17 @@ import org.junit.jupiter.api.Test;
  * @param <V> the value type.
  */
 public class CompositeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
+
+    @Nested
+    public class MapValuesTest extends AbstractMapTest.MapValuesTest {
+        @Test
+        @Override
+        public void testUnsupportedRemove() {
+            resetFull();
+            assertThrows(UnsupportedOperationException.class, () -> getCollection().remove(null));
+            verify();
+        }
+    }
 
     /** Used as a flag in MapMutator tests */
     private boolean pass;

--- a/src/test/java/org/apache/commons/collections4/map/ConcurrentHashMapSanityTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ConcurrentHashMapSanityTest.java
@@ -19,6 +19,9 @@ package org.apache.commons.collections4.map;
 
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 /**
  * A sanity test for the test framework.
  *
@@ -42,17 +45,23 @@ public class ConcurrentHashMapSanityTest<K, V> extends AbstractMapTest<Concurren
         return false;
     }
 
-    @Override
-    public boolean isEntrySetAddSupported() {
-        return true;
-    }
-
     /**
      * Don't test, just a sanity check for the test framework.
      */
     @Override
     public boolean isTestSerialization() {
         return false;
+    }
+
+    @Nested
+    public class MapEntrySetTest extends AbstractMapTest.MapEntrySetTest {
+        @Test
+        @Override
+        public void testUnsupportedAdd() {
+            resetEmpty();
+            // ConcurrentHashMap.entrySet() supports add.
+            getCollection().add(getFullNonNullElements()[0]);
+        }
     }
 
     @Override


### PR DESCRIPTION
Restore test coverage for Map entrySet and values views that was dropped during the JUnit 5 migration.

### Changes
* Convert `MapEntrySetTest` and `MapValuesTest` in `AbstractMapTest` to concrete classes annotated with `@Nested` so they are discovered and executed by JUnit 5.
* Update `bulkTestMapEntrySet` and `bulkTestMapValues` to return direct instances.
* Modify visibility of `testUnsupportedRemove` and `testUnsupportedAdd` in `AbstractCollectionTest` from package-private to `public` to allow package-cross overrides.
* Shadow `MapValuesTest` in `CompositeMapTest` to override `testUnsupportedRemove` due to `CompositeCollection` custom removal behavior.
* Remove incorrect `isEntrySetAddSupported` override in `ConcurrentHashMapSanityTest` and shadow `MapEntrySetTest` to bypass `testUnsupportedAdd` since `ConcurrentHashMap.entrySet().add()` is supported in standard Java.