### PR TITLE
Reject non-positive maxSize in LRUMap.doReadObject()

### DIFF
--- a/src/main/java/org/apache/commons/collections4/map/LRUMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/LRUMap.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4.map;
 
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -297,6 +298,9 @@ public class LRUMap<K, V>
     @Override
     protected void doReadObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         maxSize = in.readInt();
+        if (maxSize < 1) {
+            throw new InvalidObjectException("LRUMap max size must be greater than 0");
+        }
         super.doReadObject(in);
     }
 

--- a/src/test/java/org/apache/commons/collections4/map/LRUMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LRUMapTest.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.InvalidObjectException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -308,6 +310,18 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
         assertThrows(IllegalArgumentException.class, () -> new LRUMap<K, V>(10, 12), "initialSize must not be larger than maxSize");
         assertThrows(IllegalArgumentException.class, () -> new LRUMap<K, V>(10, -1, 0.75f, false), "initialSize must not be negative");
         assertThrows(IllegalArgumentException.class, () -> new LRUMap<K, V>(10, 12, 0.75f, false), "initialSize must not be larger than maxSize");
+    }
+
+    @Test
+    void testDeserializeRejectsNonPositiveMaxSize() throws Exception {
+        final LRUMap<String, String> map = new LRUMap<>(3);
+        map.put("a", "1");
+        final Field maxSizeField = LRUMap.class.getDeclaredField("maxSize");
+        maxSizeField.setAccessible(true);
+        for (final int maxSize : new int[] {0, -7}) {
+            maxSizeField.setInt(map, maxSize);
+            assertThrows(InvalidObjectException.class, () -> serializeDeserialize(map));
+        }
     }
 
     @Test


### PR DESCRIPTION
found auditing the map package readObject paths: `LRUMap.doReadObject` reads `maxSize` with `readInt()` but skips the constructor's `maxSize >= 1` check, so a crafted stream yields a map with a non-positive bound that no constructor allows and that corrupts the eviction linked list on the next `put`; this re-applies the check and throws `InvalidObjectException`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
