### PR TITLE
Reject invalid load factor in hashed/reference map doReadObject

### DIFF
--- a/src/main/java/org/apache/commons/collections4/map/AbstractHashedMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/AbstractHashedMap.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4.map;
 
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.AbstractCollection;
@@ -943,6 +944,9 @@ public class AbstractHashedMap<K, V> extends AbstractMap<K, V> implements Iterab
     @SuppressWarnings("unchecked")
     protected void doReadObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
         loadFactor = in.readFloat();
+        if (loadFactor <= 0.0f || Float.isNaN(loadFactor)) {
+            throw new InvalidObjectException("Load factor must be greater than 0");
+        }
         final int capacity = in.readInt();
         final int size = in.readInt();
         init();

--- a/src/main/java/org/apache/commons/collections4/map/AbstractReferenceMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/AbstractReferenceMap.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4.map;
 
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.ref.Reference;
@@ -823,6 +824,9 @@ public abstract class AbstractReferenceMap<K, V> extends AbstractHashedMap<K, V>
         valueType = ReferenceStrength.resolve(in.readInt());
         purgeValues = in.readBoolean();
         loadFactor = in.readFloat();
+        if (loadFactor <= 0.0f || Float.isNaN(loadFactor)) {
+            throw new InvalidObjectException("Load factor must be greater than 0");
+        }
         final int capacity = in.readInt();
         init();
         data = new HashEntry[capacity];

--- a/src/test/java/org/apache/commons/collections4/map/CaseInsensitiveMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/CaseInsensitiveMapTest.java
@@ -18,8 +18,10 @@ package org.apache.commons.collections4.map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.InvalidObjectException;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -27,6 +29,8 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for the {@link CaseInsensitiveMap} implementation.
@@ -44,6 +48,18 @@ public class CaseInsensitiveMapTest<K, V> extends AbstractIterableMapTest<K, V> 
     @Override
     public CaseInsensitiveMap<K, V> makeObject() {
         return new CaseInsensitiveMap<>();
+    }
+
+    /**
+     * A crafted stream can carry a load factor the constructor rejects. AbstractHashedMap.doReadObject
+     * must reapply that contract on read.
+     */
+    @ParameterizedTest
+    @ValueSource(floats = {0.0f, -1.0f, Float.NaN})
+    void testDeserializeRejectsInvalidLoadFactor(final float badLoadFactor) {
+        final CaseInsensitiveMap<K, V> map = new CaseInsensitiveMap<>();
+        map.loadFactor = badLoadFactor;
+        assertThrows(InvalidObjectException.class, () -> serializeDeserialize(map));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/map/HashedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/HashedMapTest.java
@@ -92,18 +92,14 @@ public class HashedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
     }
 
     /**
-     * A crafted stream can carry a load factor the constructor rejects. AbstractHashedMap and
-     * AbstractReferenceMap (its own doReadObject override) must reapply that contract on read.
+     * A crafted stream can carry a load factor the constructor rejects. AbstractHashedMap.doReadObject
+     * must reapply that contract on read.
      */
     @ParameterizedTest
     @ValueSource(floats = {0.0f, -1.0f, Float.NaN})
     void testDeserializeRejectsInvalidLoadFactor(final float badLoadFactor) {
-        final HashedMap<K, V> hashed = new HashedMap<>();
-        hashed.loadFactor = badLoadFactor;
-        assertThrows(InvalidObjectException.class, () -> serializeDeserialize(hashed));
-
-        final ReferenceMap<K, V> reference = new ReferenceMap<>();
-        reference.loadFactor = badLoadFactor;
-        assertThrows(InvalidObjectException.class, () -> serializeDeserialize(reference));
+        final HashedMap<K, V> map = new HashedMap<>();
+        map.loadFactor = badLoadFactor;
+        assertThrows(InvalidObjectException.class, () -> serializeDeserialize(map));
     }
 }

--- a/src/test/java/org/apache/commons/collections4/map/HashedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/HashedMapTest.java
@@ -23,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.InvalidObjectException;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * JUnit tests.
@@ -93,16 +95,15 @@ public class HashedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
      * A crafted stream can carry a load factor the constructor rejects. AbstractHashedMap and
      * AbstractReferenceMap (its own doReadObject override) must reapply that contract on read.
      */
-    @Test
-    void testDeserializeRejectsInvalidLoadFactor() {
-        for (final float bad : new float[] {0.0f, -1.0f, Float.NaN}) {
-            final HashedMap<K, V> hashed = new HashedMap<>();
-            hashed.loadFactor = bad;
-            assertThrows(InvalidObjectException.class, () -> serializeDeserialize(hashed));
+    @ParameterizedTest
+    @ValueSource(floats = {0.0f, -1.0f, Float.NaN})
+    void testDeserializeRejectsInvalidLoadFactor(final float badLoadFactor) {
+        final HashedMap<K, V> hashed = new HashedMap<>();
+        hashed.loadFactor = badLoadFactor;
+        assertThrows(InvalidObjectException.class, () -> serializeDeserialize(hashed));
 
-            final ReferenceMap<K, V> reference = new ReferenceMap<>();
-            reference.loadFactor = bad;
-            assertThrows(InvalidObjectException.class, () -> serializeDeserialize(reference));
-        }
+        final ReferenceMap<K, V> reference = new ReferenceMap<>();
+        reference.loadFactor = badLoadFactor;
+        assertThrows(InvalidObjectException.class, () -> serializeDeserialize(reference));
     }
 }

--- a/src/test/java/org/apache/commons/collections4/map/HashedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/HashedMapTest.java
@@ -18,6 +18,9 @@ package org.apache.commons.collections4.map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.InvalidObjectException;
 
 import org.junit.jupiter.api.Test;
 
@@ -84,5 +87,22 @@ public class HashedMapTest<K, V> extends AbstractIterableMapTest<K, V> {
         map.putAll(tmpMap);
         // the threshold has changed due to calling ensureCapacity
         assertEquals(96, map.threshold);
+    }
+
+    /**
+     * A crafted stream can carry a load factor the constructor rejects. AbstractHashedMap and
+     * AbstractReferenceMap (its own doReadObject override) must reapply that contract on read.
+     */
+    @Test
+    void testDeserializeRejectsInvalidLoadFactor() {
+        for (final float bad : new float[] {0.0f, -1.0f, Float.NaN}) {
+            final HashedMap<K, V> hashed = new HashedMap<>();
+            hashed.loadFactor = bad;
+            assertThrows(InvalidObjectException.class, () -> serializeDeserialize(hashed));
+
+            final ReferenceMap<K, V> reference = new ReferenceMap<>();
+            reference.loadFactor = bad;
+            assertThrows(InvalidObjectException.class, () -> serializeDeserialize(reference));
+        }
     }
 }

--- a/src/test/java/org/apache/commons/collections4/map/LRUMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LRUMapTest.java
@@ -37,6 +37,8 @@ import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.ResettableIterator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * JUnit tests.
@@ -165,6 +167,18 @@ public class LRUMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
     @Override
     public LRUMap<K, V> makeObject() {
         return new LRUMap<>();
+    }
+
+    /**
+     * A crafted stream can carry a load factor the constructor rejects. AbstractHashedMap.doReadObject
+     * must reapply that contract on read.
+     */
+    @ParameterizedTest
+    @ValueSource(floats = {0.0f, -1.0f, Float.NaN})
+    void testDeserializeRejectsInvalidLoadFactor(final float badLoadFactor) {
+        final LRUMap<K, V> map = new LRUMap<>();
+        map.loadFactor = badLoadFactor;
+        assertThrows(InvalidObjectException.class, () -> serializeDeserialize(map));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/map/LinkedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/LinkedMapTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.InvalidObjectException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -33,6 +34,8 @@ import org.apache.commons.collections4.ResettableIterator;
 import org.apache.commons.collections4.list.AbstractListTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * JUnit tests.
@@ -114,6 +117,18 @@ public class LinkedMapTest<K, V> extends AbstractOrderedMapTest<K, V> {
     @Override
     public LinkedMap<K, V> makeObject() {
         return new LinkedMap<>();
+    }
+
+    /**
+     * A crafted stream can carry a load factor the constructor rejects. AbstractHashedMap.doReadObject
+     * must reapply that contract on read.
+     */
+    @ParameterizedTest
+    @ValueSource(floats = {0.0f, -1.0f, Float.NaN})
+    void testDeserializeRejectsInvalidLoadFactor(final float badLoadFactor) {
+        final LinkedMap<K, V> map = new LinkedMap<>();
+        map.loadFactor = badLoadFactor;
+        assertThrows(InvalidObjectException.class, () -> serializeDeserialize(map));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/map/ReferenceIdentityMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ReferenceIdentityMapTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.InvalidObjectException;
 import java.lang.ref.WeakReference;
 import java.util.Iterator;
 import java.util.Map;
@@ -32,6 +33,8 @@ import java.util.Map;
 import org.apache.commons.collections4.IterableMap;
 import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for ReferenceIdentityMap.
@@ -233,6 +236,18 @@ public class ReferenceIdentityMapTest<K, V> extends AbstractIterableMapTest<K, V
     @Override
     public ReferenceIdentityMap<K, V> makeObject() {
         return new ReferenceIdentityMap<>(ReferenceStrength.WEAK, ReferenceStrength.WEAK);
+    }
+
+    /**
+     * A crafted stream can carry a load factor the constructor rejects. AbstractReferenceMap.doReadObject
+     * (its own override) must reapply that contract on read.
+     */
+    @ParameterizedTest
+    @ValueSource(floats = {0.0f, -1.0f, Float.NaN})
+    void testDeserializeRejectsInvalidLoadFactor(final float badLoadFactor) {
+        final ReferenceIdentityMap<K, V> map = new ReferenceIdentityMap<>();
+        map.loadFactor = badLoadFactor;
+        assertThrows(InvalidObjectException.class, () -> serializeDeserialize(map));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/map/ReferenceMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/ReferenceMapTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
@@ -41,6 +42,8 @@ import org.apache.commons.collections4.map.AbstractHashedMap.HashEntry;
 import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceEntry;
 import org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceStrength;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for ReferenceMap.
@@ -307,6 +310,18 @@ public class ReferenceMapTest<K, V> extends AbstractIterableMapTest<K, V> {
             assertEquals(serializeMap.data.length, deserializedMap.data.length);
         }
 
+    }
+
+    /**
+     * A crafted stream can carry a load factor the constructor rejects. AbstractReferenceMap.doReadObject
+     * (its own override) must reapply that contract on read.
+     */
+    @ParameterizedTest
+    @ValueSource(floats = {0.0f, -1.0f, Float.NaN})
+    void testDeserializeRejectsInvalidLoadFactor(final float badLoadFactor) {
+        final ReferenceMap<K, V> map = new ReferenceMap<>();
+        map.loadFactor = badLoadFactor;
+        assertThrows(InvalidObjectException.class, () -> serializeDeserialize(map));
     }
 
     /**


### PR DESCRIPTION
found auditing the map package deserialization paths: the `AbstractHashedMap` and `AbstractReferenceMap` constructors reject a `loadFactor` that is non-positive or `NaN`, but their `doReadObject` overrides read it straight from the stream, so a crafted serialized map deserializes with a `loadFactor` no constructor allows and a `threshold` of 0 that makes `checkCapacity` resize the bucket array on every `put` (a 12-entry map grows its backing array from 16 to 65536); this re-applies the check in both methods (`AbstractReferenceMap` does not call `super.doReadObject`) and throws `InvalidObjectException`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
