### PR TITLE
Fix AbstractMapBag.retainAll removing all copies when the other bag has more

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bag/AbstractMapBag.java
+++ b/src/main/java/org/apache/commons/collections4/bag/AbstractMapBag.java
@@ -497,7 +497,7 @@ public abstract class AbstractMapBag<E> implements Bag<E> {
             final int otherCount = other.getCount(current);
             if (1 <= otherCount && otherCount <= myCount) {
                 excess.add(current, myCount - otherCount);
-            } else {
+            } else if (otherCount == 0) {
                 excess.add(current, myCount);
             }
         }

--- a/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
@@ -720,7 +720,6 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         if (!isAddSupported()) {
             return;
         }
-
         final Bag<T> bag = makeObject();
         bag.add((T) "A", 2);
         bag.add((T) "B", 3);

--- a/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/AbstractBagTest.java
@@ -713,4 +713,24 @@ public abstract class AbstractBagTest<T> extends AbstractCollectionTest<T> {
         }
     }
 
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testBagRetainAllOtherHasMoreCopies() {
+        if (!isAddSupported()) {
+            return;
+        }
+
+        final Bag<T> bag = makeObject();
+        bag.add((T) "A", 2);
+        bag.add((T) "B", 3);
+        final Bag<T> other = makeObject();
+        other.add((T) "A", 5);
+        other.add((T) "B", 10);
+        bag.retainAll(other);
+        // When other has MORE copies, we should keep ALL of ours (the intersection keeps min)
+        assertEquals(2, bag.getCount("A"), "Should keep 2 copies of A when other has 5");
+        assertEquals(3, bag.getCount("B"), "Should keep 3 copies of B when other has 10");
+        assertEquals(5, bag.size(), "Should have 5 total items");
+    }
 }


### PR DESCRIPTION
## Problem

`AbstractMapBag.retainAll(Bag)` should keep, for each element, the minimum of this bags cardinality and the other bags cardinality. The current logic:

```java
final int myCount = getCount(current);
final int otherCount = other.getCount(current);
if (1 <= otherCount && otherCount <= myCount) {
    excess.add(current, myCount - otherCount);
} else {
    excess.add(current, myCount);   // removes ALL copies
}
```

The `else` branch removes all copies of an element whenever the guarded case (`1 <= otherCount <= myCount`) does not apply. That branch also covers `otherCount > myCount`, so when the other bag contains **more** copies than this bag, every copy is removed instead of all being kept.

Example: `bag{A:2, B:3}.retainAll(other{A:5, B:10})` empties the bag, when it should leave it unchanged (the retained count is `min(2,5)=2` and `min(3,10)=3`).

## Fix

Only remove all copies when `otherCount == 0`. When `otherCount > myCount`, no copies are removed, leaving this bags cardinality intact.

## Test

Adds `testBagRetainAllOtherHasMoreCopies` to `AbstractBagTest`, so it runs against every `Bag` implementation. It fails on `master` (`expected: <2> but was: <0>`) and passes with this change; the existing `HashBagTest` suite (51 tests, including `testBagRetainAll`) stays green.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
