### PR TITLE
Fix integer overflow in SetOperations.cosineSimilarity

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bloomfilter/SetOperations.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/SetOperations.java
@@ -100,7 +100,7 @@ public final class SetOperations {
         final int numerator = andCardinality(first, second);
         // Given that the cardinality is an int then the product as a double will not
         // overflow, we can use one sqrt:
-        return numerator == 0 ? 0 : numerator / Math.sqrt(cardinality(first) * cardinality(second));
+        return numerator == 0 ? 0 : numerator / Math.sqrt((double) cardinality(first) * cardinality(second));
     }
 
     /**
@@ -123,7 +123,7 @@ public final class SetOperations {
         final int numerator = andCardinality(first, second);
         // Given that the cardinality is an int then the product as a double will not
         // overflow, we can use one sqrt:
-        return numerator == 0 ? 0 : numerator / Math.sqrt(first.cardinality() * second.cardinality());
+        return numerator == 0 ? 0 : numerator / Math.sqrt((double) first.cardinality() * second.cardinality());
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/bloomfilter/SetOperationsTest.java
+++ b/src/test/java/org/apache/commons/collections4/bloomfilter/SetOperationsTest.java
@@ -324,4 +324,30 @@ class SetOperationsTest {
         filter2 = createFilter(shape2, IndexExtractor.fromIndexArray(5, 64, 169));
         assertSymmetricOperation(3, SetOperations::xorCardinality, filter1, filter2);
     }
+
+    @Test
+    final void testCosineSimilarityLargeCardinalityNoOverflow() {
+        // Create two identical BitMapExtractors with cardinality > 46341 each.
+        // Each long has 64 bits. We want cardinality = 50000.
+        // 781 * 64 = 49984, plus 16 more bits = 50000.
+        final long[] bitMaps = new long[782];
+        for (int i = 0; i < 781; i++) {
+            bitMaps[i] = -1L; // all 64 bits set
+        }
+        // Last word: 16 bits set = 0xFFFF
+        bitMaps[781] = 0xFFFFL;
+
+        final BitMapExtractor extractor = BitMapExtractor.fromBitMapArray(bitMaps);
+        // Verify cardinality is 50000
+        assertEquals(50000, SetOperations.cardinality(extractor));
+
+        // Cosine similarity of two identical non-empty extractors should be 1.0.
+        // With integer overflow: 50000 * 50000 = 2,500,000,000 > Integer.MAX_VALUE, overflows to negative,
+        // Math.sqrt(negative) = NaN, so the result would be NaN instead of 1.0.
+        final double similarity = SetOperations.cosineSimilarity(extractor, extractor);
+        assertEquals(1.0, similarity, 1e-9, "cosineSimilarity of identical large-cardinality extractors should be 1.0, not NaN");
+
+        final double distance = SetOperations.cosineDistance(extractor, extractor);
+        assertEquals(0.0, distance, 1e-9, "cosineDistance of identical large-cardinality extractors should be 0.0, not NaN");
+    }
 }


### PR DESCRIPTION
## Problem

`SetOperations.cosineSimilarity` computes the product of the two cardinalities as an `int` before passing it to `Math.sqrt`:

```java
// Given that the cardinality is an int then the product as a double will not
// overflow, we can use one sqrt:
return numerator == 0 ? 0 : numerator / Math.sqrt(cardinality(first) * cardinality(second));
```

The comment states the product is meant to be computed as a `double` so it will not overflow, but without a cast the multiplication happens in `int`. For large inputs (each cardinality > 46341) the product exceeds `Integer.MAX_VALUE` and wraps to a negative value, so `Math.sqrt` returns `NaN` and both `cosineSimilarity` and `cosineDistance` become `NaN`.

For example, two identical extractors of cardinality 50000 give `50000 * 50000 = 2_500_000_000`, which overflows to a negative `int`; the similarity should be `1.0` but is `NaN`.

## Fix

Cast the first operand to `double` so the product is computed in `double`, as the comment already intended. Both the `BitMapExtractor` and `BloomFilter` overloads had the same issue and are fixed.

## Test

Adds `testCosineSimilarityLargeCardinalityNoOverflow` to `SetOperationsTest`, building extractors with cardinality 50000 and asserting `cosineSimilarity == 1.0` / `cosineDistance == 0.0`. It fails on `master` (`expected: <1.0> but was: <NaN>`) and passes with this change; the existing `SetOperationsTest` suite stays green.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
