### PR TITLE
Document non-atomic merge semantics for BloomFilter

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -24,6 +24,7 @@
   <body>
   <release version="4.6.0" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
     <!-- FIX -->
+    <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">[javadoc] Document that BloomFilter merge operations are non-atomic and a filter that throws during a merge should be considered invalid.</action>
     <action type="fix" dev="ggregory" due-to="Gary Gregory">org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceEntry.toReference(ReferenceStrength, T, int) now throws IllegalArgumentException instead of Error.</action>
     <action type="fix" dev="ggregory" due-to="Eric Hubert, Gary Gregory">Remove deprecation annotation of org.apache.commons.collections4.Factory; this will be deprecated in 5.0 in favor of java.util.function.Supplier.</action>
     <action type="fix" dev="ggregory" due-to="Eric Hubert, Gary Gregory">Remove deprecation annotation of org.apache.commons.collections4.Predicate; this will be deprecated in 5.0 in favor of java.util.function.Predicate.</action>

--- a/src/main/java/org/apache/commons/collections4/bloomfilter/BloomFilter.java
+++ b/src/main/java/org/apache/commons/collections4/bloomfilter/BloomFilter.java
@@ -23,6 +23,13 @@ import java.util.Objects;
  * <p>
  * <em>See implementation notes for {@link BitMapExtractor} and {@link IndexExtractor}.</em>
  * </p>
+ * <p>
+ * The {@code merge} operations enable bit indexes one at a time and are not atomic. If an index is out of
+ * range an {@link IllegalArgumentException} is raised, but indexes processed before the bad one may already
+ * have been enabled. By design the filter is not rolled back: such an exception signals misuse with bad
+ * indexes and must not be ignored. A filter that throws during a merge should be considered invalid, since
+ * it may hold bits that do not correspond to any valid hashed value.
+ * </p>
  *
  * @param <T> The BloomFilter type.
  * @see BitMapExtractor


### PR DESCRIPTION
Per the discussion, dropped the per-index guard and documented the merge contract on the `BloomFilter` interface instead. A merge enables indexes one at a time and is not atomic, so an out-of-range index throws after earlier indexes are already set, and a filter that throws during a merge should be treated as invalid. Reverted the `SparseBloomFilter` change and its test, so only the Javadoc and a changes.xml note remain.