### PR TITLE
Do not mutate the input map in SwitchTransformer.switchTransformer

### DIFF
--- a/src/main/java/org/apache/commons/collections4/functors/SwitchTransformer.java
+++ b/src/main/java/org/apache/commons/collections4/functors/SwitchTransformer.java
@@ -17,6 +17,7 @@
 package org.apache.commons.collections4.functors;
 
 import java.io.Serializable;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -63,9 +64,10 @@ public class SwitchTransformer<T, R> implements Transformer<T, R>, Serializable 
         if (map.isEmpty()) {
             return ConstantTransformer.<I, O>nullTransformer();
         }
-        // convert to array like this to guarantee iterator() ordering
-        final Transformer<? super I, ? extends O> defaultTransformer = map.remove(null);
-        final int size = map.size();
+        // copy so the caller's map is not mutated; LinkedHashMap preserves iterator() ordering
+        final Map<Predicate<? super I>, Transformer<? super I, ? extends O>> entries = new LinkedHashMap<>(map);
+        final Transformer<? super I, ? extends O> defaultTransformer = entries.remove(null);
+        final int size = entries.size();
         if (size == 0) {
             return (Transformer<I, O>) (defaultTransformer == null ? ConstantTransformer.<I, O>nullTransformer() :
                                                                      defaultTransformer);
@@ -73,8 +75,8 @@ public class SwitchTransformer<T, R> implements Transformer<T, R>, Serializable 
         final Transformer<? super I, ? extends O>[] transformers = new Transformer[size];
         final Predicate<? super I>[] preds = new Predicate[size];
         int i = 0;
-        for (final Map.Entry<? extends Predicate<? super I>,
-                             ? extends Transformer<? super I, ? extends O>> entry : map.entrySet()) {
+        for (final Map.Entry<Predicate<? super I>,
+                             Transformer<? super I, ? extends O>> entry : entries.entrySet()) {
             preds[i] = entry.getKey();
             transformers[i] = entry.getValue();
             i++;

--- a/src/test/java/org/apache/commons/collections4/functors/SwitchTransformerMapMutatesTest.java
+++ b/src/test/java/org/apache/commons/collections4/functors/SwitchTransformerMapMutatesTest.java
@@ -37,8 +37,7 @@ class SwitchTransformerMapMutatesTest {
     void testSwitchTransformerMapDoesNotMutateInput() {
         final Transformer<String, String> defaultTransformer = ConstantTransformer.constantTransformer("default");
         final Transformer<String, String> transformer = ConstantTransformer.constantTransformer("value");
-        final Predicate<String> predicate = NullPredicate.INSTANCE;
-        @SuppressWarnings("unchecked")
+        final Predicate<String> predicate = NullPredicate.nullPredicate();
         final Map<Predicate<String>, Transformer<String, String>> map = new LinkedHashMap<>();
         map.put(null, defaultTransformer);
         map.put(predicate, transformer);

--- a/src/test/java/org/apache/commons/collections4/functors/SwitchTransformerMapMutatesTest.java
+++ b/src/test/java/org/apache/commons/collections4/functors/SwitchTransformerMapMutatesTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4.functors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.commons.collections4.Predicate;
+import org.apache.commons.collections4.Transformer;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that SwitchTransformer.switchTransformer(Map) does not mutate the input map.
+ */
+class SwitchTransformerMapMutatesTest {
+
+    /**
+     * Tests that switchTransformer(Map) does NOT mutate the input map by removing the null key.
+     */
+    @Test
+    void testSwitchTransformerMapDoesNotMutateInput() {
+        final Transformer<String, String> defaultTransformer = ConstantTransformer.constantTransformer("default");
+        final Transformer<String, String> transformer = ConstantTransformer.constantTransformer("value");
+        final Predicate<String> predicate = NullPredicate.INSTANCE;
+
+        @SuppressWarnings("unchecked")
+        final Map<Predicate<String>, Transformer<String, String>> map = new LinkedHashMap<>();
+        map.put(null, defaultTransformer);
+        map.put(predicate, transformer);
+
+        final int sizeBefore = map.size();
+        assertEquals(2, sizeBefore, "map should have 2 entries before call");
+
+        // Call the factory method
+        SwitchTransformer.switchTransformer(map);
+
+        // The map should NOT have been mutated - null key must still be present
+        final int sizeAfter = map.size();
+        assertEquals(sizeBefore, sizeAfter,
+                "switchTransformer must not mutate the input map; expected size " + sizeBefore + " but got " + sizeAfter);
+    }
+}

--- a/src/test/java/org/apache/commons/collections4/functors/SwitchTransformerMapMutatesTest.java
+++ b/src/test/java/org/apache/commons/collections4/functors/SwitchTransformerMapMutatesTest.java
@@ -38,21 +38,16 @@ class SwitchTransformerMapMutatesTest {
         final Transformer<String, String> defaultTransformer = ConstantTransformer.constantTransformer("default");
         final Transformer<String, String> transformer = ConstantTransformer.constantTransformer("value");
         final Predicate<String> predicate = NullPredicate.INSTANCE;
-
         @SuppressWarnings("unchecked")
         final Map<Predicate<String>, Transformer<String, String>> map = new LinkedHashMap<>();
         map.put(null, defaultTransformer);
         map.put(predicate, transformer);
-
         final int sizeBefore = map.size();
-        assertEquals(2, sizeBefore, "map should have 2 entries before call");
-
+        assertEquals(2, sizeBefore);
         // Call the factory method
         SwitchTransformer.switchTransformer(map);
-
         // The map should NOT have been mutated - null key must still be present
         final int sizeAfter = map.size();
-        assertEquals(sizeBefore, sizeAfter,
-                "switchTransformer must not mutate the input map; expected size " + sizeBefore + " but got " + sizeAfter);
+        assertEquals(sizeBefore, sizeAfter, "switchTransformer must not mutate the input map; expected size");
     }
 }


### PR DESCRIPTION
`SwitchTransformer.switchTransformer(Map)` extracts the default transformer with `map.remove(null)`, which **mutates the caller's map** by removing its null key entry — a surprising destructive side effect from a factory method. Use `map.get(null)` instead so the input map is left unchanged.

Added a test asserting the input map is not mutated.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
