### PR TITLE
[COLLECTIONS-804] Fix non-deterministic testCollectionToArray2() and …

### DIFF
--- a/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/AbstractCollectionTest.java
@@ -1225,13 +1225,20 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
                 "toArray(null) should raise NPE");
         verify();
 
+        final List<E> expectedList = new ArrayList<>();
+        for (final E element : getCollection()) {
+            expectedList.add(element);
+        }
+
         array = getCollection().toArray(ArrayUtils.EMPTY_OBJECT_ARRAY);
         a = getCollection().toArray();
 
         if ((getIterationBehaviour() & UNORDERED) != 0) {
-            assertUnorderedArrayEquals(array, a, "toArray(Object[]) and toArray()");
+            assertUnorderedArrayEquals(expectedList.toArray(), array, "toArray(Object[]) and iterator");
+            assertUnorderedArrayEquals(expectedList.toArray(), a, "toArray() and iterator");
         } else {
-            assertEquals(Arrays.asList(array), Arrays.asList(a), "toArrays should be equal");
+            assertEquals(expectedList, Arrays.asList(array), "toArray(Object[]) and iterator order should match");
+            assertEquals(expectedList, Arrays.asList(a), "toArray() and iterator order should match");
         }
         // Figure out if they're all the same class
         // TODO: It'd be nicer to detect a common superclass
@@ -1253,11 +1260,10 @@ public abstract class AbstractCollectionTest<E> extends AbstractObjectTest {
                 "toArray(Object[]) should return correct array type");
 
         if ((getIterationBehaviour() & UNORDERED) != 0) {
-            assertUnorderedArrayEquals(array, getCollection().toArray(), "type-specific toArray(T[]) and toArray()");
+            assertUnorderedArrayEquals(expectedList.toArray(), array, "type-specific toArray(T[]) and iterator");
         } else {
-            assertEquals(Arrays.asList(array),
-                    Arrays.asList(getCollection().toArray()),
-                    "type-specific toArrays should be equal");
+            assertEquals(expectedList, Arrays.asList(array),
+                    "type-specific toArray(T[]) and iterator order should match");
         }
         verify();
     }

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractIteratorTest.java
@@ -112,6 +112,10 @@ public abstract class AbstractIteratorTest<E> extends AbstractObjectTest {
         assertNotNull(it.toString());
     }
 
+    protected int getIterationBehaviour() {
+        return 0;
+    }
+
     /**
      * Tests {@link Iterator#forEachRemaining(java.util.function.Consumer)}.
      */
@@ -121,7 +125,11 @@ public abstract class AbstractIteratorTest<E> extends AbstractObjectTest {
         final Iterator<E> it = makeObject();
         final List<E> actual = new ArrayList<>();
         it.forEachRemaining(actual::add);
-        assertEquals(expected, actual);
+        if (getIterationBehaviour() == org.apache.commons.collections4.collection.AbstractCollectionTest.UNORDERED) {
+            assertEquals(new org.apache.commons.collections4.bag.HashBag<>(expected), new org.apache.commons.collections4.bag.HashBag<>(actual));
+        } else {
+            assertEquals(expected, actual);
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/iterators/AbstractMapIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/AbstractMapIteratorTest.java
@@ -70,6 +70,18 @@ public abstract class AbstractMapIteratorTest<K, V> extends AbstractIteratorTest
      */
     public abstract Map<K, V> getMap();
 
+    @Override
+    protected int getIterationBehaviour() {
+        final Map<K, V> map = getMap();
+        if (map instanceof org.apache.commons.collections4.OrderedMap || map instanceof java.util.SortedMap
+                || map instanceof java.util.LinkedHashMap
+                || map.getClass().getSimpleName().contains("Linked")
+                || map.getClass().getSimpleName().contains("Ordered")) {
+            return 0;
+        }
+        return org.apache.commons.collections4.collection.AbstractCollectionTest.UNORDERED;
+    }
+
     /**
      * Tests whether the get operation on the map structurally modifies the map,
      * such as with LRUMap. Default is false.

--- a/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractMapTest.java
@@ -626,7 +626,14 @@ public abstract class AbstractMapTest<M extends Map<K, V>, K, V> extends Abstrac
      * @see AbstractCollectionTest#UNORDERED
      */
     protected int getIterationBehaviour() {
-        return 0;
+        final Map<K, V> map = getMap();
+        if (map instanceof org.apache.commons.collections4.OrderedMap || map instanceof java.util.SortedMap
+                || map instanceof java.util.LinkedHashMap
+                || map.getClass().getSimpleName().contains("Linked")
+                || map.getClass().getSimpleName().contains("Ordered")) {
+            return 0;
+        }
+        return AbstractCollectionTest.UNORDERED;
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/set/MapBackedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/MapBackedSetTest.java
@@ -35,6 +35,11 @@ public class MapBackedSetTest<E> extends AbstractSetTest<E> {
         return MapBackedSet.mapBackedSet(new HashedMap<>());
     }
 
+    @Override
+    protected int getIterationBehaviour() {
+        return UNORDERED;
+    }
+
 //    void testCreate() throws Exception {
 //        resetEmpty();
 //        writeExternalFormToDisk((java.io.Serializable) getCollection(), "src/test/resources/data/test/MapBackedSet.emptyCollection.version4.obj");


### PR DESCRIPTION
COLLECTIONS-804: Fix non-deterministic testCollectionToArray2() and flaky iterator tests under NonDex

### Problem
The test case `testCollectionToArray2()` in `AbstractCollectionTest` compares two generated arrays from `toArray()` calls. For collections that do not guarantee iteration order (such as standard hash-based maps, sets, or their decorators), the elements returned can vary in order between executions—especially when executed under the NonDex tool which shuffles iteration orders to expose non-determinism.

Similarly, `testForEachRemaining()` in `AbstractIteratorTest` creates two separate iterators from the same unordered backing data structure and expects them to traverse elements in the same order, causing flaky assertions.

### Solution
1. **`AbstractCollectionTest.java`**:
   - Modified `testCollectionToArray2()` to build an expected element list from the collection's iterator.
   - Asserts the outputs of `toArray()` directly against this expected list. If the collection behaves in an unordered manner (`getIterationBehaviour() & UNORDERED != 0`), the elements are compared ignoring order using `assertUnorderedArrayEquals`. Otherwise, strict order matches are validated.

2. **`AbstractMapTest.java`**:
   - Configured `getIterationBehaviour()` in `AbstractMapTest` to automatically return `UNORDERED` for unordered maps (by default, if the map is not a `SortedMap`, `OrderedMap`, `LinkedHashMap`, or does not have "Linked" or "Ordered" in its class name). This configures all collection views of hash-based maps to use unordered matching.

3. **`MapBackedSetTest.java`**:
   - Overrode `getIterationBehaviour()` to return `UNORDERED` as it is backed by an unordered `HashedMap`.

4. **`AbstractIteratorTest.java` & `AbstractMapIteratorTest.java`**:
   - Overrode and updated `testForEachRemaining()` to perform an unordered comparison using `HashBag` when the iterator traverses an unordered data structure, resolving flakiness under NonDex.

### Verification
All tests pass successfully under standard Maven runs and NonDex verification checks:
```bash
mvn edu.illinois:nondex-maven-plugin:2.2.5:nondex -Dtest=HashMapSanityTest,ConcurrentHashMapSanityTest,DualHashBidiMapTest,MapBackedSetTest -Drat.skip
