### PR TITLE
Fix stale size in AbstractMapMultiSet view iterator remove

### DIFF
--- a/src/main/java/org/apache/commons/collections4/multiset/AbstractMapMultiSet.java
+++ b/src/main/java/org/apache/commons/collections4/multiset/AbstractMapMultiSet.java
@@ -92,7 +92,10 @@ public abstract class AbstractMapMultiSet<E> extends AbstractMultiSet<E> {
             if (!canRemove) {
                 throw new IllegalStateException("Iterator remove() can only be called once after next()");
             }
+            final int count = last.getCount();
             decorated.remove();
+            parent.size -= count;
+            parent.modCount++;
             last = null;
             canRemove = false;
         }
@@ -267,7 +270,8 @@ public abstract class AbstractMapMultiSet<E> extends AbstractMultiSet<E> {
             }
             final int count = parent.getCount(lastElement);
             super.remove();
-            parent.remove(lastElement, count);
+            parent.size -= count;
+            parent.modCount++;
             lastElement = null;
             canRemove = false;
         }

--- a/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
@@ -570,6 +570,34 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
 
     @Test
     @SuppressWarnings("unchecked")
+    void testMultiSetViewIteratorRemoveKeepsSizeConsistent() {
+        if (!isRemoveSupported()) {
+            return;
+        }
+        // removing through uniqueSet()/entrySet() drops the whole entry, so
+        // size() must fall by that entry's count and the views stay consistent
+        final MultiSet<T> multiset = makeObject();
+        multiset.add((T) "A", 3);
+        multiset.add((T) "B", 2);
+
+        final Iterator<T> unique = multiset.uniqueSet().iterator();
+        final T removed = unique.next();
+        final int removedCount = multiset.getCount(removed);
+        unique.remove();
+        assertEquals(5 - removedCount, multiset.size());
+        assertFalse(multiset.contains(removed));
+        assertEquals(multiset.size(), multiset.toArray().length);
+
+        final Iterator<MultiSet.Entry<T>> entries = multiset.entrySet().iterator();
+        entries.next();
+        entries.remove();
+        assertEquals(0, multiset.size());
+        assertTrue(multiset.isEmpty());
+        assertEquals(0, multiset.toArray().length);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     void testMultiSetRemove() {
         if (!isRemoveSupported()) {
             return;

--- a/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
@@ -16,12 +16,9 @@
  */
 package org.apache.commons.collections4.multiset;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InvalidObjectException;
-import java.util.Iterator;
 
 import org.apache.commons.collections4.MultiSet;
 import org.junit.jupiter.api.Test;
@@ -45,26 +42,6 @@ public class HashMultiSetTest<T> extends AbstractMultiSetTest<T> {
     @Override
     public MultiSet<T> makeObject() {
         return new HashMultiSet<>();
-    }
-
-    @Test
-    void testViewIteratorRemoveKeepsSizeConsistent() {
-        final HashMultiSet<String> multiset = new HashMultiSet<>();
-        multiset.add("a", 3);
-        final Iterator<String> unique = multiset.uniqueSet().iterator();
-        unique.next();
-        unique.remove();
-        assertEquals(0, multiset.size());
-        assertTrue(multiset.isEmpty());
-        assertEquals(0, multiset.toArray().length);
-
-        multiset.add("b", 4);
-        final Iterator<MultiSet.Entry<String>> entries = multiset.entrySet().iterator();
-        entries.next();
-        entries.remove();
-        assertEquals(0, multiset.size());
-        assertTrue(multiset.isEmpty());
-        assertEquals(0, multiset.toArray().length);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
@@ -16,9 +16,12 @@
  */
 package org.apache.commons.collections4.multiset;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InvalidObjectException;
+import java.util.Iterator;
 
 import org.apache.commons.collections4.MultiSet;
 import org.junit.jupiter.api.Test;
@@ -42,6 +45,26 @@ public class HashMultiSetTest<T> extends AbstractMultiSetTest<T> {
     @Override
     public MultiSet<T> makeObject() {
         return new HashMultiSet<>();
+    }
+
+    @Test
+    void testViewIteratorRemoveKeepsSizeConsistent() {
+        final HashMultiSet<String> multiset = new HashMultiSet<>();
+        multiset.add("a", 3);
+        final Iterator<String> unique = multiset.uniqueSet().iterator();
+        unique.next();
+        unique.remove();
+        assertEquals(0, multiset.size());
+        assertTrue(multiset.isEmpty());
+        assertEquals(0, multiset.toArray().length);
+
+        multiset.add("b", 4);
+        final Iterator<MultiSet.Entry<String>> entries = multiset.entrySet().iterator();
+        entries.next();
+        entries.remove();
+        assertEquals(0, multiset.size());
+        assertTrue(multiset.isEmpty());
+        assertEquals(0, multiset.toArray().length);
     }
 
     @Test


### PR DESCRIPTION
`AbstractMapMultiSet`'s `uniqueSet()` and `entrySet()` view iterators drop the whole entry from the backing map but never decrement the cached `size` field, so removing an element with `N` copies through either view leaves `size() == N` while `isEmpty()` is `true` and `toArray()` (sized by `size()`) returns `N` trailing nulls.

`UniqueSetIterator.remove()` calls `super.remove()` (which deletes the key) and then `parent.remove(lastElement, count)`, but that call short-circuits at `map.get(...) == null` and never adjusts `size`; `EntrySetIterator.remove()` calls `decorated.remove()` and never touches `size` at all. Both overrides now subtract the removed entry count from `size` and bump `modCount`, matching the size-correct `AbstractMapBag.BagIterator` and `remove(Object, int)`. Found by comparing the two map-backed count collections. `HashMultiSet` and `TreeMultiSet` inherit the fix.

Repro before the patch:

```java
MultiSet<String> ms = new HashMultiSet<>();
ms.add("a", 3);
Iterator<String> it = ms.uniqueSet().iterator();
it.next();
it.remove();
ms.size();    // 3  (expected 0)
ms.toArray(); // [null, null, null]
```

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
