### PR TITLE
Remove stale keys in OrderedProperties compute and merge

### DIFF
--- a/src/main/java/org/apache/commons/collections4/properties/OrderedProperties.java
+++ b/src/main/java/org/apache/commons/collections4/properties/OrderedProperties.java
@@ -66,6 +66,8 @@ public class OrderedProperties extends Properties {
         final Object compute = super.compute(key, remappingFunction);
         if (compute != null) {
             orderedKeys.add(key);
+        } else {
+            orderedKeys.remove(key);
         }
         return compute;
     }
@@ -123,8 +125,13 @@ public class OrderedProperties extends Properties {
     @Override
     public synchronized Object merge(final Object key, final Object value,
             final BiFunction<? super Object, ? super Object, ? extends Object> remappingFunction) {
-        orderedKeys.add(key);
-        return super.merge(key, value, remappingFunction);
+        final Object merge = super.merge(key, value, remappingFunction);
+        if (merge != null) {
+            orderedKeys.add(key);
+        } else {
+            orderedKeys.remove(key);
+        }
+        return merge;
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/properties/OrderedPropertiesTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/OrderedPropertiesTest.java
@@ -120,6 +120,20 @@ class OrderedPropertiesTest {
     }
 
     @Test
+    void testComputeToNullRemovesKey() {
+        final OrderedProperties orderedProperties = new OrderedProperties();
+        orderedProperties.put("a", "1");
+        orderedProperties.put("b", "2");
+        // A remapping to null removes the mapping; the ordered key view must follow.
+        orderedProperties.compute("a", (k, v) -> null);
+        assertFalse(orderedProperties.containsKey("a"));
+        assertFalse(orderedProperties.keySet().contains("a"));
+        assertEquals(1, orderedProperties.size());
+        assertEquals("[b]", orderedProperties.keySet().toString());
+        assertEquals("{b=2}", orderedProperties.toString());
+    }
+
+    @Test
     void testComputeIfAbsent() {
         final OrderedProperties orderedProperties = new OrderedProperties();
         int first = 1;
@@ -215,6 +229,19 @@ class OrderedPropertiesTest {
             orderedProperties.merge("key" + i, "value" + i, (k, v) -> v);
         }
         assertDescendingOrder(orderedProperties);
+    }
+
+    @Test
+    void testMergeToNullRemovesKey() {
+        final OrderedProperties orderedProperties = new OrderedProperties();
+        orderedProperties.put("a", "1");
+        orderedProperties.put("b", "2");
+        // A remapping to null removes the mapping; the ordered key view must follow.
+        orderedProperties.merge("a", "x", (oldVal, newVal) -> null);
+        assertFalse(orderedProperties.containsKey("a"));
+        assertFalse(orderedProperties.keySet().contains("a"));
+        assertEquals(1, orderedProperties.size());
+        assertEquals("{b=2}", orderedProperties.toString());
     }
 
     @Test


### PR DESCRIPTION
`OrderedProperties` keeps a parallel `orderedKeys` set that backs `keys()`, `keySet()`, `entrySet()` and `toString()`, but `compute()` and `merge()` only ever add to it. both operations remove the mapping from the backing `Hashtable` when the remapping function returns `null`, so after `compute(key, (k, v) -> null)` on a present key the mapping is gone yet the key still shows up in `keySet()`, `size()` disagrees with the key view, and `toString()` throws `NullPointerException` on the stale key's null value.

remove the key from `orderedKeys` when the result is `null`. a `Hashtable` never stores null values, so a null result means the mapping was removed, which is what the existing `remove()` overrides already do. found while auditing the ordered-view bookkeeping against the `Properties` contract; `SortedProperties` derives its keys live from `super.keySet()` and needs no change.