### PR TITLE
Fix MapUtils.getIntValue(Map, K, Function) returning a byte

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -32,6 +32,7 @@
     <action type="fix" dev="ggregory" due-to="Eric Hubert, Gary Gregory">Remove deprecation annotation of org.apache.commons.collections4.Transformer; this will be deprecated in 5.0 in favor of java.util.function.Function.</action>
     <action type="fix" dev="ggregory" due-to="Eric Hubert, Gary Gregory">Remove deprecation annotation of org.apache.commons.collections4.Closure; this will be deprecated in 5.0 in favor of java.util.function.Consumer.</action>
     <action type="fix" dev="ggregory" due-to="Sebastian Götz, Gary Gregory" issue="COLLECTIONS-874">MapUtils.getLongValue(Map, K, Function) returns a byte instead of a long.</action>
+    <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">MapUtils.getIntValue(Map, K, Function) returns a byte instead of an int.</action>
     <action type="fix" dev="ggregory" due-to="Gary Gregory">Fix exception message in org.apache.commons.collections4.functors.FunctorUtils.validate(Consumer...)</action>
     <action type="fix" dev="ggregory" due-to="Gary Gregory">Fix exception message in org.apache.commons.collections4.iterators.UnmodifiableIterator.remove() to match java.util.Iterator.remove().</action>
     <action type="fix" dev="pkarwasz" due-to="Piotr P. Karwasz, Joerg Budischewski" issue="COLLECTIONS-838">Calling SetUtils.union on multiple instances of SetView causes JVM to hang</action>

--- a/src/main/java/org/apache/commons/collections4/MapUtils.java
+++ b/src/main/java/org/apache/commons/collections4/MapUtils.java
@@ -738,7 +738,7 @@ public class MapUtils {
      */
     public static <K> int getIntValue(final Map<? super K, ?> map, final K key,
             final Function<K, Integer> defaultFunction) {
-        return applyDefaultFunction(map, key, MapUtils::getInteger, defaultFunction, 0).byteValue();
+        return applyDefaultFunction(map, key, MapUtils::getInteger, defaultFunction, 0).intValue();
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
@@ -482,11 +482,13 @@ class MapUtilsTest {
     void testGetIntValue() {
         final Map<String, Integer> in = new HashMap<>();
         in.put("key", 2);
+        in.put("big", 1000);
 
         assertEquals(2, MapUtils.getIntValue(in, "key", 0), 0);
         assertEquals(2, MapUtils.getIntValue(in, "key"), 0);
         assertEquals(0, MapUtils.getIntValue(in, "noKey", 0), 0);
-        assertEquals(0, MapUtils.getIntValue(in, "noKey", key -> 0), 0);
+        assertEquals(1000, MapUtils.getIntValue(in, "big", key -> 0), 0);
+        assertEquals(Integer.MAX_VALUE, MapUtils.getIntValue(in, "noKey", key -> Integer.MAX_VALUE), 0);
         assertEquals(Integer.MIN_VALUE, MapUtils.getIntValue(in, "noKey", Integer.MIN_VALUE), 0);
         assertEquals(Integer.MAX_VALUE, MapUtils.getIntValue(in, "noKey", Integer.MAX_VALUE), 0);
         assertEquals(0, MapUtils.getIntValue(in, "noKey"), 0);

--- a/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/MapUtilsTest.java
@@ -589,7 +589,7 @@ class MapUtilsTest {
         assertEquals(val, MapUtils.getShortValue(in, "key", val), 0);
         assertEquals(val, MapUtils.getShortValue(in, "key"), 0);
         assertEquals(val, MapUtils.getShortValue(in, "noKey", val), 0);
-        assertEquals(val, MapUtils.getShortValue(in, "noKey", key -> val), 0);
+        assertEquals(1000, MapUtils.getShortValue(in, "noKey", key -> (short) 1000), 0);
         assertEquals(Short.MIN_VALUE, MapUtils.getShortValue(in, "noKey", Short.MIN_VALUE), 0);
         assertEquals(Short.MAX_VALUE, MapUtils.getShortValue(in, "noKey", Short.MAX_VALUE), 0);
         assertEquals(0, MapUtils.getShortValue(in, "noKey"), 0);


### PR DESCRIPTION
`MapUtils.getIntValue(Map, K, Function)` narrows the resolved `Integer` through `.byteValue()`, so any value outside signed-byte range comes back truncated: a map entry of `1000` returns `-24`, and a `defaultFunction` yielding `Integer.MAX_VALUE` returns `-1`. This is the same defect fixed under COLLECTIONS-874 for the sibling `getLongValue(Map, K, Function)`, which moved to `.longValue()`; the `int` overload kept `.byteValue()`. Found while checking that each `getXxxValue(Map, K, Function)` matches its declared return type.

Use `.intValue()` like every other numeric overload. `testGetIntValue` only drove the `Function` variant with `key -> 0`, which is unaffected by the narrowing, so the gap stayed invisible; the added assertions pin a map value and a default-function value that fall outside byte range.
