### PR TITLE
Clamp overflow in AbstractMapBag and AbstractMapMultiSet add

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -24,6 +24,7 @@
   <body>
   <release version="4.6.0" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
     <!-- FIX -->
+    <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">AbstractMapBag and AbstractMapMultiSet.add(Object, int) overflow the size and element count past Integer.MAX_VALUE.</action>
     <action type="fix" dev="ggregory" due-to="Gary Gregory" issue="COLLECTIONS-776">Wrapping PassiveExpiringMap in Collections.synchronizedMap breaks expiration.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">[javadoc] Document that BloomFilter merge operations are non-atomic and a filter that throws during a merge should be considered invalid.</action>
     <action type="fix" dev="ggregory" due-to="Gary Gregory">org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceEntry.toReference(ReferenceStrength, T, int) now throws IllegalArgumentException instead of Error.</action>

--- a/src/main/java/org/apache/commons/collections4/bag/AbstractMapBag.java
+++ b/src/main/java/org/apache/commons/collections4/bag/AbstractMapBag.java
@@ -146,8 +146,8 @@ public abstract class AbstractMapBag<E> implements Bag<E> {
     /** The map to use to store the data */
     private transient Map<E, MutableInteger> map;
 
-    /** The current total size of the bag */
-    private int size;
+    /** The current total size of the bag; kept exact past {@link Integer#MAX_VALUE}, {@link #size()} saturates */
+    private long size;
 
     /** The modification count for fail fast iterators */
     private transient int modCount;
@@ -196,6 +196,8 @@ public abstract class AbstractMapBag<E> implements Bag<E> {
 
     /**
      * Adds a new element to the bag, incrementing its count in the map.
+     * The count of an element saturates at {@code Integer.MAX_VALUE}; copies
+     * that would take it past that limit are not added.
      *
      * @param object the object to search for
      * @param nCopies the number of copies to add
@@ -206,12 +208,14 @@ public abstract class AbstractMapBag<E> implements Bag<E> {
         modCount++;
         if (nCopies > 0) {
             final MutableInteger mut = map.get(object);
-            size = (int) Math.min((long) size + nCopies, Integer.MAX_VALUE);
             if (mut == null) {
                 map.put(object, new MutableInteger(nCopies));
+                size += nCopies;
                 return true;
             }
-            mut.value = (int) Math.min((long) mut.value + nCopies, Integer.MAX_VALUE);
+            final int applied = Math.min(nCopies, Integer.MAX_VALUE - mut.value);
+            mut.value += applied;
+            size += applied;
         }
         return false;
     }
@@ -523,13 +527,14 @@ public abstract class AbstractMapBag<E> implements Bag<E> {
     }
 
     /**
-     * Returns the number of elements in this bag.
+     * Returns the number of elements in this bag, or {@code Integer.MAX_VALUE}
+     * if the bag contains more than {@code Integer.MAX_VALUE} elements.
      *
      * @return current size of the bag
      */
     @Override
     public int size() {
-        return size;
+        return (int) Math.min(size, Integer.MAX_VALUE);
     }
 
     /**

--- a/src/main/java/org/apache/commons/collections4/bag/AbstractMapBag.java
+++ b/src/main/java/org/apache/commons/collections4/bag/AbstractMapBag.java
@@ -206,12 +206,12 @@ public abstract class AbstractMapBag<E> implements Bag<E> {
         modCount++;
         if (nCopies > 0) {
             final MutableInteger mut = map.get(object);
-            size += nCopies;
+            size = (int) Math.min((long) size + nCopies, Integer.MAX_VALUE);
             if (mut == null) {
                 map.put(object, new MutableInteger(nCopies));
                 return true;
             }
-            mut.value += nCopies;
+            mut.value = (int) Math.min((long) mut.value + nCopies, Integer.MAX_VALUE);
         }
         return false;
     }

--- a/src/main/java/org/apache/commons/collections4/multiset/AbstractMapMultiSet.java
+++ b/src/main/java/org/apache/commons/collections4/multiset/AbstractMapMultiSet.java
@@ -313,11 +313,11 @@ public abstract class AbstractMapMultiSet<E> extends AbstractMultiSet<E> {
 
         if (occurrences > 0) {
             modCount++;
-            size += occurrences;
+            size = (int) Math.min((long) size + occurrences, Integer.MAX_VALUE);
             if (mut == null) {
                 map.put(object, new MutableInteger(occurrences));
             } else {
-                mut.value += occurrences;
+                mut.value = (int) Math.min((long) mut.value + occurrences, Integer.MAX_VALUE);
             }
         }
         return oldCount;

--- a/src/main/java/org/apache/commons/collections4/multiset/AbstractMapMultiSet.java
+++ b/src/main/java/org/apache/commons/collections4/multiset/AbstractMapMultiSet.java
@@ -280,8 +280,8 @@ public abstract class AbstractMapMultiSet<E> extends AbstractMultiSet<E> {
     /** The map to use to store the data */
     private transient Map<E, MutableInteger> map;
 
-    /** The current total size of the multiset */
-    private transient int size;
+    /** The current total size of the multiset; kept exact past {@link Integer#MAX_VALUE}, {@link #size()} saturates */
+    private transient long size;
 
     /** The modification count for fail fast iterators */
     private transient int modCount;
@@ -313,11 +313,13 @@ public abstract class AbstractMapMultiSet<E> extends AbstractMultiSet<E> {
 
         if (occurrences > 0) {
             modCount++;
-            size = (int) Math.min((long) size + occurrences, Integer.MAX_VALUE);
             if (mut == null) {
                 map.put(object, new MutableInteger(occurrences));
+                size += occurrences;
             } else {
-                mut.value = (int) Math.min((long) mut.value + occurrences, Integer.MAX_VALUE);
+                final int applied = Math.min(occurrences, Integer.MAX_VALUE - mut.value);
+                mut.value += applied;
+                size += applied;
             }
         }
         return oldCount;
@@ -510,13 +512,14 @@ public abstract class AbstractMapMultiSet<E> extends AbstractMultiSet<E> {
     }
 
     /**
-     * Returns the number of elements in this multiset.
+     * Returns the number of elements in this multiset, or {@code Integer.MAX_VALUE}
+     * if the multiset contains more than {@code Integer.MAX_VALUE} elements.
      *
      * @return current size of the multiset
      */
     @Override
     public int size() {
-        return size;
+        return (int) Math.min(size, Integer.MAX_VALUE);
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.collections4.bag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.InvalidObjectException;
@@ -55,6 +56,18 @@ public class HashBagTest<T> extends AbstractBagTest<T> {
             replaceInt(bytes, marker, count);
             assertThrows(InvalidObjectException.class, () -> deserialize(bytes));
         }
+    }
+
+    @Test
+    void testAddClampsCountAndSizeToIntegerMaxValue() {
+        final HashBag<String> bag = new HashBag<>();
+        bag.add("X", Integer.MAX_VALUE - 1);
+        bag.add("Y", Integer.MAX_VALUE - 1);
+        assertEquals(Integer.MAX_VALUE, bag.size());
+        bag.add("X", 10);
+        assertEquals(Integer.MAX_VALUE, bag.getCount("X"));
+        assertEquals(Integer.MAX_VALUE, bag.size());
+        assertEquals(2, bag.uniqueSet().size());
     }
 
 //    void testCreate() throws Exception {

--- a/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
+++ b/src/test/java/org/apache/commons/collections4/bag/HashBagTest.java
@@ -68,6 +68,13 @@ public class HashBagTest<T> extends AbstractBagTest<T> {
         assertEquals(Integer.MAX_VALUE, bag.getCount("X"));
         assertEquals(Integer.MAX_VALUE, bag.size());
         assertEquals(2, bag.uniqueSet().size());
+        // true size is 2 * Integer.MAX_VALUE - 11 after this, so size() must stay saturated
+        bag.remove("X", 10);
+        assertEquals(Integer.MAX_VALUE - 10, bag.getCount("X"));
+        assertEquals(Integer.MAX_VALUE, bag.size());
+        // size() only drops below Integer.MAX_VALUE once the true size does
+        bag.remove("Y");
+        assertEquals(Integer.MAX_VALUE - 10, bag.size());
     }
 
 //    void testCreate() throws Exception {

--- a/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.collections4.multiset;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.InvalidObjectException;
@@ -55,6 +56,17 @@ public class HashMultiSetTest<T> extends AbstractMultiSetTest<T> {
             replaceInt(bytes, marker, count);
             assertThrows(InvalidObjectException.class, () -> deserialize(bytes));
         }
+    }
+
+    @Test
+    void testAddClampsCountAndSizeToIntegerMaxValue() {
+        final HashMultiSet<String> set = new HashMultiSet<>();
+        set.add("X", Integer.MAX_VALUE);
+        set.add("X", 1);
+        assertEquals(Integer.MAX_VALUE, set.getCount("X"));
+        assertEquals(Integer.MAX_VALUE, set.size());
+        set.add("Y", Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE, set.size());
     }
 
 //    void testCreate() throws Exception {

--- a/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/HashMultiSetTest.java
@@ -67,6 +67,13 @@ public class HashMultiSetTest<T> extends AbstractMultiSetTest<T> {
         assertEquals(Integer.MAX_VALUE, set.size());
         set.add("Y", Integer.MAX_VALUE);
         assertEquals(Integer.MAX_VALUE, set.size());
+        // true size is 2 * Integer.MAX_VALUE - 2 after this, so size() must stay saturated
+        set.remove("X", 2);
+        assertEquals(Integer.MAX_VALUE - 2, set.getCount("X"));
+        assertEquals(Integer.MAX_VALUE, set.size());
+        // size() only drops below Integer.MAX_VALUE once the true size does
+        set.remove("Y", Integer.MAX_VALUE);
+        assertEquals(Integer.MAX_VALUE - 2, set.size());
     }
 
 //    void testCreate() throws Exception {


### PR DESCRIPTION
`add(Object, int)` in `AbstractMapBag` and `AbstractMapMultiSet` accumulates the running `size` and the per-element count into plain `int` fields with no upper bound, so a second `add` whose total crosses `Integer.MAX_VALUE` overflows both: `add(x, Integer.MAX_VALUE)` then `add(x, 1)` leaves `getCount(x) == Integer.MIN_VALUE` and `size()` negative. Clamp both to `Integer.MAX_VALUE` inside `add()`, matching the `Collection.size()` contract and the existing `BloomFilter`/`CompositeMap.size()` idiom. Found while auditing the bag/multiset count arithmetic; the regression tests in `HashBagTest` and `HashMultiSetTest` fail before the change (`-4` / `Integer.MIN_VALUE`) and pass after.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
