### PR TITLE
[COLLECTIONS-732]: Document UnsupportedOperationException on MultiValue…

### DIFF
--- a/src/main/java/org/apache/commons/collections4/MultiValuedMap.java
+++ b/src/main/java/org/apache/commons/collections4/MultiValuedMap.java
@@ -199,6 +199,10 @@ public interface MultiValuedMap<K, V> {
      * A map iterator is an efficient way of iterating over maps. There is no
      * need to access the entries collection or use {@code Map.Entry} objects.
      * </p>
+     * <p>
+     * The returned map iterator's {@link MapIterator#setValue(Object)} method is not supported
+     * and will throw an {@link UnsupportedOperationException}.
+     * </p>
      *
      * @return a map iterator
      */

--- a/src/main/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMap.java
+++ b/src/main/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMap.java
@@ -343,6 +343,11 @@ public abstract class AbstractMultiValuedMap<K, V> implements MultiValuedMap<K, 
             it.remove();
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * @throws UnsupportedOperationException always, as this method is not supported by the iterator.
+         */
         @Override
         public V setValue(final V value) {
             if (current == null) {
@@ -742,6 +747,13 @@ public abstract class AbstractMultiValuedMap<K, V> implements MultiValuedMap<K, 
         return getMap().keySet();
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The returned map iterator's {@link MapIterator#setValue(Object)} method is not supported
+     * and will throw an {@link UnsupportedOperationException}.
+     * </p>
+     */
     @Override
     public MapIterator<K, V> mapIterator() {
         if (isEmpty()) {

--- a/src/main/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapDecorator.java
+++ b/src/main/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapDecorator.java
@@ -130,13 +130,6 @@ public abstract class AbstractMultiValuedMapDecorator<K, V>
         return decorated().keySet();
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * The returned map iterator's {@link MapIterator#setValue(Object)} method is not supported
-     * and will throw an {@link UnsupportedOperationException}.
-     * </p>
-     */
     @Override
     public MapIterator<K, V> mapIterator() {
         return decorated().mapIterator();

--- a/src/main/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapDecorator.java
+++ b/src/main/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapDecorator.java
@@ -130,6 +130,13 @@ public abstract class AbstractMultiValuedMapDecorator<K, V>
         return decorated().keySet();
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The returned map iterator's {@link MapIterator#setValue(Object)} method is not supported
+     * and will throw an {@link UnsupportedOperationException}.
+     * </p>
+     */
     @Override
     public MapIterator<K, V> mapIterator() {
         return decorated().mapIterator();

--- a/src/main/java/org/apache/commons/collections4/multimap/UnmodifiableMultiValuedMap.java
+++ b/src/main/java/org/apache/commons/collections4/multimap/UnmodifiableMultiValuedMap.java
@@ -114,6 +114,13 @@ public final class UnmodifiableMultiValuedMap<K, V>
         return UnmodifiableSet.unmodifiableSet(decorated().keySet());
     }
 
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The returned map iterator's {@link MapIterator#setValue(Object)} method is not supported
+     * and will throw an {@link UnsupportedOperationException}.
+     * </p>
+     */
     @Override
     public MapIterator<K, V> mapIterator() {
         return UnmodifiableMapIterator.unmodifiableMapIterator(decorated().mapIterator());


### PR DESCRIPTION
## Problem
When calling `setValue(V value)` on the `MapIterator` returned by `MultiValuedMap.mapIterator()`, it throws an `UnsupportedOperationException`. However, this behavior was previously undocumented in the interface and its implementing classes/decorators, causing confusion for users.

For details, see [JIRA COLLECTIONS-732](https://issues.apache.org/jira/browse/COLLECTIONS-732).

## Proposed Changes
Documented that the returned map iterator's `setValue` method is unsupported and throws `UnsupportedOperationException` in:
- `MultiValuedMap.java` (Interface)
- `AbstractMultiValuedMap.java` (Base Implementation, including the inner classes `MultiValuedMapIterator` and `MultiValuedMapEntry`)
- `AbstractMultiValuedMapDecorator.java` (Decorator base)
- `UnmodifiableMultiValuedMap.java` (Unmodifiable wrapper)

## Verification
- Verified that all unit tests compile and pass successfully (`mvn test`).
- Existing tests (such as `testMapIteratorUnsupportedSet` in `AbstractMultiValuedMapTest.java`) already assert that `setValue()` throws `UnsupportedOperationException`, confirming the behavior matches the new documentation.
