### PR TITLE
Clamp size() int overflow in composite and multi-valued classes

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -25,6 +25,7 @@
   <release version="4.6.0" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
     <!-- FIX -->
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">AbstractMapBag and AbstractMapMultiSet.add(Object, int) overflow the size and element count past Integer.MAX_VALUE.</action>
+    <action type="fix" dev="ggregory" due-to="Naveed Khan">CompositeCollection, CompositeSet, CompositeMap, AbstractMultiValuedMap and AbstractMultiSet size() overflow int when the total exceeds Integer.MAX_VALUE.</action>
     <action type="fix" dev="ggregory" due-to="Gary Gregory" issue="COLLECTIONS-776">Wrapping PassiveExpiringMap in Collections.synchronizedMap breaks expiration.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">[javadoc] Document that BloomFilter merge operations are non-atomic and a filter that throws during a merge should be considered invalid.</action>
     <action type="fix" dev="ggregory" due-to="Gary Gregory">org.apache.commons.collections4.map.AbstractReferenceMap.ReferenceEntry.toReference(ReferenceStrength, T, int) now throws IllegalArgumentException instead of Error.</action>

--- a/src/main/java/org/apache/commons/collections4/collection/CompositeCollection.java
+++ b/src/main/java/org/apache/commons/collections4/collection/CompositeCollection.java
@@ -425,15 +425,16 @@ public class CompositeCollection<E> implements Collection<E>, Serializable {
      * This implementation calls {@code size()} on each collection.
      * </p>
      *
-     * @return total number of elements in all contained containers.
+     * @return total number of elements in all contained containers, or
+     *         {@code Integer.MAX_VALUE} if the total exceeds it.
      */
     @Override
     public int size() {
-        int size = 0;
+        long size = 0;
         for (final Collection<E> item : all) {
             size += item.size();
         }
-        return size;
+        return (int) Math.min(size, Integer.MAX_VALUE);
     }
 
     /**

--- a/src/main/java/org/apache/commons/collections4/map/CompositeMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/CompositeMap.java
@@ -536,11 +536,11 @@ public class CompositeMap<K, V> extends AbstractIterableMap<K, V> implements Ser
      */
     @Override
     public int size() {
-        int size = 0;
+        long size = 0;
         for (int i = composite.length - 1; i >= 0; --i) {
             size += composite[i].size();
         }
-        return size;
+        return (int) Math.min(size, Integer.MAX_VALUE);
     }
 
     /**

--- a/src/main/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMap.java
+++ b/src/main/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMap.java
@@ -903,11 +903,11 @@ public abstract class AbstractMultiValuedMap<K, V> implements MultiValuedMap<K, 
         // but this requires that all modifications of the multimap
         // (including the wrapped collections and entry/value
         // collections) are tracked.
-        int size = 0;
+        long size = 0;
         for (final Collection<V> col : getMap().values()) {
             size += col.size();
         }
-        return size;
+        return (int) Math.min(size, Integer.MAX_VALUE);
     }
 
     @Override

--- a/src/main/java/org/apache/commons/collections4/multiset/AbstractMultiSet.java
+++ b/src/main/java/org/apache/commons/collections4/multiset/AbstractMultiSet.java
@@ -475,15 +475,16 @@ public abstract class AbstractMultiSet<E> extends AbstractCollection<E> implemen
     /**
      * Returns the number of elements in this multiset.
      *
-     * @return current size of the multiset
+     * @return current size of the multiset, or {@code Integer.MAX_VALUE}
+     *         if the total exceeds it
      */
     @Override
     public int size() {
-        int totalSize = 0;
+        long totalSize = 0;
         for (final Entry<E> entry : entrySet()) {
             totalSize += entry.getCount();
         }
-        return totalSize;
+        return (int) Math.min(totalSize, Integer.MAX_VALUE);
     }
 
     /**

--- a/src/main/java/org/apache/commons/collections4/set/CompositeSet.java
+++ b/src/main/java/org/apache/commons/collections4/set/CompositeSet.java
@@ -464,15 +464,16 @@ public class CompositeSet<E> implements Set<E>, Serializable {
      * <p>
      * This implementation calls {@code size()} on each set.
      *
-     * @return total number of elements in all contained containers
+     * @return total number of elements in all contained containers, or
+     *         {@code Integer.MAX_VALUE} if the total exceeds it
      */
     @Override
     public int size() {
-        int size = 0;
+        long size = 0;
         for (final Set<E> item : all) {
             size += item.size();
         }
-        return size;
+        return (int) Math.min(size, Integer.MAX_VALUE);
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/collection/CompositeCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/CompositeCollectionTest.java
@@ -29,6 +29,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.function.Predicate;
 
+import org.apache.commons.collections4.bag.HashBag;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -422,6 +423,16 @@ public class CompositeCollectionTest<E> extends AbstractCollectionTest<E> {
         set.add((E) "b");
         c.addComposited(set);
         assertEquals(set.size(), c.size());
+    }
+
+    @Test
+    void testSizeClampsToIntegerMaxValue() {
+        final HashBag<String> one = new HashBag<>();
+        one.add("A", Integer.MAX_VALUE);
+        final HashBag<String> two = new HashBag<>();
+        two.add("B", Integer.MAX_VALUE);
+        final CompositeCollection<String> composite = new CompositeCollection<>(one, two);
+        assertEquals(Integer.MAX_VALUE, composite.size());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/map/CompositeMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/CompositeMapTest.java
@@ -21,9 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.AbstractMap;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -233,6 +236,28 @@ public class CompositeMapTest<K, V> extends AbstractIterableMapTest<K, V> {
 
         map.addComposited(buildOne());
         assertTrue(pass);
+    }
+
+    @Test
+    void testSizeClampsToIntegerMaxValue() {
+        final CompositeMap<String, String> map = new CompositeMap<>(maxSizeMap(), maxSizeMap());
+        assertEquals(Integer.MAX_VALUE, map.size());
+    }
+
+    /** An empty-iterating map that reports {@code Integer.MAX_VALUE} mappings. */
+    private static Map<String, String> maxSizeMap() {
+        return new AbstractMap<String, String>() {
+
+            @Override
+            public Set<Map.Entry<String, String>> entrySet() {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public int size() {
+                return Integer.MAX_VALUE;
+            }
+        };
     }
 
 //    void testCreate() throws Exception {

--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -1280,6 +1280,23 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
     }
 
     @Test
+    void testSizeClampsToIntegerMaxValue() {
+        // bag-valued map: value collection sizes are counts, so the total is cheap to grow past Integer.MAX_VALUE
+        final AbstractMultiValuedMap<String, String> map = new AbstractMultiValuedMap<String, String>(new HashMap<>()) {
+
+            @Override
+            protected Collection<String> createCollection() {
+                return new HashBag<>();
+            }
+        };
+        map.put("k1", "v1");
+        map.put("k2", "v2");
+        ((HashBag<String>) map.getMap().get("k1")).add("v1", Integer.MAX_VALUE - 1);
+        ((HashBag<String>) map.getMap().get("k2")).add("v2", Integer.MAX_VALUE - 1);
+        assertEquals(Integer.MAX_VALUE, map.size());
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     void testSize_Key() {
         final MultiValuedMap<K, V> map = makeFullMap();

--- a/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/multiset/AbstractMultiSetTest.java
@@ -692,6 +692,39 @@ public abstract class AbstractMultiSetTest<T> extends AbstractCollectionTest<T> 
     }
 
     @Test
+    void testMultiSetSizeClampsToIntegerMaxValue() {
+        final List<MultiSet.Entry<String>> entries = Arrays.asList(maxCountEntry("A"), maxCountEntry("B"));
+        final MultiSet<String> multiset = new AbstractMultiSet<String>() {
+
+            @Override
+            protected Iterator<MultiSet.Entry<String>> createEntrySetIterator() {
+                return entries.iterator();
+            }
+
+            @Override
+            protected int uniqueElements() {
+                return entries.size();
+            }
+        };
+        assertEquals(Integer.MAX_VALUE, multiset.size());
+    }
+
+    private static MultiSet.Entry<String> maxCountEntry(final String element) {
+        return new AbstractMultiSet.AbstractEntry<String>() {
+
+            @Override
+            public int getCount() {
+                return Integer.MAX_VALUE;
+            }
+
+            @Override
+            public String getElement() {
+                return element;
+            }
+        };
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     void testMultiSetToArray() {
         if (!isAddSupported()) {

--- a/src/test/java/org/apache/commons/collections4/set/CompositeSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/CompositeSetTest.java
@@ -21,8 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.AbstractSet;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -178,6 +181,29 @@ public class CompositeSetTest<E> extends AbstractSetTest<E> {
 
         set.remove("3");
         assertFalse(one.contains("3"));
+    }
+
+    @Test
+    void testSizeClampsToIntegerMaxValue() {
+        final CompositeSet<String> set = new CompositeSet<>(maxSizeSet());
+        set.addComposited(maxSizeSet());
+        assertEquals(Integer.MAX_VALUE, set.size());
+    }
+
+    /** An empty-iterating set that reports {@code Integer.MAX_VALUE} elements. */
+    private static Set<String> maxSizeSet() {
+        return new AbstractSet<String>() {
+
+            @Override
+            public Iterator<String> iterator() {
+                return Collections.emptyIterator();
+            }
+
+            @Override
+            public int size() {
+                return Integer.MAX_VALUE;
+            }
+        };
     }
 
     @Test


### PR DESCRIPTION
Follow-up to #705, per the review request to check the rest of the library for int/long mismatches. `CompositeCollection.size()`, `CompositeSet.size()` and `CompositeMap.size()` sum the composited containers' sizes into an `int`, so two max-size members wrap the total negative (`CompositeMap`'s javadoc already promises `Integer.MAX_VALUE`); compositing two full bags makes this cheap to hit. `AbstractMultiValuedMap.size()` and `AbstractMultiSet.size()` accumulate value collection sizes and entry counts the same way. All five now sum into a `long` and clamp the return to `Integer.MAX_VALUE`, matching the `Collection.size()` contract and the #705 idiom. The regression tests fail before the change (`-2` from two max-size members) and pass after: the `CompositeCollection` and `AbstractMultiValuedMap` tests use real `HashBag`s at max count, the set/map tests use empty-iterating members that report `Integer.MAX_VALUE`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
