### PR TITLE
Fix AbstractDualBidiMap.MapEntry.setValue returning new value

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -24,6 +24,7 @@
   <body>
   <release version="4.6.0" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
     <!-- FIX -->
+    <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">DualHashBidiMap, DualLinkedHashBidiMap, and DualTreeBidiMap entrySet() Map.Entry.setValue(Object) returns the new value instead of the previous value.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">AbstractMapBag and AbstractMapMultiSet.add(Object, int) overflow the size and element count past Integer.MAX_VALUE.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan">CompositeCollection, CompositeSet, CompositeMap, AbstractMultiValuedMap and AbstractMultiSet size() overflow int when the total exceeds Integer.MAX_VALUE.</action>
     <action type="fix" dev="ggregory" due-to="Gary Gregory" issue="COLLECTIONS-776">Wrapping PassiveExpiringMap in Collections.synchronizedMap breaks expiration.</action>

--- a/src/main/java/org/apache/commons/collections4/bidimap/AbstractDualBidiMap.java
+++ b/src/main/java/org/apache/commons/collections4/bidimap/AbstractDualBidiMap.java
@@ -359,8 +359,9 @@ public abstract class AbstractDualBidiMap<K, V> implements BidiMap<K, V> {
                 throw new IllegalArgumentException(
                         "Cannot use setValue() when the object being set is already in the map");
             }
-            parent.put(key, value);
-            return super.setValue(value);
+            final V oldValue = parent.put(key, value);
+            super.setValue(value);
+            return oldValue;
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractBidiMapTest.java
@@ -108,6 +108,19 @@ public abstract class AbstractBidiMapTest<K, V> extends AbstractIterableMapTest<
             }
         }
 
+        @Test
+        void testMapEntrySetValueReturnsOldValue() {
+            if (!isSetValueSupported()) {
+                return;
+            }
+            final V newValue = getNewSampleValues()[0];
+            resetFull();
+            final Map.Entry<K, V> entry = BidiMapEntrySetTest.this.getCollection().iterator().next();
+            final V oldValue = entry.getValue();
+            assertEquals(oldValue, entry.setValue(newValue));
+            assertEquals(newValue, entry.getValue());
+        }
+
     }
 
     @Nested


### PR DESCRIPTION
`MapEntry.setValue` runs `parent.put` before the delegating `super.setValue`, so `entrySet()` entries return the just-written value instead of the previous one; return `put`'s result like the sibling `DualTreeBidiMap` map iterator, matching `java.util.HashMap`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
