### PR TITLE
Reject out-of-range index before mutating in indexed add

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -24,6 +24,7 @@
   <body>
   <release version="4.6.0" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
     <!-- FIX -->
+    <action type="fix" dev="ggregory" due-to="Naveed Khan">SetUniqueList and ListOrderedSet leave the backing collection inconsistent when add(int, Object) or addAll(int, Collection) is called with an out-of-range index.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">AbstractMapBag and AbstractMapMultiSet.add(Object, int) overflow the size and element count past Integer.MAX_VALUE.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan">CompositeCollection, CompositeSet, CompositeMap, AbstractMultiValuedMap and AbstractMultiSet size() overflow int when the total exceeds Integer.MAX_VALUE.</action>
     <action type="fix" dev="ggregory" due-to="Gary Gregory" issue="COLLECTIONS-776">Wrapping PassiveExpiringMap in Collections.synchronizedMap breaks expiration.</action>

--- a/src/main/java/org/apache/commons/collections4/list/SetUniqueList.java
+++ b/src/main/java/org/apache/commons/collections4/list/SetUniqueList.java
@@ -219,6 +219,9 @@ public class SetUniqueList<E> extends AbstractSerializableListDecorator<E> {
      */
     @Override
     public void add(final int index, final E object) {
+        if (index < 0 || index > size()) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size());
+        }
         // adds element if it is not contained already
         if (!set.contains(object)) {
             set.add(object);
@@ -261,6 +264,9 @@ public class SetUniqueList<E> extends AbstractSerializableListDecorator<E> {
      */
     @Override
     public boolean addAll(final int index, final Collection<? extends E> coll) {
+        if (index < 0 || index > size()) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + size());
+        }
         final List<E> temp = new ArrayList<>();
         for (final E e : coll) {
             if (set.add(e)) {

--- a/src/main/java/org/apache/commons/collections4/set/ListOrderedSet.java
+++ b/src/main/java/org/apache/commons/collections4/set/ListOrderedSet.java
@@ -232,6 +232,9 @@ public class ListOrderedSet<E>
      * @see List#add(int, Object)
      */
     public void add(final int index, final E object) {
+        if (index < 0 || index > setOrder.size()) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + setOrder.size());
+        }
         if (!contains(object)) {
             decorated().add(object);
             setOrder.add(index, object);
@@ -259,6 +262,9 @@ public class ListOrderedSet<E>
      * @see List#addAll(int, Collection)
      */
     public boolean addAll(final int index, final Collection<? extends E> coll) {
+        if (index < 0 || index > setOrder.size()) {
+            throw new IndexOutOfBoundsException("Index: " + index + ", Size: " + setOrder.size());
+        }
         boolean changed = false;
         // collect all elements to be added for performance reasons
         final List<E> toAdd = new ArrayList<>();

--- a/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
@@ -356,6 +356,7 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
         assertThrows(IndexOutOfBoundsException.class,
                 () -> list.addAll(9, Arrays.asList(Integer.valueOf(3), Integer.valueOf(4))));
         assertFalse(list.contains(Integer.valueOf(3)));
+        assertFalse(list.contains(Integer.valueOf(4)));
         assertEquals(list.size(), list.asSet().size(), "list and uniqueness set diverged");
     }
 

--- a/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/SetUniqueListTest.java
@@ -340,6 +340,26 @@ public class SetUniqueListTest<E> extends AbstractListTest<E> {
     }
 
     @Test
+    void testIntCollectionAddAllOutOfBoundsIndex() {
+        final SetUniqueList<Integer> list = new SetUniqueList<>(new ArrayList<>(), new HashSet<>());
+        list.add(Integer.valueOf(1));
+        final Integer newElement = Integer.valueOf(2);
+
+        // an out-of-range index must be rejected before the uniqueness set is mutated
+        assertThrows(IndexOutOfBoundsException.class, () -> list.add(5, newElement));
+        assertFalse(list.contains(newElement), "rejected element leaked into the uniqueness set");
+        assertEquals(list.size(), list.asSet().size(), "list and uniqueness set diverged");
+        // otherwise the element is silently dropped on the next add
+        assertTrue(list.add(newElement));
+        assertEquals(newElement, list.get(1));
+
+        assertThrows(IndexOutOfBoundsException.class,
+                () -> list.addAll(9, Arrays.asList(Integer.valueOf(3), Integer.valueOf(4))));
+        assertFalse(list.contains(Integer.valueOf(3)));
+        assertEquals(list.size(), list.asSet().size(), "list and uniqueness set diverged");
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     void testListIterator() {
         final SetUniqueList<E> lset = new SetUniqueList<>(new ArrayList<>(), new HashSet<>());

--- a/src/test/java/org/apache/commons/collections4/set/ListOrderedSetTest.java
+++ b/src/test/java/org/apache/commons/collections4/set/ListOrderedSetTest.java
@@ -17,12 +17,14 @@
 package org.apache.commons.collections4.set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InvalidObjectException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -169,6 +171,28 @@ public class ListOrderedSetTest<E>
         assertSame(THREE, set.get(1));
         assertSame(TWO, set.get(2));
         assertSame(ONE, set.get(3));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testListAddIndexedOutOfBounds() {
+        final ListOrderedSet<E> set = makeObject();
+        set.add((E) ZERO);
+
+        // an out-of-range index is rejected before the backing set is touched
+        assertThrows(IndexOutOfBoundsException.class, () -> set.add(5, (E) ONE));
+        assertFalse(set.contains(ONE), "rejected element leaked into the backing set");
+        assertEquals(set.size(), set.asList().size(), "backing set and order list diverged");
+        // the element is still insertable afterwards
+        assertTrue(set.add((E) ONE));
+        assertSame(ONE, set.get(1));
+
+        final ListOrderedSet<E> other = makeObject();
+        other.add((E) ZERO);
+        assertThrows(IndexOutOfBoundsException.class, () -> other.addAll(9, Arrays.asList((E) ONE, (E) TWO)));
+        assertFalse(other.contains(ONE));
+        assertFalse(other.contains(TWO));
+        assertEquals(other.size(), other.asList().size(), "backing set and order list diverged");
     }
 
     @Test


### PR DESCRIPTION
`SetUniqueList.add(int, E)`/`addAll(int, Collection)` and `ListOrderedSet.add(int, E)`/`addAll(int, Collection)` mutate the uniqueness set before the index-validating backing collection, so an out-of-range index throws from the list but the element is already in the set, leaving `contains(x)` true while the element is absent, `size()` out of step with `asSet()`/`asList()`, and the element silently dropped by the next `add`; `ListOrderedMap.put(int, K, V)` already range-checks the index up front, so these four now do the same. Found while auditing the ordered/unique decorators for state left behind by a rejected operation.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
