### PR TITLE
Fix Flat3Map entrySet remove ignoring the entry value

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -24,8 +24,6 @@
   <body>
   <release version="4.6.0" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
     <!-- FIX -->
-    <action type="fix" dev="ggregory" due-to="Naveed Khan">Flat3Map entrySet().remove(Object) removes a mapping when only the key matches, ignoring the entry value.</action>
-    <action type="fix" dev="ggregory" due-to="Naveed Khan">SetUniqueList and ListOrderedSet leave the backing collection inconsistent when add(int, Object) or addAll(int, Collection) is called with an out-of-range index.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">DualHashBidiMap, DualLinkedHashBidiMap, and DualTreeBidiMap entrySet() Map.Entry.setValue(Object) returns the new value instead of the previous value.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">AbstractMapBag and AbstractMapMultiSet.add(Object, int) overflow the size and element count past Integer.MAX_VALUE.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan">CompositeCollection, CompositeSet, CompositeMap, AbstractMultiValuedMap and AbstractMultiSet size() overflow int when the total exceeds Integer.MAX_VALUE.</action>
@@ -84,6 +82,8 @@
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">Clamp size() int overflow in composite and multi-valued classes (#710).</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">Fix AbstractDualBidiMap.MapEntry.setValue returning new value (#711).</action>
     <action type="fix" dev="ggregory" due-to="sankalp suman, Gary Gregory" issue="COLLECTIONS-714">PatriciaTrie ignores trailing null characters in keys (#712).</action>
+    <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">Flat3Map entrySet().remove(Object) removes a mapping when only the key matches, ignoring the entry value.</action>
+    <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">SetUniqueList and ListOrderedSet leave the backing collection inconsistent when add(int, Object) or addAll(int, Collection) is called with an out-of-range index.</action>
     <!-- ADD -->
     <action type="add" dev="ggregory" due-to="Gary Gregory">Add generics to UnmodifiableIterator for the wrapped type.</action>
     <action type="add" dev="ggregory" due-to="Gary Gregory">Add a Maven benchmark profile for JMH.</action>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -24,6 +24,7 @@
   <body>
   <release version="4.6.0" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
     <!-- FIX -->
+    <action type="fix" dev="ggregory" due-to="Naveed Khan">Flat3Map entrySet().remove(Object) removes a mapping when only the key matches, ignoring the entry value.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan">SetUniqueList and ListOrderedSet leave the backing collection inconsistent when add(int, Object) or addAll(int, Collection) is called with an out-of-range index.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">DualHashBidiMap, DualLinkedHashBidiMap, and DualTreeBidiMap entrySet() Map.Entry.setValue(Object) returns the new value instead of the previous value.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">AbstractMapBag and AbstractMapMultiSet.add(Object, int) overflow the size and element count past Integer.MAX_VALUE.</action>

--- a/src/main/java/org/apache/commons/collections4/map/Flat3Map.java
+++ b/src/main/java/org/apache/commons/collections4/map/Flat3Map.java
@@ -149,11 +149,12 @@ public class Flat3Map<K, V> implements IterableMap<K, V>, Serializable, Cloneabl
             if (!(obj instanceof Map.Entry)) {
                 return false;
             }
+            if (!contains(obj)) {
+                return false;
+            }
             final Map.Entry<?, ?> entry = (Map.Entry<?, ?>) obj;
-            final Object key = entry.getKey();
-            final boolean result = parent.containsKey(key);
-            parent.remove(key);
-            return result;
+            parent.remove(entry.getKey());
+            return true;
         }
 
         @Override

--- a/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
@@ -24,6 +24,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -275,6 +276,23 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         m.put(ONE, null);
         final boolean contains = m.containsValue(null);
         assertTrue(contains);
+    }
+
+    @Test
+    void testEntrySetRemoveChecksValue() {
+        final Flat3Map<Integer, String> m = new Flat3Map<>();
+        m.put(ONE, TEN);
+        m.put(TWO, TWENTY);
+
+        // key present but value differs: entrySet().remove must not remove
+        assertFalse(m.entrySet().remove(new AbstractMap.SimpleEntry<>(ONE, TWENTY)));
+        assertEquals(2, m.size());
+        assertEquals(TEN, m.get(ONE));
+
+        // matching key and value: removes
+        assertTrue(m.entrySet().remove(new AbstractMap.SimpleEntry<>(ONE, TEN)));
+        assertFalse(m.containsKey(ONE));
+        assertEquals(1, m.size());
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/Flat3MapTest.java
@@ -283,12 +283,10 @@ public class Flat3MapTest<K, V> extends AbstractIterableMapTest<K, V> {
         final Flat3Map<Integer, String> m = new Flat3Map<>();
         m.put(ONE, TEN);
         m.put(TWO, TWENTY);
-
         // key present but value differs: entrySet().remove must not remove
         assertFalse(m.entrySet().remove(new AbstractMap.SimpleEntry<>(ONE, TWENTY)));
         assertEquals(2, m.size());
         assertEquals(TEN, m.get(ONE));
-
         // matching key and value: removes
         assertTrue(m.entrySet().remove(new AbstractMap.SimpleEntry<>(ONE, TEN)));
         assertFalse(m.containsKey(ONE));


### PR DESCRIPTION
noticed `Flat3Map.EntrySet.remove` diverges from `AbstractHashedMap`: it removes on a key match alone, so `entrySet().remove(entry)` drops a mapping even when the entry value differs; guard with `contains(obj)` so only a full key-and-value match removes.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
