### PR TITLE
Fix CollectionUtils collate keeping duplicate nulls when includeDuplicates is false

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -24,6 +24,7 @@
   <body>
   <release version="4.6.0" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
     <!-- FIX -->
+    <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">CollectionUtils.collate(Iterable, Iterable, Comparator, boolean) does not remove duplicate null elements when includeDuplicates is false.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">DualHashBidiMap, DualLinkedHashBidiMap, and DualTreeBidiMap entrySet() Map.Entry.setValue(Object) returns the new value instead of the previous value.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan, Gary Gregory">AbstractMapBag and AbstractMapMultiSet.add(Object, int) overflow the size and element count past Integer.MAX_VALUE.</action>
     <action type="fix" dev="ggregory" due-to="Naveed Khan">CompositeCollection, CompositeSet, CompositeMap, AbstractMultiValuedMap and AbstractMultiSet size() overflow int when the total exceeds Integer.MAX_VALUE.</action>

--- a/src/main/java/org/apache/commons/collections4/CollectionUtils.java
+++ b/src/main/java/org/apache/commons/collections4/CollectionUtils.java
@@ -481,12 +481,14 @@ public class CollectionUtils {
         }
         final ArrayList<O> mergedList = new ArrayList<>(totalSize);
         O lastItem = null;
+        boolean first = true;
         while (iterator.hasNext()) {
             final O item = iterator.next();
-            if (lastItem == null || !lastItem.equals(item)) {
+            if (first || !Objects.equals(lastItem, item)) {
                 mergedList.add(item);
             }
             lastItem = item;
+            first = false;
         }
         mergedList.trimToSize();
         return mergedList;

--- a/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/CollectionUtilsTest.java
@@ -648,6 +648,17 @@ class CollectionUtilsTest extends MockTestCase {
     }
 
     @Test
+    void testCollateIgnoreDuplicatesWithNullElements() {
+        final Comparator<String> nullsFirst = Comparator.nullsFirst(Comparator.<String>naturalOrder());
+        final List<String> left = Arrays.asList(null, "a");
+        final List<String> right = Arrays.asList(null, "a");
+        // a null element is a legal, sorted value here, so consecutive nulls must
+        // collapse just like any other duplicate when includeDuplicates is false
+        assertEquals(Arrays.asList(null, "a"), CollectionUtils.collate(left, right, nullsFirst, false));
+        assertEquals(Arrays.asList(null, null, "a", "a"), CollectionUtils.collate(left, right, nullsFirst, true));
+    }
+
+    @Test
     void testCollect() {
         final Transformer<Number, Long> transformer = TransformerUtils.constantTransformer(2L);
         Collection<Number> collection = CollectionUtils.<Integer, Number>collect(iterableA, transformer);


### PR DESCRIPTION
`collate` used `lastItem == null` as its first-iteration sentinel, so a real null element (legal when a null-tolerant `Comparator` like `Comparator.nullsFirst` is supplied) was treated as unseen and re-added, leaving duplicate nulls in the result when `includeDuplicates` is false; found while tracing the merge dedup path with null-permitting comparators.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
