### PR TITLE
Increment modCount after the bounds check in TreeList add and remove

### DIFF
--- a/src/main/java/org/apache/commons/collections4/list/TreeList.java
+++ b/src/main/java/org/apache/commons/collections4/list/TreeList.java
@@ -966,8 +966,8 @@ public class TreeList<E> extends AbstractList<E> {
      */
     @Override
     public void add(final int index, final E obj) {
-        modCount++;
         checkInterval(index, 0, size());
+        modCount++;
         if (root == null) {
             root = new AVLNode<>(index, obj, null, null);
         } else {
@@ -1105,8 +1105,8 @@ public class TreeList<E> extends AbstractList<E> {
      */
     @Override
     public E remove(final int index) {
-        modCount++;
         checkInterval(index, 0, size() - 1);
+        modCount++;
         final E result = get(index);
         root = root.remove(index);
         size--;

--- a/src/test/java/org/apache/commons/collections4/list/TreeListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/TreeListTest.java
@@ -172,6 +172,25 @@ public class TreeListTest<E> extends AbstractListTest<E> {
     }
 
     @Test
+    void testFailedIndexedChangeKeepsIteratorValid() {
+        final List<String> list = new TreeList<>();
+        list.add("a");
+        list.add("b");
+
+        // a rejected add(index) is a no-op and must not invalidate a live iterator
+        final ListIterator<String> addIt = list.listIterator();
+        assertThrows(IndexOutOfBoundsException.class, () -> list.add(5, "x"));
+        assertEquals(2, list.size());
+        assertEquals("a", addIt.next());
+
+        // same for a rejected remove(index)
+        final ListIterator<String> removeIt = list.listIterator();
+        assertThrows(IndexOutOfBoundsException.class, () -> list.remove(10));
+        assertEquals(2, list.size());
+        assertEquals("a", removeIt.next());
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     void testIndexOf() {
         final List<E> l = makeObject();


### PR DESCRIPTION
noticed `add(int, E)` and `remove(int)` bump `modCount` before `checkInterval`, so a rejected out-of-range index leaves the list unchanged yet still trips a spurious `ConcurrentModificationException` in an iterator obtained earlier. `set(int, E)` already validates first and `AbstractLinkedList` validates via `getNode` before bumping `modCount`; moving the increment below the bounds check in both methods makes a rejected index a true no-op.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
