### PR TITLE
Do not register a value collection until an add succeeds

### DIFF
--- a/src/main/java/org/apache/commons/collections4/multimap/AbstractListValuedMap.java
+++ b/src/main/java/org/apache/commons/collections4/multimap/AbstractListValuedMap.java
@@ -126,10 +126,12 @@ public abstract class AbstractListValuedMap<K, V> extends AbstractMultiValuedMap
 
         @Override
         public void add(final int index, final V value) {
-            List<V> list = getMapping();
+            final List<V> list = getMapping();
             if (list == null) {
-                list = createCollection();
-                getMap().put(key, list);
+                final List<V> newList = createCollection();
+                newList.add(index, value);
+                getMap().put(key, newList);
+                return;
             }
             list.add(index, value);
         }

--- a/src/main/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMap.java
+++ b/src/main/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMap.java
@@ -441,10 +441,14 @@ public abstract class AbstractMultiValuedMap<K, V> implements MultiValuedMap<K, 
 
         @Override
         public boolean addAll(final Collection<? extends V> other) {
-            Collection<V> coll = getMapping();
+            final Collection<V> coll = getMapping();
             if (coll == null) {
-                coll = createCollection();
-                AbstractMultiValuedMap.this.map.put(key, coll);
+                final Collection<V> newColl = createCollection();
+                if (newColl.addAll(other)) {
+                    AbstractMultiValuedMap.this.map.put(key, newColl);
+                    return true;
+                }
+                return false;
             }
             return coll.addAll(other);
         }

--- a/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/AbstractMultiValuedMapTest.java
@@ -705,6 +705,19 @@ public abstract class AbstractMultiValuedMapTest<K, V> extends AbstractObjectTes
         assertTrue(col2.contains("v1_1"));
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void testAddAllThroughGetEmptyLeavesKeyAbsent() {
+        assumeTrue(isAddSupported());
+        resetEmpty();
+        final MultiValuedMap<K, V> map = getMap();
+        final Collection<V> col = map.get((K) "k0");
+        assertFalse(col.addAll(new ArrayList<>()));
+        assertFalse(map.containsKey("k0"));
+        assertFalse(map.keySet().contains("k0"));
+        assertEquals(0, map.size());
+    }
+
     /*void testRemoveViaGetCollectionRemove() {
         if (!isRemoveSupported()) {
             return;

--- a/src/test/java/org/apache/commons/collections4/multimap/ArrayListValuedHashMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/ArrayListValuedHashMapTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.collections4.multimap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -115,6 +116,17 @@ public class ArrayListValuedHashMapTest<K, V> extends AbstractMultiValuedMapTest
         list.add((V) "a1");
         assertEquals(1, listMap.size());
         assertTrue(listMap.containsKey("A"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testListValuedMapAddByIndexInvalidIndexLeavesKeyAbsent() {
+        final ListValuedMap<K, V> listMap = makeObject();
+        final List<V> list = listMap.get((K) "A");
+        assertThrows(IndexOutOfBoundsException.class, () -> list.add(1, (V) "a1"));
+        assertFalse(listMap.containsKey("A"));
+        assertTrue(listMap.get((K) "A").isEmpty());
+        assertEquals(0, listMap.size());
     }
 
     @Test


### PR DESCRIPTION
`AbstractMultiValuedMap.WrappedCollection.addAll` stores a freshly created backing collection in the map before running the add that fills it, so `get(key).addAll(emptyCollection)` reports no change yet leaves `key` mapped to an empty collection. `AbstractListValuedMap.WrappedList.add(int, value)` has the same shape and leaves an empty list behind when the index is out of range and the insert throws. Both break the invariant every remove path keeps, that a key never maps to an empty collection; found by comparing these `get(key)` mutators against `put(K, V)`.

`put(K, V)` already does this right, adding to the new collection first and storing it only once the add changed something. The wrapped `addAll` and indexed `add` now follow that order, so a no-op argument or a rejected index leaves the backing map untouched.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
