### PR TITLE
Reject remove on the Unmodifiable map from SplitMapUtils.readableMap

### DIFF
--- a/src/main/java/org/apache/commons/collections4/SplitMapUtils.java
+++ b/src/main/java/org/apache/commons/collections4/SplitMapUtils.java
@@ -134,7 +134,7 @@ public class SplitMapUtils {
         /**
          * Always throws {@link UnsupportedOperationException}.
          *
-         * @param key Ignored.
+         * @param key The key whose mapping would be removed.
          * @throws UnsupportedOperationException Always thrown.
          */
         @Override

--- a/src/main/java/org/apache/commons/collections4/SplitMapUtils.java
+++ b/src/main/java/org/apache/commons/collections4/SplitMapUtils.java
@@ -131,9 +131,15 @@ public class SplitMapUtils {
             throw new UnsupportedOperationException();
         }
 
+        /**
+         * Always throws {@link UnsupportedOperationException}.
+         *
+         * @param key Ignored.
+         * @throws UnsupportedOperationException Always thrown.
+         */
         @Override
         public V remove(final Object key) {
-            return get.remove(key);
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/src/test/java/org/apache/commons/collections4/SplitMapUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/SplitMapUtilsTest.java
@@ -120,7 +120,8 @@ class SplitMapUtilsTest {
         attemptPutOperation(() -> map.remove("0"));
         attemptPutOperation(() -> map.remove("1", 1));
         attemptPutOperation(() -> map.computeIfPresent("2", (k, v) -> null));
-        attemptPutOperation(() -> map.merge("3", 3, (a, b) -> null));
+        attemptPutOperation(() -> map.compute("3", (k, v) -> null));
+        attemptPutOperation(() -> map.merge("4", 4, (a, b) -> null));
 
         assertEquals(sz, map.size());
         assertEquals(sz, backingMap.size());

--- a/src/test/java/org/apache/commons/collections4/SplitMapUtilsTest.java
+++ b/src/test/java/org/apache/commons/collections4/SplitMapUtilsTest.java
@@ -97,7 +97,7 @@ class SplitMapUtilsTest {
         assertInstanceOf(Unmodifiable.class, map);
 
         // check individual operations
-        int sz = map.size();
+        final int sz = map.size();
 
         attemptPutOperation(map::clear);
 
@@ -116,12 +116,14 @@ class SplitMapUtilsTest {
         assertEquals(other, map);
         assertEquals(other.hashCode(), map.hashCode());
 
-        // remove
-        for (int i = 0; i < 10; i++) {
-            assertEquals(i, map.remove(String.valueOf(i)).intValue());
-            assertEquals(--sz, map.size());
-        }
-        assertTrue(map.isEmpty());
+        // remove, and the Map default methods that route through it
+        attemptPutOperation(() -> map.remove("0"));
+        attemptPutOperation(() -> map.remove("1", 1));
+        attemptPutOperation(() -> map.computeIfPresent("2", (k, v) -> null));
+        attemptPutOperation(() -> map.merge("3", 3, (a, b) -> null));
+
+        assertEquals(sz, map.size());
+        assertEquals(sz, backingMap.size());
         assertSame(map, SplitMapUtils.readableMap(map));
     }
 


### PR DESCRIPTION
`SplitMapUtils.readableMap` returns a `WrappedGet` that implements `Unmodifiable` and blocks `clear`, `put` and `putAll`, but `remove(Object)` delegates to the wrapped `Get`, so the view deletes from the underlying map. The `Map` default methods that route through it inherit the hole, so `remove(k, v)`, `computeIfPresent`, `compute` and `merge` empty it just as well, and `UnmodifiableMap.unmodifiableMap` hands the view straight back on its `instanceof Unmodifiable` check, so re-wrapping does not close it. Found while auditing the library's `Unmodifiable` implementations for mutators that reach the delegate; every other one throws, so the fix stays inside `WrappedGet`.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
