### PR TITLE
Keep OrderedProperties keySet and values in sync with the map

### DIFF
--- a/src/main/java/org/apache/commons/collections4/properties/OrderedProperties.java
+++ b/src/main/java/org/apache/commons/collections4/properties/OrderedProperties.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.collections4.properties;
 
+import java.util.AbstractCollection;
 import java.util.AbstractMap.SimpleEntry;
+import java.util.AbstractSet;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -40,6 +43,80 @@ import java.util.stream.Collectors;
  * @since 4.5.0-M1
  */
 public class OrderedProperties extends Properties {
+
+    /**
+     * A key set view in insertion order.
+     */
+    private final class KeySet extends AbstractSet<Object> {
+
+        @Override
+        public void clear() {
+            OrderedProperties.this.clear();
+        }
+
+        @Override
+        public boolean contains(final Object key) {
+            return containsKey(key);
+        }
+
+        @Override
+        public Iterator<Object> iterator() {
+            return orderedKeysIterator();
+        }
+
+        @Override
+        public boolean remove(final Object key) {
+            return OrderedProperties.this.remove(key) != null;
+        }
+
+        @Override
+        public int size() {
+            return OrderedProperties.this.size();
+        }
+    }
+
+    /**
+     * A values view in key insertion order.
+     */
+    private final class Values extends AbstractCollection<Object> {
+
+        @Override
+        public void clear() {
+            OrderedProperties.this.clear();
+        }
+
+        @Override
+        public boolean contains(final Object value) {
+            return containsValue(value);
+        }
+
+        @Override
+        public Iterator<Object> iterator() {
+            final Iterator<Object> keys = orderedKeysIterator();
+            return new Iterator<Object>() {
+
+                @Override
+                public boolean hasNext() {
+                    return keys.hasNext();
+                }
+
+                @Override
+                public Object next() {
+                    return get(keys.next());
+                }
+
+                @Override
+                public void remove() {
+                    keys.remove();
+                }
+            };
+        }
+
+        @Override
+        public int size() {
+            return OrderedProperties.this.size();
+        }
+    }
 
     private static final long serialVersionUID = 1L;
 
@@ -119,7 +196,7 @@ public class OrderedProperties extends Properties {
 
     @Override
     public Set<Object> keySet() {
-        return orderedKeys;
+        return new KeySet();
     }
 
     @Override
@@ -132,6 +209,37 @@ public class OrderedProperties extends Properties {
             orderedKeys.remove(key);
         }
         return merge;
+    }
+
+    /**
+     * Creates an iterator over the keys in insertion order whose {@link Iterator#remove()} also removes the mapping.
+     *
+     * @return A new iterator.
+     */
+    private Iterator<Object> orderedKeysIterator() {
+        final Iterator<Object> iterator = orderedKeys.iterator();
+        return new Iterator<Object>() {
+
+            private Object last;
+
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public Object next() {
+                last = iterator.next();
+                return last;
+            }
+
+            @Override
+            public void remove() {
+                // Not remove(Object), which would edit orderedKeys while this iterator walks it.
+                iterator.remove();
+                OrderedProperties.super.remove(last);
+            }
+        };
     }
 
     @Override
@@ -208,5 +316,10 @@ public class OrderedProperties extends Properties {
             }
             sb.append(", ");
         }
+    }
+
+    @Override
+    public Collection<Object> values() {
+        return new Values();
     }
 }

--- a/src/main/java/org/apache/commons/collections4/properties/OrderedProperties.java
+++ b/src/main/java/org/apache/commons/collections4/properties/OrderedProperties.java
@@ -235,9 +235,12 @@ public class OrderedProperties extends Properties {
 
             @Override
             public void remove() {
-                // Not remove(Object), which would edit orderedKeys while this iterator walks it.
-                iterator.remove();
-                OrderedProperties.super.remove(last);
+                // All orderedKeys writes happen under the OrderedProperties monitor.
+                synchronized (OrderedProperties.this) {
+                    // Not remove(Object), which would edit orderedKeys while this iterator walks it.
+                    iterator.remove();
+                    OrderedProperties.super.remove(last);
+                }
             }
         };
     }

--- a/src/test/java/org/apache/commons/collections4/properties/OrderedPropertiesTest.java
+++ b/src/test/java/org/apache/commons/collections4/properties/OrderedPropertiesTest.java
@@ -18,7 +18,9 @@ package org.apache.commons.collections4.properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -30,13 +32,36 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests {@link OrderedProperties}.
  */
 class OrderedPropertiesTest {
+
+    /**
+     * Every way of dropping the middle mapping through the key and value views.
+     */
+    static Stream<Arguments> getViewRemovals() {
+        return Stream.of(
+                arguments("keySet().remove", (Consumer<OrderedProperties>) props -> props.keySet().remove("key2")),
+                arguments("keySet().removeAll", (Consumer<OrderedProperties>) props -> props.keySet().removeAll(Collections.singleton("key2"))),
+                arguments("keySet().iterator().remove", (Consumer<OrderedProperties>) props -> removeSecond(props.keySet().iterator())),
+                arguments("values().remove", (Consumer<OrderedProperties>) props -> props.values().remove("value2")),
+                arguments("values().iterator().remove", (Consumer<OrderedProperties>) props -> removeSecond(props.values().iterator())));
+    }
+
+    private static void removeSecond(final Iterator<Object> iterator) {
+        iterator.next();
+        iterator.next();
+        iterator.remove();
+    }
 
     private void assertAscendingOrder(final OrderedProperties orderedProperties) {
         final int first = 1;
@@ -97,6 +122,14 @@ class OrderedPropertiesTest {
             orderedProperties.load(reader);
         }
         return assertDescendingOrder(orderedProperties);
+    }
+
+    private OrderedProperties newThreeKeyProperties() {
+        final OrderedProperties orderedProperties = new OrderedProperties();
+        orderedProperties.put("key1", "value1");
+        orderedProperties.put("key2", "value2");
+        orderedProperties.put("key3", "value3");
+        return orderedProperties;
     }
 
     @Test
@@ -183,6 +216,15 @@ class OrderedPropertiesTest {
             assertEquals(String.valueOf(ch), k);
             assertEquals("Value" + ch, v);
         });
+    }
+
+    @Test
+    void testKeySetRejectsAdd() {
+        final OrderedProperties orderedProperties = newThreeKeyProperties();
+        final Set<Object> keySet = orderedProperties.keySet();
+        assertThrows(UnsupportedOperationException.class, () -> keySet.add("key4"));
+        assertEquals("[key1, key2, key3]", orderedProperties.keySet().toString());
+        assertEquals("{key1=value1, key2=value2, key3=value3}", orderedProperties.toString());
     }
 
     @Test
@@ -339,5 +381,17 @@ class OrderedPropertiesTest {
         assertEquals(
                 "{Z=ValueZ, Y=ValueY, X=ValueX, W=ValueW, V=ValueV, U=ValueU, T=ValueT, S=ValueS, R=ValueR, Q=ValueQ, P=ValueP, O=ValueO, N=ValueN, M=ValueM, L=ValueL, K=ValueK, J=ValueJ, I=ValueI, H=ValueH, G=ValueG, F=ValueF, E=ValueE, D=ValueD, C=ValueC, B=ValueB, A=ValueA}",
                 orderedProperties.toString());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getViewRemovals")
+    void testViewRemovalRemovesMapping(final String description, final Consumer<OrderedProperties> removal) {
+        final OrderedProperties orderedProperties = newThreeKeyProperties();
+        removal.accept(orderedProperties);
+        assertFalse(orderedProperties.containsKey("key2"));
+        assertEquals(2, orderedProperties.size());
+        assertEquals("[key1, key3]", orderedProperties.keySet().toString());
+        assertEquals("[value1, value3]", orderedProperties.values().toString());
+        assertEquals("{key1=value1, key3=value3}", orderedProperties.toString());
     }
 }


### PR DESCRIPTION
`OrderedProperties.keySet()` hands out `orderedKeys` itself, the private `LinkedHashSet` that tracks insertion order, so mutations through the returned set never reach the backing `Hashtable`. `keySet().remove(k)` reports success and drops the key from `keys()`, `entrySet()` and `store()` while `getProperty(k)` still returns the value, and `keySet().add(k)` succeeds where a key set view has to reject it. `values()` has the mirror problem: it is not overridden, so the inherited view deletes the mapping and leaves a stale key behind, which makes `toString()` throw.

Both now return small views whose removals route through the map, so the order tracker and the store move together. Keeping it in the views is what makes the plain `Properties` idioms work here, rather than callers having to know that `remove(k)` is the only safe way to delete a key. Found by running SpotBugs over the module, which flags the `keySet()` return as exposed internal state.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
