### PR TITLE
Synchronize forEach() in SynchronizedCollection

### DIFF
--- a/src/main/java/org/apache/commons/collections4/collection/SynchronizedCollection.java
+++ b/src/main/java/org/apache/commons/collections4/collection/SynchronizedCollection.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 /**
@@ -139,6 +140,16 @@ public class SynchronizedCollection<E> implements Collection<E>, Serializable {
                 return true;
             }
             return object == this || decorated().equals(object);
+        }
+    }
+
+    /**
+     * @since 4.6.0
+     */
+    @Override
+    public void forEach(final Consumer<? super E> action) {
+        synchronized (lock) {
+            decorated().forEach(action);
         }
     }
 

--- a/src/test/java/org/apache/commons/collections4/collection/SynchronizedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/SynchronizedCollectionTest.java
@@ -16,15 +16,51 @@
  */
 package org.apache.commons.collections4.collection;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.apache.commons.collections4.bag.HashBag;
+import org.apache.commons.collections4.bag.SynchronizedBag;
+import org.apache.commons.collections4.bag.SynchronizedSortedBag;
+import org.apache.commons.collections4.bag.TreeBag;
+import org.apache.commons.collections4.multiset.HashMultiSet;
+import org.apache.commons.collections4.multiset.SynchronizedMultiSet;
+import org.apache.commons.collections4.multiset.SynchronizedSortedMultiSet;
+import org.apache.commons.collections4.multiset.TreeMultiSet;
+import org.apache.commons.collections4.queue.SynchronizedQueue;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Extension of {@link AbstractCollectionTest} for exercising the
  * {@link SynchronizedCollection} implementation.
  */
 public class SynchronizedCollectionTest<E> extends AbstractCollectionTest<E> {
+
+    /** The elements every decorator under test is populated with. */
+    private static final List<String> ELEMENTS = Arrays.asList("a", "b");
+
+    /**
+     * Every decorator that inherits {@link SynchronizedCollection#forEach(java.util.function.Consumer)}.
+     */
+    static Stream<Arguments> getSynchronizedDecorators() {
+        return Stream.of(
+                arguments("SynchronizedCollection", SynchronizedCollection.synchronizedCollection(new ArrayList<>(ELEMENTS))),
+                arguments("SynchronizedBag", SynchronizedBag.synchronizedBag(new HashBag<>(ELEMENTS))),
+                arguments("SynchronizedSortedBag", SynchronizedSortedBag.synchronizedSortedBag(new TreeBag<>(ELEMENTS))),
+                arguments("SynchronizedMultiSet", SynchronizedMultiSet.synchronizedMultiSet(new HashMultiSet<>(ELEMENTS))),
+                arguments("SynchronizedSortedMultiSet", SynchronizedSortedMultiSet.synchronizedSortedMultiSet(new TreeMultiSet<>(ELEMENTS))),
+                arguments("SynchronizedQueue", SynchronizedQueue.synchronizedQueue(new LinkedList<>(ELEMENTS))));
+    }
 
     @Override
     public String getCompatibilityVersion() {
@@ -44,6 +80,18 @@ public class SynchronizedCollectionTest<E> extends AbstractCollectionTest<E> {
     @Override
     public Collection<E> makeObject() {
         return SynchronizedCollection.synchronizedCollection(new ArrayList<>());
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("getSynchronizedDecorators")
+    void testForEachHoldsLock(final String description, final Collection<String> decorator) {
+        final List<String> visited = new ArrayList<>();
+        decorator.forEach(element -> {
+            assertTrue(Thread.holdsLock(decorator), () -> description + " ran forEach without holding its lock");
+            visited.add(element);
+        });
+        assertEquals(ELEMENTS.size(), visited.size());
+        assertTrue(visited.containsAll(ELEMENTS));
     }
 
 //    void testCreate() throws Exception {

--- a/src/test/java/org/apache/commons/collections4/collection/SynchronizedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/SynchronizedCollectionTest.java
@@ -46,7 +46,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public class SynchronizedCollectionTest<E> extends AbstractCollectionTest<E> {
 
-    /** The elements every decorator under test is populated with. */
+    /** The elements used to populate each decorator under test. */
     private static final List<String> ELEMENTS = Arrays.asList("a", "b");
 
     /**


### PR DESCRIPTION
noticed while diffing the overridden method list against `java.util.Collections.synchronizedCollection`: `SynchronizedCollection` guards `removeIf` but never overrides `forEach`, so the inherited default walks the deliberately unsynchronized `iterator()` and a concurrent writer trips `ConcurrentModificationException`; delegating `forEach` under `lock` covers `SynchronizedBag`, `SynchronizedSortedBag`, `SynchronizedMultiSet`, `SynchronizedSortedMultiSet` and `SynchronizedQueue` too since they all extend it, while `stream()` and `spliterator()` stay unsynchronized for the same reason the JDK leaves them so: their traversal happens after the lock would be released.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
