### PR TITLE
Fix inverted fixed-size guard in FixedSizeSortedMap.putAll

### DIFF
--- a/src/main/java/org/apache/commons/collections4/map/FixedSizeSortedMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/FixedSizeSortedMap.java
@@ -144,7 +144,7 @@ public class FixedSizeSortedMap<K, V>
 
     @Override
     public void putAll(final Map<? extends K, ? extends V> mapToCopy) {
-        if (CollectionUtils.isSubCollection(mapToCopy.keySet(), keySet())) {
+        if (!CollectionUtils.isSubCollection(mapToCopy.keySet(), keySet())) {
             throw new IllegalArgumentException("Cannot put new key/value pair - Map is fixed size");
         }
         map.putAll(mapToCopy);

--- a/src/test/java/org/apache/commons/collections4/map/FixedSizeSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/FixedSizeSortedMapTest.java
@@ -16,8 +16,15 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
 import java.util.SortedMap;
 import java.util.TreeMap;
+
+import org.junit.jupiter.api.Test;
 
 /**
  * Extension of {@link AbstractSortedMapTest} for exercising the {@link FixedSizeSortedMap}
@@ -31,6 +38,27 @@ public class FixedSizeSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
     @Override
     public String getCompatibilityVersion() {
         return "4";
+    }
+
+    @Test
+    void testPutAllAllowsUpdatesRejectsNewKeys() {
+        final SortedMap<String, String> base = new TreeMap<>();
+        base.put("a", "1");
+        final SortedMap<String, String> fixed = FixedSizeSortedMap.fixedSizeSortedMap(base);
+
+        // updating the value of an existing key is allowed
+        fixed.putAll(Collections.singletonMap("a", "2"));
+        assertEquals("2", fixed.get("a"));
+
+        // an empty map is a no-op, not a rejection
+        fixed.putAll(Collections.emptyMap());
+        assertEquals(1, fixed.size());
+
+        // a new key must be rejected and must not grow the map
+        assertThrows(IllegalArgumentException.class,
+                () -> fixed.putAll(Collections.singletonMap("b", "9")));
+        assertEquals(1, fixed.size());
+        assertFalse(fixed.containsKey("b"));
     }
 
     @Override

--- a/src/test/java/org/apache/commons/collections4/map/FixedSizeSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/FixedSizeSortedMapTest.java
@@ -45,18 +45,14 @@ public class FixedSizeSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
         final SortedMap<String, String> base = new TreeMap<>();
         base.put("a", "1");
         final SortedMap<String, String> fixed = FixedSizeSortedMap.fixedSizeSortedMap(base);
-
         // updating the value of an existing key is allowed
         fixed.putAll(Collections.singletonMap("a", "2"));
         assertEquals("2", fixed.get("a"));
-
         // an empty map is a no-op, not a rejection
         fixed.putAll(Collections.emptyMap());
         assertEquals(1, fixed.size());
-
         // a new key must be rejected and must not grow the map
-        assertThrows(IllegalArgumentException.class,
-                () -> fixed.putAll(Collections.singletonMap("b", "9")));
+        assertThrows(IllegalArgumentException.class, () -> fixed.putAll(Collections.singletonMap("b", "9")));
         assertEquals(1, fixed.size());
         assertFalse(fixed.containsKey("b"));
     }


### PR DESCRIPTION
`putAll` inverted the `isSubCollection` check so it rejected legal value updates and let a new key grow the fixed-size map; negate it to match sibling `FixedSizeMap.putAll`, spotted while auditing the fixed-size decorators.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
