### PR TITLE
Keep existing sort order in ComparatorChain.setComparator

### DIFF
--- a/src/main/java/org/apache/commons/collections4/comparators/ComparatorChain.java
+++ b/src/main/java/org/apache/commons/collections4/comparators/ComparatorChain.java
@@ -294,7 +294,7 @@ public class ComparatorChain<E> implements Comparator<E>, Serializable {
      *                   if index &lt; 0 or index &gt;= size()
      */
     public void setComparator(final int index, final Comparator<E> comparator) throws IndexOutOfBoundsException {
-        setComparator(index, comparator, false);
+        setComparator(index, comparator, orderingBits.get(index));
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/comparators/ComparatorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/comparators/ComparatorChainTest.java
@@ -187,4 +187,18 @@ class ComparatorChainTest extends AbstractComparatorTest<ComparatorChainTest.Pse
         assertEquals(chain.compare(i1, i2), correctValue, "Comparison returns the right order");
     }
 
+    @Test
+    void testSetComparatorKeepsExistingSortOrder() {
+        // a reverse column must stay reverse after the two-arg setComparator,
+        // which is documented to maintain the existing sort order
+        final ComparatorChain<Integer> reverse = new ComparatorChain<>(new ComparableComparator<Integer>(), true);
+        reverse.setComparator(0, new ComparableComparator<Integer>());
+        assertTrue(reverse.compare(1, 2) > 0, "reverse column must stay descending");
+
+        // a forward column must stay forward
+        final ComparatorChain<Integer> forward = new ComparatorChain<>(new ComparableComparator<Integer>(), false);
+        forward.setComparator(0, new ComparableComparator<Integer>());
+        assertTrue(forward.compare(1, 2) < 0, "forward column must stay ascending");
+    }
+
 }


### PR DESCRIPTION
the two-arg `setComparator(int, Comparator)` delegated with a hard-coded `false`, so replacing a reverse-sorted column silently reset it to ascending; pass `orderingBits.get(index)` through so the replacement keeps the column's existing order as the javadoc promises.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
