### PR TITLE
Update the index on remove via IndexedCollection.iterator()

### DIFF
--- a/src/main/java/org/apache/commons/collections4/collection/IndexedCollection.java
+++ b/src/main/java/org/apache/commons/collections4/collection/IndexedCollection.java
@@ -24,6 +24,7 @@ import java.util.function.Predicate;
 
 import org.apache.commons.collections4.MultiMap;
 import org.apache.commons.collections4.Transformer;
+import org.apache.commons.collections4.iterators.AbstractIteratorDecorator;
 import org.apache.commons.collections4.map.MultiValueMap;
 
 /**
@@ -188,6 +189,11 @@ public class IndexedCollection<K, C> extends AbstractCollectionDecorator<C> {
         return coll == null ? null : coll.iterator().next();
     }
 
+    @Override
+    public Iterator<C> iterator() {
+        return new IndexedCollectionIterator(decorated().iterator());
+    }
+
     /**
      * Clears the index and re-indexes the entire decorated {@link Collection}.
      */
@@ -272,6 +278,31 @@ public class IndexedCollection<K, C> extends AbstractCollectionDecorator<C> {
     @SuppressWarnings("unchecked") // index is a MultiMap which returns a Collection.
     public Collection<C> values(final K key) {
         return (Collection<C>) index.get(key);
+    }
+
+    /**
+     * Iterator that keeps the index in sync when {@code remove()} is used.
+     */
+    private final class IndexedCollectionIterator extends AbstractIteratorDecorator<C> {
+
+        private C lastReturned;
+
+        private IndexedCollectionIterator(final Iterator<C> iterator) {
+            super(iterator);
+        }
+
+        @Override
+        public C next() {
+            lastReturned = super.next();
+            return lastReturned;
+        }
+
+        @Override
+        public void remove() {
+            super.remove();
+            removeFromIndex(lastReturned);
+            lastReturned = null;
+        }
     }
 
 }

--- a/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
+++ b/src/test/java/org/apache/commons/collections4/collection/IndexedCollectionTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.collections4.collection;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -26,6 +27,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 
 import org.apache.commons.collections4.Transformer;
 import org.junit.jupiter.api.Test;
@@ -164,6 +166,27 @@ class IndexedCollectionTest extends AbstractCollectionTest<String> {
         assertEquals("1", indexed.get(1));
         assertEquals("2", indexed.get(2));
         assertEquals("3", indexed.get(3));
+    }
+
+    @Test
+    void testIteratorRemoveUpdatesIndex() {
+        final IndexedCollection<Integer, String> indexed = decorateUniqueCollection(new ArrayList<>());
+        indexed.add("1");
+        indexed.add("2");
+
+        final Iterator<String> it = indexed.iterator();
+        while (it.hasNext()) {
+            if ("1".equals(it.next())) {
+                it.remove();
+            }
+        }
+
+        assertFalse(indexed.contains("1"));
+        assertNull(indexed.get(1));
+        assertEquals(1, indexed.size());
+        // the unique index must no longer report the removed key
+        indexed.add("1");
+        assertEquals("1", indexed.get(1));
     }
 
     @Test


### PR DESCRIPTION
`iterator()` was never overridden, so `remove()` on the decorator's own iterator dropped the element from the backing collection but not the index `MultiMap`, leaving `contains`/`get` seeing the removed element (and a unique index rejecting its re-add); found auditing the decorators that promise index-synced mutation.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.