### PR TITLE
Fix AbstractLinkedList addAll returning true for an empty collection

### DIFF
--- a/src/main/java/org/apache/commons/collections4/list/AbstractLinkedList.java
+++ b/src/main/java/org/apache/commons/collections4/list/AbstractLinkedList.java
@@ -588,6 +588,9 @@ public abstract class AbstractLinkedList<E> implements List<E> {
     @Override
     public boolean addAll(final int index, final Collection<? extends E> coll) {
         final Node<E> node = getNode(index, true);
+        if (coll.isEmpty()) {
+            return false;
+        }
         for (final E e : coll) {
             addNodeBefore(node, e);
         }

--- a/src/main/java/org/apache/commons/collections4/list/AbstractLinkedListJava21.java
+++ b/src/main/java/org/apache/commons/collections4/list/AbstractLinkedListJava21.java
@@ -592,6 +592,9 @@ public abstract class AbstractLinkedListJava21<E> implements List<E> {
     @Override
     public boolean addAll(final int index, final Collection<? extends E> coll) {
         final Node<E> node = getNode(index, true);
+        if (coll.isEmpty()) {
+            return false;
+        }
         for (final E e : coll) {
             addNodeBefore(node, e);
         }

--- a/src/test/java/org/apache/commons/collections4/list/AbstractListTest.java
+++ b/src/test/java/org/apache/commons/collections4/list/AbstractListTest.java
@@ -467,6 +467,21 @@ public abstract class AbstractListTest<E> extends AbstractCollectionTest<E> {
     }
 
     /**
+     * Tests that {@link List#addAll(Collection)} and {@link List#addAll(int, Collection)}
+     * return false and leave the list unchanged when the collection to add is empty.
+     */
+    @Test
+    void testListAddAllEmptyReturnsFalse() {
+        if (!isAddSupported()) {
+            return;
+        }
+        final List<E> list = makeObject();
+        assertFalse(list.addAll(Collections.<E>emptyList()), "addAll of an empty collection must return false");
+        assertFalse(list.addAll(0, Collections.<E>emptyList()), "addAll(index) of an empty collection must return false");
+        assertTrue(list.isEmpty());
+    }
+
+    /**
      * Tests {@link List#add(int,Object)}.
      */
     @Test


### PR DESCRIPTION
`addAll(int, Collection)` hard-codes `return true`, so adding an empty collection reports a change that never happened, breaking the `List.addAll` contract (return `true` only if the list changed). Spotted because the class's own `LinkedSubList.addAll` already returns `false` for an empty collection, as does `TreeList.addAll`. The fix returns `false` for an empty collection after the `getNode` range check, so an out-of-range index still throws `IndexOutOfBoundsException`. `AbstractLinkedListJava21` is a copy of this class with the same defect and gets the same one-line fix. Regression test in `AbstractListTest` runs against every list impl; it fails before for `CursorableLinkedList`, `NodeCachingLinkedList` and the `AbstractLinkedListJava21` default list, and passes after.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.