### PR TITLE
Fix nextKey skipping a key and throwing for keys not in the map

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap.java
+++ b/src/main/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap.java
@@ -25,6 +25,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
@@ -364,15 +365,15 @@ public class DualTreeBidiMap<K, V> extends AbstractDualBidiMap<K, V>
 
     @Override
     public K nextKey(final K key) {
-        if (isEmpty()) {
+        if (isEmpty() || !normalMap.containsKey(key)) {
             return null;
         }
         if (normalMap instanceof OrderedMap) {
             return ((OrderedMap<K, ?>) normalMap).nextKey(key);
         }
         final SortedMap<K, V> sm = (SortedMap<K, V>) normalMap;
-        if (!sm.containsKey(key)) {
-            return null;
+        if (sm instanceof NavigableMap) {
+            return ((NavigableMap<K, V>) sm).higherKey(key);
         }
         final Iterator<K> it = sm.tailMap(key).keySet().iterator();
         it.next();

--- a/src/main/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap.java
+++ b/src/main/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap.java
@@ -371,6 +371,9 @@ public class DualTreeBidiMap<K, V> extends AbstractDualBidiMap<K, V>
             return ((OrderedMap<K, ?>) normalMap).nextKey(key);
         }
         final SortedMap<K, V> sm = (SortedMap<K, V>) normalMap;
+        if (!sm.containsKey(key)) {
+            return null;
+        }
         final Iterator<K> it = sm.tailMap(key).keySet().iterator();
         it.next();
         if (it.hasNext()) {

--- a/src/main/java/org/apache/commons/collections4/map/AbstractSortedMapDecorator.java
+++ b/src/main/java/org/apache/commons/collections4/map/AbstractSortedMapDecorator.java
@@ -20,6 +20,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Set;
 import java.util.SortedMap;
 
@@ -153,6 +154,10 @@ public abstract class AbstractSortedMapDecorator<K, V> extends AbstractMapDecora
     public K nextKey(final K key) {
         if (!containsKey(key)) {
             return null;
+        }
+        final SortedMap<K, V> map = decorated();
+        if (map instanceof NavigableMap) {
+            return ((NavigableMap<K, V>) map).higherKey(key);
         }
         final Iterator<K> it = tailMap(key).keySet().iterator();
         it.next();

--- a/src/main/java/org/apache/commons/collections4/map/AbstractSortedMapDecorator.java
+++ b/src/main/java/org/apache/commons/collections4/map/AbstractSortedMapDecorator.java
@@ -151,6 +151,9 @@ public abstract class AbstractSortedMapDecorator<K, V> extends AbstractMapDecora
 
     @Override
     public K nextKey(final K key) {
+        if (!containsKey(key)) {
+            return null;
+        }
         final Iterator<K> it = tailMap(key).keySet().iterator();
         it.next();
         return it.hasNext() ? it.next() : null;

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapTest.java
@@ -157,6 +157,8 @@ public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTe
             confirmedLast = confirmedObject;
         }
         assertNull(bidi.nextKey(confirmedLast));
+        // a key that is not in the map has no next key
+        assertNull(bidi.nextKey(getOtherKeys()[0]));
 
         if (!isAllowNullKey()) {
             final OrderedBidiMap<K, V> finalBidi = bidi;

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMapTest.java
@@ -16,6 +16,11 @@
  */
 package org.apache.commons.collections4.bidimap;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
 /**
  * JUnit tests.
  */
@@ -27,6 +32,20 @@ public class DualTreeBidiMapTest<K extends Comparable<K>, V extends Comparable<V
     @Override
     public DualTreeBidiMap<K, V> makeObject() {
         return new DualTreeBidiMap<>();
+    }
+
+    @Test
+    void testNextKeyAbsentKey() {
+        final DualTreeBidiMap<String, Integer> map = new DualTreeBidiMap<>();
+        map.put("a", 1);
+        map.put("c", 3);
+        map.put("e", 5);
+        // an absent key inside the key range must not return the successor
+        assertNull(map.nextKey("b"));
+        // an absent key past the last key must not throw
+        assertNull(map.nextKey("z"));
+        assertEquals("c", map.nextKey("a"));
+        assertNull(map.nextKey("e"));
     }
 
 //    void testCreate() throws Exception {

--- a/src/test/java/org/apache/commons/collections4/map/FixedSizeSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/FixedSizeSortedMapTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.collections4.map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
@@ -66,6 +67,23 @@ public class FixedSizeSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
     @Override
     public SortedMap<K, V> makeObject() {
         return FixedSizeSortedMap.fixedSizeSortedMap(new TreeMap<>());
+    }
+
+    @Test
+    void testNextKey() {
+        final SortedMap<String, String> base = new TreeMap<>();
+        base.put("a", "1");
+        base.put("c", "3");
+        base.put("e", "5");
+        final FixedSizeSortedMap<String, String> fixed = FixedSizeSortedMap.fixedSizeSortedMap(base);
+        // a present key returns its successor, or null once at the end
+        assertEquals("c", fixed.nextKey("a"));
+        assertEquals("e", fixed.nextKey("c"));
+        assertNull(fixed.nextKey("e"));
+        // a key that is not in the map has no next key, whether it is in range or past the end
+        assertNull(fixed.nextKey("b"));
+        assertNull(fixed.nextKey("z"));
+        assertNull(FixedSizeSortedMap.fixedSizeSortedMap(new TreeMap<String, String>()).nextKey("a"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/collections4/map/UnmodifiableSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/UnmodifiableSortedMapTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.collections4.map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -23,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import org.apache.commons.collections4.OrderedMap;
 import org.apache.commons.collections4.Unmodifiable;
 import org.junit.jupiter.api.Test;
 
@@ -65,6 +68,19 @@ public class UnmodifiableSortedMapTest<K, V> extends AbstractSortedMapTest<K, V>
     @Override
     public SortedMap<K, V> makeObject() {
         return UnmodifiableSortedMap.unmodifiableSortedMap(new TreeMap<>());
+    }
+
+    @Test
+    void testNextKey() {
+        final SortedMap<String, String> base = new TreeMap<>();
+        base.put("a", "1");
+        base.put("c", "3");
+        final OrderedMap<String, String> map = (OrderedMap<String, String>) UnmodifiableSortedMap.unmodifiableSortedMap(base);
+        assertEquals("c", map.nextKey("a"));
+        // an absent key has no next key, whether inside the key range or past the end
+        assertNull(map.nextKey("b"));
+        assertNull(map.nextKey("c"));
+        assertNull(map.nextKey("z"));
     }
 
     @Test


### PR DESCRIPTION
`AbstractSortedMapDecorator.nextKey` walks `tailMap(key)` and discards the first element to step over `key` itself, but never checks that `key` is present. When `key` is absent that first element is the successor, so it gets dropped and the wrong key comes back; when `key` is at or past the end `tailMap` is empty and `it.next()` throws `NoSuchElementException` instead of returning `null`. `DualTreeBidiMap.nextKey` repeats the same `tailMap().iterator().next()` shape and fails the same two ways, since its `isEmpty()` guard only covers a fully empty map.

Return `null` when the map does not contain `key`, matching the documented `null if no match` contract and every other `nextKey` in the library (`AbstractLinkedMap`, `ListOrderedMap`, `TreeBidiMap`, `PatriciaTrie` all return `null` for an absent key); the skip-first logic then runs only for a present key, the case it was written for. `FixedSizeSortedMap` and `UnmodifiableSortedMap` inherit the decorator fix. Found by auditing the `OrderedMap.nextKey` implementations against the contract.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
