### PR TITLE
Reset last-returned element in EnumerationIterator.remove

### DIFF
--- a/src/main/java/org/apache/commons/collections4/iterators/EnumerationIterator.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/EnumerationIterator.java
@@ -120,6 +120,7 @@ public class EnumerationIterator<E> implements Iterator<E> {
             throw new IllegalStateException("next() must have been called for remove() to function");
         }
         collection.remove(last);
+        last = null;
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/iterators/EnumerationIteratorTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/EnumerationIteratorTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.collections4.iterators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the EnumerationIterator.
+ */
+public class EnumerationIteratorTest {
+
+    @Test
+    void testRemoveBeforeNext() {
+        final List<String> list = new ArrayList<>(Arrays.asList("a", "b"));
+        final Vector<String> vector = new Vector<>(list);
+        final EnumerationIterator<String> it = new EnumerationIterator<>(vector.elements(), list);
+        assertThrows(IllegalStateException.class, it::remove);
+    }
+
+    @Test
+    void testRemoveTwiceThrows() {
+        final List<String> list = new ArrayList<>(Arrays.asList("a", "a", "b"));
+        final Vector<String> vector = new Vector<>(list);
+        final EnumerationIterator<String> it = new EnumerationIterator<>(vector.elements(), list);
+        it.next();
+        it.remove();
+        assertEquals(Arrays.asList("a", "b"), list);
+        // remove() may only run once per next(); a repeat must not delete a second element
+        assertThrows(IllegalStateException.class, it::remove);
+        assertEquals(Arrays.asList("a", "b"), list);
+    }
+
+    @Test
+    void testRemoveWithoutCollection() {
+        final Vector<String> vector = new Vector<>(Arrays.asList("a"));
+        final EnumerationIterator<String> it = new EnumerationIterator<>(vector.elements());
+        it.next();
+        assertThrows(UnsupportedOperationException.class, it::remove);
+    }
+
+}


### PR DESCRIPTION
`remove()` never nulls `last`, so a second call without an intervening `next()` deletes another element equal to the last returned one from the backing collection instead of throwing `IllegalStateException`; found sweeping the package's `remove()` methods, where the sibling adapters (`EntrySetMapIterator`, `ZippingIterator`, `IteratorChain`) already clear their last-returned field.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
