### PR TITLE
COLLECTIONS-900: IteratorChain#addIterator() does not work properly with IteratorChain parameters

### DIFF
--- a/src/main/java/org/apache/commons/collections4/iterators/IteratorChain.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/IteratorChain.java
@@ -175,7 +175,11 @@ public class IteratorChain<E> implements Iterator<E> {
                 // in case it is an IteratorChain, wrap every underlying iterators as unmodifiable
                 // multiple rechainings would otherwise lead to exponential growing number of function calls
                 // when the iteratorChain gets used.
-                for (final Iterator<? extends E> nestedIterator : ((IteratorChain<? extends E>) underlyingIterator).iteratorQueue) {
+                IteratorChain<? extends E> iteratorChain = ((IteratorChain<? extends E>) underlyingIterator);
+                if (iteratorChain.currentIterator != null) {
+                    iteratorQueue.add(UnmodifiableIterator.unmodifiableIterator(iteratorChain.currentIterator));
+                }
+                for (final Iterator<? extends E> nestedIterator : iteratorChain.iteratorQueue) {
                     iteratorQueue.add(UnmodifiableIterator.unmodifiableIterator(nestedIterator));
                 }
             } else {
@@ -186,7 +190,11 @@ public class IteratorChain<E> implements Iterator<E> {
             // add the wrapped iterators directly instead of reusing the given instance
             // multiple rechainings would otherwise lead to exponential growing number of function calls
             // when the iteratorChain gets used.
-            iteratorQueue.addAll(((IteratorChain) iterator).iteratorQueue);
+            IteratorChain<? extends E> iteratorChain = (IteratorChain<? extends E>) iterator;
+            if (iteratorChain.currentIterator != null) {
+                iteratorQueue.add(iteratorChain.currentIterator);
+            }
+            iteratorQueue.addAll(iteratorChain.iteratorQueue);
         } else {
             // arbitrary other iterator
             iteratorQueue.add(iterator);

--- a/src/main/java/org/apache/commons/collections4/iterators/IteratorChain.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/IteratorChain.java
@@ -175,7 +175,7 @@ public class IteratorChain<E> implements Iterator<E> {
                 // in case it is an IteratorChain, wrap every underlying iterators as unmodifiable
                 // multiple rechainings would otherwise lead to exponential growing number of function calls
                 // when the iteratorChain gets used.
-                IteratorChain<? extends E> iteratorChain = ((IteratorChain<? extends E>) underlyingIterator);
+                final IteratorChain<? extends E> iteratorChain = (IteratorChain<? extends E>) underlyingIterator;
                 if (iteratorChain.currentIterator != null) {
                     iteratorQueue.add(UnmodifiableIterator.unmodifiableIterator(iteratorChain.currentIterator));
                 }
@@ -190,7 +190,7 @@ public class IteratorChain<E> implements Iterator<E> {
             // add the wrapped iterators directly instead of reusing the given instance
             // multiple rechainings would otherwise lead to exponential growing number of function calls
             // when the iteratorChain gets used.
-            IteratorChain<? extends E> iteratorChain = (IteratorChain<? extends E>) iterator;
+            final IteratorChain<? extends E> iteratorChain = (IteratorChain<? extends E>) iterator;
             if (iteratorChain.currentIterator != null) {
                 iteratorQueue.add(iteratorChain.currentIterator);
             }

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
@@ -127,6 +127,16 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
     }
 
     @Test
+    public void testChainingAfterHasNextCall() {
+        IteratorChain<String> chain = new IteratorChain<>();
+        chain.addIterator(list1.iterator());
+        chain.hasNext();
+        chain = new IteratorChain<>(chain);
+        chain.addIterator(list2.iterator());
+        assertEquals(list1.get(0), chain.next());
+    }
+
+    @Test
     public void testChainingPerformsWell() {
         Iterator<String> iter = makeObject();
         for (int i = 0; i < 150; i++) {

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
@@ -126,6 +126,7 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         assertTrue(list3.isEmpty(), "List is empty");
     }
 
+    //COLLECTIONS-900
     @Test
     public void testChainingAfterHasNextCall() {
         IteratorChain<String> chain = new IteratorChain<>();
@@ -134,6 +135,14 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         chain = new IteratorChain<>(chain);
         chain.addIterator(list2.iterator());
         // test that the first element is still returned correctly after a hasNext() call
+        assertEquals(list1.get(0), chain.next());
+
+        //same test with unmodifiable IteratorChain
+        chain = new IteratorChain<>();
+        chain.addIterator(list1.iterator());
+        chain.hasNext();
+        chain = new IteratorChain<>(UnmodifiableIterator.unmodifiableIterator(chain));
+        chain.addIterator(list2.iterator());
         assertEquals(list1.get(0), chain.next());
     }
 

--- a/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/IteratorChainTest.java
@@ -133,6 +133,7 @@ public class IteratorChainTest extends AbstractIteratorTest<String> {
         chain.hasNext();
         chain = new IteratorChain<>(chain);
         chain.addIterator(list2.iterator());
+        // test that the first element is still returned correctly after a hasNext() call
         assertEquals(list1.get(0), chain.next());
     }
 


### PR DESCRIPTION
Added failing test case.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->
