### PR TITLE
Fix putAll(K, Iterable) NPE for null value transformer

### DIFF
--- a/src/main/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMap.java
+++ b/src/main/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMap.java
@@ -133,8 +133,7 @@ public class TransformedMultiValuedMap<K, V> extends AbstractMultiValuedMapDecor
     public boolean putAll(final K key, final Iterable<? extends V> values) {
         Objects.requireNonNull(values, "values");
 
-        final Iterable<? extends V> transformedValues =
-                valueTransformer == null ? values : FluentIterable.of(values).transform(valueTransformer);
+        final Iterable<V> transformedValues = FluentIterable.of(values).transform(this::transformValue);
         final Iterator<? extends V> it = transformedValues.iterator();
         return it.hasNext() && CollectionUtils.addAll(decorated().get(transformKey(key)), it);
     }

--- a/src/main/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMap.java
+++ b/src/main/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMap.java
@@ -133,7 +133,8 @@ public class TransformedMultiValuedMap<K, V> extends AbstractMultiValuedMapDecor
     public boolean putAll(final K key, final Iterable<? extends V> values) {
         Objects.requireNonNull(values, "values");
 
-        final Iterable<V> transformedValues = FluentIterable.of(values).transform(valueTransformer);
+        final Iterable<? extends V> transformedValues =
+                valueTransformer == null ? values : FluentIterable.of(values).transform(valueTransformer);
         final Iterator<? extends V> it = transformedValues.iterator();
         return it.hasNext() && CollectionUtils.addAll(decorated().get(transformKey(key)), it);
     }

--- a/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
@@ -142,6 +142,22 @@ public class TransformedMultiValuedMapTest<K, V> extends AbstractMultiValuedMapT
 
     @Test
     @SuppressWarnings("unchecked")
+    void testPutAllIterableAppliesTransformValueOverride() {
+        final TransformedMultiValuedMap<K, V> map = new TransformedMultiValuedMap<K, V>(
+                new ArrayListValuedHashMap<>(), null, null) {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected V transformValue(final V object) {
+                return (V) String.valueOf(object);
+            }
+        };
+        assertTrue(map.putAll((K) "k", Arrays.asList((V) Integer.valueOf(1), (V) Integer.valueOf(2))));
+        assertEquals(Arrays.asList("1", "2"), map.get((K) "k"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     void testValueTransformedMap() {
         final Object[] els = { "1", "3", "5", "7", "2", "4", "6" };
 

--- a/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/multimap/TransformedMultiValuedMapTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 import org.apache.commons.collections4.MultiValuedMap;
@@ -128,6 +129,15 @@ public class TransformedMultiValuedMapTest<K, V> extends AbstractMultiValuedMapT
         assertNotNull(coll);
         assertEquals(0, coll.size());
         assertTrue(map.remove(Integer.valueOf((String) els[0])).contains(els[0]));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testPutAllIterableWithNullTransformers() {
+        final MultiValuedMap<K, V> map = TransformedMultiValuedMap.transformingMap(
+                new ArrayListValuedHashMap<>(), null, null);
+        assertTrue(map.putAll((K) "k", Arrays.asList((V) "a", (V) "b")));
+        assertEquals(Arrays.asList("a", "b"), map.get((K) "k"));
     }
 
     @Test


### PR DESCRIPTION
`putAll(K, Iterable)` sends values through `FluentIterable.of(values).transform(valueTransformer)`, and `IterableUtils.transformedIterable` rejects a null transformer with `NullPointerException`, so a map built with a null value transformer (documented as "no conversion", and handled fine by `put` via `transformValue`) throws on `putAll` while `put` works; skip the transform when the transformer is null.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Claude Code (Anthropic) was used to locate the bug, write the fix and the regression test, and run the build.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HUmTCFCnFFDWKGVYWbUDtA
