### PR TITLE
hold the bucket lock in StaticBucketMap compound operations

### DIFF
--- a/src/main/java/org/apache/commons/collections4/map/StaticBucketMap.java
+++ b/src/main/java/org/apache/commons/collections4/map/StaticBucketMap.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.apache.commons.collections4.KeyValue;
 
@@ -50,7 +52,11 @@ import org.apache.commons.collections4.KeyValue;
  * safely operate on the map at the same time, often without incurring any
  * monitor contention.  This means that you don't have to wrap instances
  * of this class with {@link java.util.Collections#synchronizedMap(Map)};
- * instances are already thread-safe.  Unfortunately, however, this means
+ * instances are already thread-safe.  Single-key operations, including
+ * compound ones such as {@link #putIfAbsent(Object, Object) putIfAbsent},
+ * {@link #compute(Object, BiFunction) compute} and
+ * {@link #merge(Object, Object, BiFunction) merge}, hold the bucket lock
+ * for their whole duration.  Unfortunately, however, this means
  * that this map implementation behaves in ways you may find disconcerting.
  * Bulk operations, such as {@link #putAll(Map) putAll} or the
  * {@link Collection#retainAll(Collection) retainAll} operation in collection
@@ -444,6 +450,36 @@ public final class StaticBucketMap<K, V> extends AbstractIterableMap<K, V> {
     }
 
     /**
+     * @since 4.6.1
+     */
+    @Override
+    public V compute(final K key, final BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        synchronized (locks[getHash(key)]) {
+            return super.compute(key, remappingFunction);
+        }
+    }
+
+    /**
+     * @since 4.6.1
+     */
+    @Override
+    public V computeIfAbsent(final K key, final Function<? super K, ? extends V> mappingFunction) {
+        synchronized (locks[getHash(key)]) {
+            return super.computeIfAbsent(key, mappingFunction);
+        }
+    }
+
+    /**
+     * @since 4.6.1
+     */
+    @Override
+    public V computeIfPresent(final K key, final BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        synchronized (locks[getHash(key)]) {
+            return super.computeIfPresent(key, remappingFunction);
+        }
+    }
+
+    /**
      * Checks if the map contains the specified key.
      *
      * @param key  The key to check
@@ -572,6 +608,16 @@ public final class StaticBucketMap<K, V> extends AbstractIterableMap<K, V> {
     }
 
     /**
+     * @since 4.6.1
+     */
+    @Override
+    public V getOrDefault(final Object key, final V defaultValue) {
+        synchronized (locks[getHash(key)]) {
+            return super.getOrDefault(key, defaultValue);
+        }
+    }
+
+    /**
      * Gets the hash code, as per the Map specification.
      *
      * @return The hash code
@@ -611,6 +657,16 @@ public final class StaticBucketMap<K, V> extends AbstractIterableMap<K, V> {
     @Override
     public Set<K> keySet() {
         return new KeySet();
+    }
+
+    /**
+     * @since 4.6.1
+     */
+    @Override
+    public V merge(final K key, final V value, final BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        synchronized (locks[getHash(key)]) {
+            return super.merge(key, value, remappingFunction);
+        }
     }
 
     /**
@@ -674,6 +730,16 @@ public final class StaticBucketMap<K, V> extends AbstractIterableMap<K, V> {
     }
 
     /**
+     * @since 4.6.1
+     */
+    @Override
+    public V putIfAbsent(final K key, final V value) {
+        synchronized (locks[getHash(key)]) {
+            return super.putIfAbsent(key, value);
+        }
+    }
+
+    /**
      * Removes the specified key from the map.
      *
      * @param key  The key to remove
@@ -706,6 +772,36 @@ public final class StaticBucketMap<K, V> extends AbstractIterableMap<K, V> {
             }
         }
         return null;
+    }
+
+    /**
+     * @since 4.6.1
+     */
+    @Override
+    public boolean remove(final Object key, final Object value) {
+        synchronized (locks[getHash(key)]) {
+            return super.remove(key, value);
+        }
+    }
+
+    /**
+     * @since 4.6.1
+     */
+    @Override
+    public V replace(final K key, final V value) {
+        synchronized (locks[getHash(key)]) {
+            return super.replace(key, value);
+        }
+    }
+
+    /**
+     * @since 4.6.1
+     */
+    @Override
+    public boolean replace(final K key, final V oldValue, final V newValue) {
+        synchronized (locks[getHash(key)]) {
+            return super.replace(key, oldValue, newValue);
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/collections4/map/StaticBucketMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/StaticBucketMapTest.java
@@ -21,7 +21,15 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Unit tests.
@@ -31,6 +39,45 @@ import org.junit.jupiter.api.Test;
  * @param <V> The value type.
  */
 public class StaticBucketMapTest<K, V> extends AbstractIterableMapTest<K, V> {
+
+    /**
+     * Starts {@code access} on another thread and reports whether it blocks on a monitor instead of running to completion.
+     */
+    private static boolean blocksWhileRunning(final Runnable access) {
+        final Thread thread = new Thread(access);
+        thread.setDaemon(true);
+        thread.start();
+        Thread.State state = thread.getState();
+        while (state != Thread.State.BLOCKED && state != Thread.State.TERMINATED) {
+            Thread.yield();
+            state = thread.getState();
+        }
+        return state == Thread.State.BLOCKED;
+    }
+
+    private static Arguments compoundOperation(final String name, final BiConsumer<Map<String, String>, Runnable> operation) {
+        return Arguments.of(name, operation);
+    }
+
+    static Stream<Arguments> compoundOperations() {
+        return Stream.of(
+                compoundOperation("compute", (map, probe) -> map.compute("present", (k, v) -> {
+                    probe.run();
+                    return v;
+                })),
+                compoundOperation("computeIfAbsent", (map, probe) -> map.computeIfAbsent("absent", k -> {
+                    probe.run();
+                    return k;
+                })),
+                compoundOperation("computeIfPresent", (map, probe) -> map.computeIfPresent("present", (k, v) -> {
+                    probe.run();
+                    return v;
+                })),
+                compoundOperation("merge", (map, probe) -> map.merge("present", "value", (a, b) -> {
+                    probe.run();
+                    return a;
+                })));
+    }
 
     /**
      * {@inheritDoc}
@@ -69,6 +116,20 @@ public class StaticBucketMapTest<K, V> extends AbstractIterableMapTest<K, V> {
             final String str = String.valueOf((char) i);
             assertFalse(map.containsValue(str), "String: " + str);
         }
+    }
+
+    /**
+     * A compound operation must hold the bucket lock while it runs its function, otherwise a concurrent update to the same key is lost. Since
+     * {@code size()} visits every bucket, another thread calling it in the meantime is expected to block on the monitor rather than complete.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("compoundOperations")
+    void testCompoundOperationHoldsBucketLock(final String name, final BiConsumer<Map<String, String>, Runnable> operation) {
+        final StaticBucketMap<String, String> map = new StaticBucketMap<>();
+        map.put("present", "value");
+        final AtomicBoolean blocked = new AtomicBoolean();
+        operation.accept(map, () -> blocked.set(blocksWhileRunning(map::size)));
+        assertTrue(blocked.get(), () -> name + " ran its function without holding the bucket lock");
     }
 
     // Bugzilla 37567


### PR DESCRIPTION
`StaticBucketMap` extends `AbstractIterableMap` and never overrides the `java.util.Map` defaults, so `putIfAbsent`, `compute`, `computeIfAbsent`, `computeIfPresent`, `merge`, `remove(key, value)`, both `replace` overloads and `getOrDefault` release the bucket monitor between their nested `get` and `put` calls and lose concurrent updates on a map whose javadoc says not to wrap it in `Collections.synchronizedMap` (found while checking which thread-safe classes override the `Map` defaults; 8 threads doing 20000 `merge(key, 1, Integer::sum)` each finish near 41000 instead of 160000), so each of them now runs the inherited default inside `synchronized (locks[getHash(key)])`, while `forEach` and `replaceAll` stay as they are because bulk operations are documented as non-atomic.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Claude Code (Anthropic) was used for the whole change: it found the issue, drafted the overrides and the test, and ran the reproducer and the full default Maven goal.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
