### PR TITLE
Fix previousKey returning the predecessor and throwing for keys not in the map

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap.java
+++ b/src/main/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap.java
@@ -385,13 +385,16 @@ public class DualTreeBidiMap<K, V> extends AbstractDualBidiMap<K, V>
 
     @Override
     public K previousKey(final K key) {
-        if (isEmpty()) {
+        if (isEmpty() || !normalMap.containsKey(key)) {
             return null;
         }
         if (normalMap instanceof OrderedMap) {
             return ((OrderedMap<K, V>) normalMap).previousKey(key);
         }
         final SortedMap<K, V> sm = (SortedMap<K, V>) normalMap;
+        if (sm instanceof NavigableMap) {
+            return ((NavigableMap<K, V>) sm).lowerKey(key);
+        }
         final SortedMap<K, V> hm = sm.headMap(key);
         if (hm.isEmpty()) {
             return null;

--- a/src/main/java/org/apache/commons/collections4/map/AbstractSortedMapDecorator.java
+++ b/src/main/java/org/apache/commons/collections4/map/AbstractSortedMapDecorator.java
@@ -166,6 +166,13 @@ public abstract class AbstractSortedMapDecorator<K, V> extends AbstractMapDecora
 
     @Override
     public K previousKey(final K key) {
+        if (!containsKey(key)) {
+            return null;
+        }
+        final SortedMap<K, V> map = decorated();
+        if (map instanceof NavigableMap) {
+            return ((NavigableMap<K, V>) map).lowerKey(key);
+        }
         final SortedMap<K, V> headMap = headMap(key);
         return headMap.isEmpty() ? null : headMap.lastKey();
     }

--- a/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/AbstractOrderedBidiMapTest.java
@@ -196,6 +196,8 @@ public abstract class AbstractOrderedBidiMapTest<K, V> extends AbstractBidiMapTe
             confirmedLast = confirmedObject;
         }
         assertNull(bidi.previousKey(confirmedLast));
+        // a key that is not in the map has no previous key
+        assertNull(bidi.previousKey(getOtherKeys()[0]));
 
         if (!isAllowNullKey()) {
             final OrderedBidiMap<K, V> finalBidi = bidi;

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMapTest.java
@@ -48,6 +48,21 @@ public class DualTreeBidiMapTest<K extends Comparable<K>, V extends Comparable<V
         assertNull(map.nextKey("e"));
     }
 
+    @Test
+    void testPreviousKeyAbsentKey() {
+        final DualTreeBidiMap<String, Integer> map = new DualTreeBidiMap<>();
+        map.put("a", 1);
+        map.put("c", 3);
+        map.put("e", 5);
+        // an absent key inside the key range must not return the predecessor
+        assertNull(map.previousKey("b"));
+        // an absent key past either end must not return an entry either
+        assertNull(map.previousKey("z"));
+        assertNull(map.previousKey("A"));
+        assertEquals("c", map.previousKey("e"));
+        assertNull(map.previousKey("a"));
+    }
+
 //    void testCreate() throws Exception {
 //        resetEmpty();
 //        writeExternalFormToDisk((java.io.Serializable) map, "src/test/resources/data/test/DualTreeBidiMap.emptyCollection.version4.obj");

--- a/src/test/java/org/apache/commons/collections4/map/AbstractOrderedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/AbstractOrderedMapTest.java
@@ -229,6 +229,8 @@ public abstract class AbstractOrderedMapTest<K, V> extends AbstractIterableMapTe
             confirmedLast = confirmedObject;
         }
         assertNull(ordered.previousKey(confirmedLast));
+        // a key that is not in the map has no previous key
+        assertNull(ordered.previousKey(getOtherKeys()[0]));
 
         if (!isAllowNullKey()) {
             final OrderedMap<K, V> finalOrdered = ordered;

--- a/src/test/java/org/apache/commons/collections4/map/FixedSizeSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/FixedSizeSortedMapTest.java
@@ -87,6 +87,24 @@ public class FixedSizeSortedMapTest<K, V> extends AbstractSortedMapTest<K, V> {
     }
 
     @Test
+    void testPreviousKey() {
+        final SortedMap<String, String> base = new TreeMap<>();
+        base.put("a", "1");
+        base.put("c", "3");
+        base.put("e", "5");
+        final FixedSizeSortedMap<String, String> fixed = FixedSizeSortedMap.fixedSizeSortedMap(base);
+        // a present key returns its predecessor, or null once at the start
+        assertEquals("c", fixed.previousKey("e"));
+        assertEquals("a", fixed.previousKey("c"));
+        assertNull(fixed.previousKey("a"));
+        // a key that is not in the map has no previous key, whether it is in range or past either end
+        assertNull(fixed.previousKey("b"));
+        assertNull(fixed.previousKey("z"));
+        assertNull(fixed.previousKey("A"));
+        assertNull(FixedSizeSortedMap.fixedSizeSortedMap(new TreeMap<String, String>()).previousKey("a"));
+    }
+
+    @Test
     void testPutAllAllowsUpdatesRejectsNewKeys() {
         final SortedMap<String, String> base = new TreeMap<>();
         base.put("a", "1");

--- a/src/test/java/org/apache/commons/collections4/map/UnmodifiableSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/UnmodifiableSortedMapTest.java
@@ -105,6 +105,33 @@ public class UnmodifiableSortedMapTest<K, V> extends AbstractSortedMapTest<K, V>
     }
 
     @Test
+    void testPreviousKey() {
+        final SortedMap<String, String> base = new TreeMap<>();
+        base.put("a", "1");
+        base.put("c", "3");
+        final OrderedMap<String, String> map = (OrderedMap<String, String>) UnmodifiableSortedMap.unmodifiableSortedMap(base);
+        assertEquals("a", map.previousKey("c"));
+        assertNull(map.previousKey("a"));
+        // an absent key has no previous key, whether inside the key range or past either end
+        assertNull(map.previousKey("b"));
+        assertNull(map.previousKey("z"));
+        assertNull(map.previousKey("A"));
+    }
+
+    @Test
+    void testPreviousKeyOnRangeRestrictedMap() {
+        final SortedMap<String, String> base = new TreeMap<>();
+        base.put("a", "1");
+        base.put("c", "3");
+        final OrderedMap<String, String> view =
+                (OrderedMap<String, String>) UnmodifiableSortedMap.unmodifiableSortedMap(base.subMap("a", "d"));
+        assertEquals("a", view.previousKey("c"));
+        // a key outside the view's range must not throw, it has no previous key
+        assertNull(view.previousKey("A"));
+        assertNull(view.previousKey("z"));
+    }
+
+    @Test
     void testSubMap() {
         final SortedMap<K, V> map = makeFullMap();
 


### PR DESCRIPTION
`previousKey` carries the defect #728 fixed in `nextKey`. `AbstractSortedMapDecorator.previousKey` returns `headMap(key).lastKey()` without checking that `key` is present, so an absent key inside the range returns its predecessor and a key outside a range-restricted view throws `IllegalArgumentException`; `DualTreeBidiMap.previousKey` fails the same way. `OrderedMap` documents `null` for a key with no match, and every other `previousKey` in the library returns it.

Return `null` when the map does not contain `key`, and use `NavigableMap.lowerKey` when the decorated map offers it, mirroring #728 line for line.

Tests: both ordered-map conformance suites now assert the absent-key case on a full map, plus four explicit tests; red on master and green with the change. Default Maven goal green.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Claude (Anthropic) found the defect and drafted the fix and tests; I reviewed them, reproduced the failure on a fresh clone of master, and ran the default Maven goal.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
