### PR TITLE
set lastUsedIterator only in next() in LazyIteratorChain

### DIFF
--- a/src/main/java/org/apache/commons/collections4/iterators/LazyIteratorChain.java
+++ b/src/main/java/org/apache/commons/collections4/iterators/LazyIteratorChain.java
@@ -62,8 +62,8 @@ public abstract class LazyIteratorChain<E> implements Iterator<E> {
     private Iterator<? extends E> currentIterator;
 
     /**
-     * The "last used" Iterator is the Iterator upon which next() or hasNext()
-     * was most recently called used for the remove() operation only.
+     * The "last used" Iterator is the Iterator upon which next()
+     * was most recently called, used for the remove() operation only.
      */
     private Iterator<? extends E> lastUsedIterator;
 
@@ -82,7 +82,6 @@ public abstract class LazyIteratorChain<E> implements Iterator<E> {
     @Override
     public boolean hasNext() {
         updateCurrentIterator();
-        lastUsedIterator = currentIterator;
         return currentIterator.hasNext();
     }
 
@@ -125,10 +124,11 @@ public abstract class LazyIteratorChain<E> implements Iterator<E> {
      */
     @Override
     public void remove() {
-        if (currentIterator == null) {
-            updateCurrentIterator();
+        if (lastUsedIterator == null) {
+            throw new IllegalStateException("remove() cannot be called before calling next()");
         }
         lastUsedIterator.remove();
+        lastUsedIterator = null;
     }
 
     /**
@@ -142,9 +142,6 @@ public abstract class LazyIteratorChain<E> implements Iterator<E> {
                 currentIterator = EmptyIterator.<E>emptyIterator();
                 chainExhausted = true;
             }
-            // set last used iterator here, in case the user calls remove
-            // before calling hasNext() or next() (although they shouldn't)
-            lastUsedIterator = currentIterator;
         }
         while (!currentIterator.hasNext() && !chainExhausted) {
             final Iterator<? extends E> nextIterator = nextIterator(++callCounter);

--- a/src/test/java/org/apache/commons/collections4/iterators/LazyIteratorChainTest.java
+++ b/src/test/java/org/apache/commons/collections4/iterators/LazyIteratorChainTest.java
@@ -156,6 +156,34 @@ class LazyIteratorChainTest extends AbstractIteratorTest<String> {
     }
 
     @Test
+    void testRemoveAfterHasNext() {
+        // hasNext() peeks past the current sub-iterator once it is exhausted; it must not
+        // change which element a following remove() deletes.
+        final List<String> listA = new ArrayList<>();
+        listA.add("A");
+        final List<String> listB = new ArrayList<>();
+        listB.add("B");
+        final LazyIteratorChain<String> chain = new LazyIteratorChain<String>() {
+            @Override
+            protected Iterator<String> nextIterator(final int count) {
+                switch (count) {
+                case 1:
+                    return listA.iterator();
+                case 2:
+                    return listB.iterator();
+                }
+                return null;
+            }
+        };
+        assertEquals("A", chain.next());
+        assertTrue(chain.hasNext());
+        chain.remove();
+        assertTrue(listA.isEmpty(), "remove() should have deleted \"A\" from the first list");
+        assertEquals(1, listB.size(), "remove() must not touch the second list");
+        assertEquals("B", listB.get(0));
+    }
+
+    @Test
     void testRemoveFromFilteredIterator() {
 
         final Predicate<Integer> myPredicate = i -> i.compareTo(Integer.valueOf(4)) < 0;


### PR DESCRIPTION
`hasNext()` reassigned `lastUsedIterator`, and `updateCurrentIterator()` advances `currentIterator` to the next sub-iterator once the current one is exhausted, so a `hasNext()` call between `next()` and `remove()` repointed the remove target at a sub-iterator `next()` never used and `remove()` then threw `IllegalStateException` instead of deleting the element `next()` returned; `lastUsedIterator` is now set only by `next()`, matching the sibling `IteratorChain`, which handles the same call sequence correctly. Found while sweeping the iterators package for `remove()` contract holes.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Claude assisted in locating the defect and drafting the fix and regression test; I reviewed the change and ran the build.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.