### PR TITLE
fix previousKey returning a predecessor for an absent key

### DIFF
--- a/src/main/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap.java
+++ b/src/main/java/org/apache/commons/collections4/bidimap/DualTreeBidiMap.java
@@ -385,13 +385,16 @@ public class DualTreeBidiMap<K, V> extends AbstractDualBidiMap<K, V>
 
     @Override
     public K previousKey(final K key) {
-        if (isEmpty()) {
+        if (isEmpty() || !normalMap.containsKey(key)) {
             return null;
         }
         if (normalMap instanceof OrderedMap) {
             return ((OrderedMap<K, V>) normalMap).previousKey(key);
         }
         final SortedMap<K, V> sm = (SortedMap<K, V>) normalMap;
+        if (sm instanceof NavigableMap) {
+            return ((NavigableMap<K, V>) sm).lowerKey(key);
+        }
         final SortedMap<K, V> hm = sm.headMap(key);
         if (hm.isEmpty()) {
             return null;

--- a/src/main/java/org/apache/commons/collections4/map/AbstractSortedMapDecorator.java
+++ b/src/main/java/org/apache/commons/collections4/map/AbstractSortedMapDecorator.java
@@ -166,6 +166,13 @@ public abstract class AbstractSortedMapDecorator<K, V> extends AbstractMapDecora
 
     @Override
     public K previousKey(final K key) {
+        if (!containsKey(key)) {
+            return null;
+        }
+        final SortedMap<K, V> map = decorated();
+        if (map instanceof NavigableMap) {
+            return ((NavigableMap<K, V>) map).lowerKey(key);
+        }
         final SortedMap<K, V> headMap = headMap(key);
         return headMap.isEmpty() ? null : headMap.lastKey();
     }

--- a/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/bidimap/DualTreeBidiMapTest.java
@@ -48,6 +48,22 @@ public class DualTreeBidiMapTest<K extends Comparable<K>, V extends Comparable<V
         assertNull(map.nextKey("e"));
     }
 
+    @Test
+    void testPreviousKeyAbsentKey() {
+        final DualTreeBidiMap<String, Integer> map = new DualTreeBidiMap<>();
+        map.put("b", 2);
+        map.put("d", 4);
+        map.put("f", 6);
+        // an absent key inside the key range must not return the predecessor
+        assertNull(map.previousKey("c"));
+        // an absent key before the first key has no predecessor either
+        assertNull(map.previousKey("a"));
+        // an absent key past the last key must not return the last key
+        assertNull(map.previousKey("z"));
+        assertEquals("d", map.previousKey("f"));
+        assertNull(map.previousKey("b"));
+    }
+
 //    void testCreate() throws Exception {
 //        resetEmpty();
 //        writeExternalFormToDisk((java.io.Serializable) map, "src/test/resources/data/test/DualTreeBidiMap.emptyCollection.version4.obj");

--- a/src/test/java/org/apache/commons/collections4/map/UnmodifiableSortedMapTest.java
+++ b/src/test/java/org/apache/commons/collections4/map/UnmodifiableSortedMapTest.java
@@ -105,6 +105,20 @@ public class UnmodifiableSortedMapTest<K, V> extends AbstractSortedMapTest<K, V>
     }
 
     @Test
+    void testPreviousKey() {
+        final SortedMap<String, String> base = new TreeMap<>();
+        base.put("d", "4");
+        base.put("f", "6");
+        final OrderedMap<String, String> map = (OrderedMap<String, String>) UnmodifiableSortedMap.unmodifiableSortedMap(base);
+        assertEquals("d", map.previousKey("f"));
+        // an absent key has no previous key, whether inside the range, before the first key, or past the end
+        assertNull(map.previousKey("e"));
+        assertNull(map.previousKey("d"));
+        assertNull(map.previousKey("a"));
+        assertNull(map.previousKey("z"));
+    }
+
+    @Test
     void testSubMap() {
         final SortedMap<K, V> map = makeFullMap();
 


### PR DESCRIPTION
`AbstractSortedMapDecorator.previousKey` and `DualTreeBidiMap.previousKey` compute the predecessor with `headMap(key).lastKey()` without first checking that `key` is present, so an absent key returns a predecessor instead of `null`, disagreeing with the sibling `nextKey` fixed in #728 and with every other `OrderedMap.previousKey` (`AbstractLinkedMap`, `ListOrderedMap`, `TreeBidiMap`, `PatriciaTrie`, `SingletonMap` all return `null` for an absent key); this guards with `containsKey` and uses `NavigableMap.lowerKey` when the map supports it, mirroring the merged `nextKey`. Found while addressing the `nextKey` review in #728, where a separate PR for `previousKey` was requested.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Claude Code helped locate the inconsistency, draft the fix, and write the regression tests; I reviewed and verified the change and ran the full build.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
